### PR TITLE
Basic toolkit and drag drop support

### DIFF
--- a/Designer.xaml
+++ b/Designer.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MAUIDesigner.Designer"
+             Title="Designer">
+
+    <Grid VerticalOptions="FillAndExpand">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <VerticalStackLayout Grid.Column="0">
+            <Label x:Name="LabelSelector" Text="Label">
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="CreateElementInDesignerFrame"/>
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="EditorSelector" Text="Editor">
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="CreateElementInDesignerFrame"/>
+                </Label.GestureRecognizers>
+            </Label>
+            <Label x:Name="ShowPointer">
+                
+            </Label>
+        </VerticalStackLayout>
+        <AbsoluteLayout Margin="20" VerticalOptions="FillAndExpand" x:Name="designerFrame" Grid.Column="1">
+            <AbsoluteLayout.GestureRecognizers>
+                <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped"  NumberOfTapsRequired="2"/>
+                <PointerGestureRecognizer PointerMoved="PointerGestureRecognizer_PointerMoved" PointerPressed="PointerGestureRecognizer_PointerPressed" PointerReleased="PointerGestureRecognizer_PointerReleased"/>
+            </AbsoluteLayout.GestureRecognizers>
+
+        </AbsoluteLayout>
+    </Grid>
+</ContentPage>

--- a/Designer.xaml.cs
+++ b/Designer.xaml.cs
@@ -1,0 +1,220 @@
+
+
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Devices.Sensors;
+using System.Text;
+
+namespace MAUIDesigner;
+
+public partial class Designer : ContentPage
+{
+    private bool isDragging = false;
+    private View? draggingView;
+    Border gradientBorder = new Border
+    {
+        StrokeThickness = 2,
+        ZIndex = -10,
+        HorizontalOptions = LayoutOptions.Center,
+        StrokeShape = new RoundRectangle
+        {
+            CornerRadius = new CornerRadius(2)
+        },
+        Stroke = new SolidColorBrush(Colors.White),
+        InputTransparent = true,
+        IsEnabled = false
+    };
+    private const string LabelXAML = "<Label Text=\"Drag Me away\" HorizontalTextAlignment=\"Center\" TextColor=\"White\" FontSize=\"36\">\r\n</Label>";
+    private IDictionary<Guid, View> views = new Dictionary<Guid, View>();
+
+    public Designer()
+	{
+		InitializeComponent();
+        designerFrame.Add(gradientBorder);
+    }
+    //private async void DragGestureRecognizer_DragStarting_1(object sender, DragStartingEventArgs e)
+    //{
+    //    var label = (sender as Element)?.Parent as VisualElement;
+    //    await label.TranslateTo(10000, 10000, 1);
+    //    e.Data.Properties.Add("DraggingObject", label);
+    //}
+
+    //private void DropGestureRecognizer_Drop_1(object sender, DropEventArgs e)
+    //{
+    //    var data = e.Data.Properties["DraggingObject"] as VisualElement;
+    //    // add the data element as a child of the frame
+
+    //    //frameGrid.Add(data);
+
+    //    Point location = e.GetPosition(data).Value;
+
+    //    data.TranslateTo(location.X + data.TranslationX + data.X - data.Width/2, location.Y + data.TranslationY - data.Y, 1);
+
+    //    data.Opacity = 1;
+    //}
+
+    //private async void ElementSelector_DragStarted(object sender, DragStartingEventArgs e)
+    //{
+    //    var element = sender as VisualElement;
+    //    // Duplicate element as a VisualElement class object
+    //    /*var elementType = element.GetType();
+    //    VisualElement duplicate = Activator.CreateInstance(elementType) as VisualElement;
+    //    element.GetType().GetProperties().ToList().ForEach(p =>
+    //    {
+    //        if (p.CanWrite)
+    //        {
+    //            p.SetValue(duplicate, p.GetValue(element));
+    //        }
+    //    });*/
+
+    //    //Point location = e.GetPosition(element).Value;
+    //    await element.TranslateTo(10000, 10000, 1);
+
+    //    e.Data.Properties.Add("DraggingObject", element);
+    //}
+
+    private void TapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
+    {
+    }
+
+    private void CreateElementInDesignerFrame(object sender, TappedEventArgs e)
+    {
+        try
+        {
+            var newElement = ElementCreator.Create((sender as Label).Text);
+            var gestureRecognizer = new PointerGestureRecognizer();
+            gestureRecognizer.PointerEntered += AddBorder;
+            gestureRecognizer.PointerExited += RemoveBorder;
+            newElement.GestureRecognizers.Add(gestureRecognizer);
+            designerFrame.Add(newElement);
+            views.Add(newElement.Id, newElement);
+
+            // Get the XAML from the new element
+            var xaml = GetXamlForElement(designerFrame);
+        }
+        catch (Exception et)
+        {
+            Console.WriteLine(et);
+            // Do nothing
+        }
+    }
+
+
+    public string GetXamlForElement(VisualElement element)
+    {
+        StringBuilder xamlBuilder = new StringBuilder();
+        xamlBuilder.AppendLine($"<{element.GetType().Name}");
+
+        foreach (var property in element.GetType().GetProperties())
+        {
+            if (property.CanRead && property.CanWrite && property.GetIndexParameters().Length == 0)
+            {
+                var value = property.GetValue(element);
+                var valueType = value?.GetType();
+                if (value != null && OnlyPrimitiveTypeOrString(valueType))
+                {
+                    xamlBuilder.AppendLine($"    {property.Name}=\"{value}\"");
+                }
+            }
+        }
+
+        // Check if element can contain children
+        if (element is Layout layout)
+        {
+            xamlBuilder.AppendLine(">");
+            foreach (var child in layout.Children.Where(x => x is VisualElement))
+            {
+                xamlBuilder.AppendLine(GetXamlForElement(child as VisualElement));
+            }
+            xamlBuilder.AppendLine($"</{element.GetType().Name}>");
+        }
+        else
+        {
+
+            xamlBuilder.AppendLine("/>");
+        }
+        return xamlBuilder.ToString();
+    }
+
+    private bool OnlyPrimitiveTypeOrString(Type valueType)
+    {
+        // Check if the type is a primitive type or string
+        return valueType.IsPrimitive || valueType == typeof(string);
+    }
+
+    private void RemoveBorder(object? sender, PointerEventArgs e)
+    {
+        gradientBorder.Opacity = 0;
+        if(draggingView != null) return;
+    }
+
+    private void AddBorder(object? sender, PointerEventArgs e)
+    {
+        try
+        {
+            if (draggingView != null) return;
+            View? senderView = (sender as View);
+            var location = new Point(senderView.X, senderView.Y);
+            //var gestureRecognizer = new PointerGestureRecognizer();
+            //gestureRecognizer.PointerExited += RemoveBorder;
+
+            //gradientBorder.GestureRecognizers.Add(gestureRecognizer);
+
+            gradientBorder.HeightRequest = senderView.Height;
+            gradientBorder.WidthRequest = senderView.Width+10;
+            gradientBorder.Opacity = 1;
+            gradientBorder.TranslationX = senderView.TranslationX+ gradientBorder.Width/4;
+            gradientBorder.TranslationY = senderView.Y;
+            gradientBorder.Frame = new Rect(senderView.X, senderView.Y, senderView.Width, senderView.Height);
+        }catch(Exception)
+        {
+
+        }
+    }
+
+    private void PointerGestureRecognizer_PointerMoved(object sender, PointerEventArgs e)
+    {
+        // Get pointer location from PointerEventArgs
+        if(!isDragging || draggingView == null) return;
+
+        Point location = e.GetPosition(designerFrame).Value;
+        gradientBorder.Opacity = 1;
+        gradientBorder.ZIndex = -10;
+        draggingView.ZIndex = 0;
+        draggingView.TranslationX = location.X - draggingView.Width/3;
+        draggingView.TranslationY = location.Y - draggingView.Height;
+        gradientBorder.TranslationX = location.X;
+        gradientBorder.TranslationY = location.Y;
+        draggingView.Frame = new Rect(location.X, location.Y, draggingView.Width, draggingView.Height);
+        gradientBorder.Frame = new Rect(location.X, location.Y + draggingView.Height, draggingView.Width, draggingView.Height);
+    }
+
+    private void PointerGestureRecognizer_PointerPressed(object sender, PointerEventArgs e)
+    {
+        isDragging = true;
+        Point location = e.GetPosition(designerFrame).Value;
+        ShowPointer.Text = location.ToString();
+        // Get all children of designerFrame and find the element that is being dragged
+        var childElements = designerFrame.Children.Where(c => c.Frame.Contains(location) && c is not Border);
+
+        draggingView = (View)childElements.FirstOrDefault();
+        if (draggingView != null)
+        {
+           // gradientBorder.HeightRequest = draggingView.Height;
+           // gradientBorder.WidthRequest = draggingView.Width;
+        }
+    }
+
+    private void PointerGestureRecognizer_PointerReleased(object sender, PointerEventArgs e)
+    {
+        if (!isDragging || draggingView == null) return;
+        isDragging = false;
+        RemoveBorder(draggingView, null);
+        //Point location = e.GetPosition(designerFrame).Value;
+        //await draggingView.TranslateTo(location.X, location.Y - 80, 1);
+        //views[draggingView.Id].Layout(new Rect(location.X, location.Y, draggingView.Width, draggingView.Height));
+        //draggingView.Layout(new Rect(location.X, location.Y, draggingView.Width, draggingView.Height));
+        draggingView = null;
+    }
+
+
+}

--- a/ElementCreator.cs
+++ b/ElementCreator.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MAUIDesigner
+{
+    internal static class ElementCreator
+    {
+        internal static View Create(string elementTypeName)
+        {
+            // Get the class that extends View with the name as elementType
+            var elementType = typeof(View).Assembly.GetTypes().FirstOrDefault(t => t.Name == elementTypeName);
+            var newElement = Activator.CreateInstance(elementType) as View;
+            newElement.Margin = new Thickness(20);
+            if(newElement is Label)
+            {
+                (newElement as Label).Text = "Drag me!";
+            }
+            else if(newElement is Editor)
+            {
+                var element = newElement as Editor;
+                element.Text = "Type here";
+                // disable editor text edit
+                element.IsEnabled = false;
+            }
+
+            return newElement;
+        }
+    }
+}

--- a/MAUIDesigner.csproj
+++ b/MAUIDesigner.csproj
@@ -62,4 +62,10 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <MauiXaml Update="Designer.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	</ItemGroup>
+
 </Project>

--- a/MAUIDesigner.sln
+++ b/MAUIDesigner.sln
@@ -3,20 +3,36 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.35013.160
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MAUIDesigner", "MAUIDesigner.csproj", "{236EF176-B4C2-4091-B97E-6AA1B99F0775}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MAUIDesigner", "MAUIDesigner.csproj", "{236EF176-B4C2-4091-B97E-6AA1B99F0775}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|arm64 = Debug|arm64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|arm64 = Release|arm64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|arm64.Build.0 = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|arm64.Deploy.0 = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|x86.Build.0 = Debug|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Debug|x86.Deploy.0 = Debug|Any CPU
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|Any CPU.Build.0 = Release|Any CPU
 		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|arm64.ActiveCfg = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|arm64.Build.0 = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|arm64.Deploy.0 = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|x86.ActiveCfg = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|x86.Build.0 = Release|Any CPU
+		{236EF176-B4C2-4091-B97E-6AA1B99F0775}.Release|x86.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -16,6 +16,4 @@
             </Frame>
         </Grid>
     </StackLayout>
-
-
 </ContentPage>


### PR DESCRIPTION
This commit includes the following changes:
- Added a basic toolkit section on the left side that currently contains hardcoded "Label" and "Editor" items. This can later be modified to be dynamically loaded. Clicking on the items creates corresponding element in the right side frame.
- Added basic drag/drop functionality on the frame side.
- Added border around the items that are being hovered.
- Added rudimentary XAML generation from the absolute layout. Currently it is not getting logged and need to be checked in the Immediate window while debugging.

Things to update:
- The border and drag code is quite messy with magic numbers being added to the translation logic. Need to check generic way of doing it.
- XAML generation with button.
- Update toolkit section to dynamically load visual elements.
- Add support for other layouts such as Grid Layout.