### PR TITLE
Added XAML generation in the designer

### DIFF
--- a/Designer.xaml
+++ b/Designer.xaml
@@ -6,12 +6,14 @@
 
     <Grid VerticalOptions="FillAndExpand">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="150"/>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="300" />
         </Grid.ColumnDefinitions>
         <ScrollView>
             <VerticalStackLayout x:Name="Toolbox" Grid.Column="0">
+                <Button Text="Generate XAML" Clicked="GenerateXamlForTheView">
+                </Button>
             </VerticalStackLayout>
         </ScrollView>
         <AbsoluteLayout Margin="20" VerticalOptions="FillAndExpand" x:Name="designerFrame" Grid.Column="1">

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿
+using Microsoft.Extensions.Logging;
 
 namespace MAUIDesigner
 {
@@ -18,6 +19,7 @@ namespace MAUIDesigner
 #if DEBUG
     		builder.Logging.AddDebug();
 #endif
+
 
             return builder.Build();
         }

--- a/XamlHelpers/ColorXamlGenerator.cs
+++ b/XamlHelpers/ColorXamlGenerator.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MAUIDesigner.XamlHelpers
+{
+    public class ColorXamlGenerator
+    {
+        public static string GenerateXamlForColor(string parentName, string colorHex)
+        {
+            return $"<{parentName} BackgroundColor=\"{colorHex}\" />";
+        }
+    }
+}

--- a/XamlViewModel.cs
+++ b/XamlViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MAUIDesigner
+{
+    public class XamlViewModel : INotifyPropertyChanged
+    {
+        private string _generatedXaml;
+        public string GeneratedXaml
+        {
+            get { return _generatedXaml; }
+            set
+            {
+                if (_generatedXaml != value)
+                {
+                    _generatedXaml = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GeneratedXaml)));
+                }
+            }
+        }
+
+        public XamlViewModel(string xaml)
+        {
+            _generatedXaml = xaml;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}


### PR DESCRIPTION
- Added XAML generator button in the designer view
- Updated border to follow PropertyChanged event from the draggingView/focusedView to remove unnecessary code

The generated XAML Can directly be put into an XAML file and the content View will be displayed correctly.
- Currently supports primitive values (int,float etc), string, Color, Thickness and Enum values like Font case and formatting ( Italic/bold ).