### PR TITLE
Refactor code and fix dragging time

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MAUIDesigner
+{
+    public static class Constants
+    {
+        public const string DraggingViewName = "gradientBorder2";
+    }
+}

--- a/Designer.xaml
+++ b/Designer.xaml
@@ -60,7 +60,7 @@
                  AbsoluteLayout.LayoutFlags="All"/>
             </AbsoluteLayout>
             <AbsoluteLayout.GestureRecognizers>
-                <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped"/>
+                <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" Buttons="Secondary,Primary"/>
                 <PointerGestureRecognizer PointerMoved="PointerGestureRecognizer_PointerMoved" PointerPressed="PointerGestureRecognizer_PointerPressed" PointerReleased="PointerGestureRecognizer_PointerReleased"/>
             </AbsoluteLayout.GestureRecognizers>
 

--- a/ElementCreator.cs
+++ b/ElementCreator.cs
@@ -26,7 +26,6 @@ namespace MAUIDesigner
                 element.Text = "Type here";
                 // disable editor text edit
                 element.IsEnabled = false;
-                element.InputTransparent = false;
             }
 
             return newElement;

--- a/ToolBox.cs
+++ b/ToolBox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -25,11 +26,8 @@ namespace MAUIDesigner
         internal static IDictionary<string, View> GetAllPropertiesForView(View view)
         {
             var viewProperties = view.GetType().GetProperties().Where(x => x.CanWrite);
-            var properties = new Dictionary<string, View>();
-            foreach (var property in viewProperties)
-            {
-                properties[property.Name] = GetViewForPropertyType(view, property, property.GetValue(view));
-            }
+            var properties = new ConcurrentDictionary<string, View>();
+            Parallel.ForEach(viewProperties, property => properties[property.Name] = GetViewForPropertyType(view, property, property.GetValue(view)));
 
             return properties;
         }
@@ -132,10 +130,10 @@ namespace MAUIDesigner
                 {
                     try
                     {
-                        var valueA = byte.Parse(red.Text);
-                        var valueB = byte.Parse(green.Text);
-                        var valueC = byte.Parse(blue.Text);
-                        var valueD = byte.Parse(alpha.Text);
+                        var valueA = int.Parse(red.Text);
+                        var valueB = int.Parse(green.Text);
+                        var valueC = int.Parse(blue.Text);
+                        var valueD = int.Parse(alpha.Text);
                         if (value.GetType() == typeof(Color))
                         {
                             var color = Color.FromRgba(valueA, valueB, valueC, valueD);

--- a/XamlHelpers/XAMLGenerator.cs
+++ b/XamlHelpers/XAMLGenerator.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MAUIDesigner.XamlHelpers
+{
+    class XAMLGenerator
+    {
+        private static Type[] allowedTypesForXamlProperties = { typeof(string), typeof(Color), typeof(Thickness), typeof(Enum) };
+
+        public static string GetXamlForElement(VisualElement element)
+        {
+            var xaml = GetInternalXAML(element);
+            var finalXamlBuilder = new StringBuilder();
+            finalXamlBuilder.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n<ContentPage xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\"\r\n             xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\"\r\n>");
+            finalXamlBuilder.AppendLine(xaml);
+            finalXamlBuilder.AppendLine("</ContentPage>");
+
+            return finalXamlBuilder.ToString();
+        }
+
+        private static string GetInternalXAML(VisualElement element)
+        {
+            StringBuilder xamlBuilder = new StringBuilder();
+            if (element.StyleId == Constants.DraggingViewName)
+            {
+                return string.Empty;
+            }
+
+            xamlBuilder.AppendLine($"<{element.GetType().Name}");
+
+            foreach (var property in element.GetType().GetProperties())
+            {
+                if (property.CanRead && property.CanWrite && property.GetIndexParameters().Length == 0)
+                {
+                    var value = property.GetValue(element);
+                    var valueType = value?.GetType();
+                    if (value != null && IsSupportedType(valueType) && value.ToString() != "∞")
+                    {
+                        if (valueType == typeof(Color))
+                        {
+                            value = ((Color)value).ToArgbHex(true);
+                        }
+                        else if (valueType == typeof(Thickness))
+                        {
+                            var tValue = ((Thickness)value);
+                            value = $"{tValue.Left},{tValue.Top},{tValue.Right},{tValue.Bottom}";
+                        }
+
+                        xamlBuilder.AppendLine($"    {property.Name}=\"{value}\"");
+                    }
+                }
+            }
+
+            // Check if element can contain children
+            if (element is Layout layout)
+            {
+                xamlBuilder.AppendLine(">");
+                foreach (var child in layout.Children.Where(x => x is VisualElement))
+                {
+                    xamlBuilder.AppendLine(XAMLGenerator.GetXamlForElement(child as VisualElement));
+                }
+                xamlBuilder.AppendLine($"</{element.GetType().Name}>");
+            }
+            else
+            {
+
+                xamlBuilder.AppendLine("/>");
+            }
+            return xamlBuilder.ToString();
+        }
+
+        private static bool IsSupportedType(Type valueType)
+        {
+            // Check if the type is a primitive type or string
+            return valueType.IsPrimitive || valueType.IsEnum || allowedTypesForXamlProperties.Contains(valueType);
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Updated property view to use shadow list so that only final update makes it to the view.
- Moved property generation to parallel.
- Moved the responsibility of dragging a view to the view itself, which was earlier on parent. The parent still holds the responsibility of some views like Editor which don't support tap.
- Refactored some code and moved it to specific classes.
- Changed direct element margin update on drag to property update to promote reusability of code.