### PR TITLE
Designer power features: multi-select, alignment, clipboard, live preview and richer controls

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,8 +39,10 @@ Always reference these instructions first and fallback to search or bash command
   4. **Properties Panel**: Select an element and modify properties like color, margin, padding, text
   5. **XAML Generation**: Use the "Download" feature to export the designed layout
   6. **Load Design**: Import existing XAML to recreate the visual design
+  7. **Multi-Selection**: Shift-click or marquee several elements, then align, bulk-edit and delete them
+  8. **Clipboard**: `Ctrl+C`/`Ctrl+X`/`Ctrl+V`, save a template from the toolbar, apply a starter page
+  9. **Viewport**: Zoom in/out, pick a device preset, toggle the dark preview and the rulers
 - **Layout Support**: Supports multiple layout types including StackLayout, Grid, and AbsoluteLayout
-- **Limited Automated Tests**: This repository has minimal test infrastructure - validation is primarily manual
 - **Post-Build Validation**: Always run `ng serve` after building to ensure UI components load correctly in browser
 - **Designer Workflow Test**: Create a simple layout with Label, Button, and Entry controls to verify basic functionality
 
@@ -49,6 +51,8 @@ Always reference these instructions first and fallback to search or bash command
 - **Build Tests**: `ng build` -- verifies TypeScript compilation and bundling
 - **E2E Tests**: `npm run e2e` -- headless Playwright suite in `e2e/`; it boots `ng serve` on port 4300 automatically. Run `npx playwright install chromium` once first. Use `E2E_BASE_URL` to target an existing server.
 - **Test hooks**: components expose `data-testid` attributes consumed by `e2e/helpers/designer-page.ts`. Preserve them when editing templates.
+- **Polling helpers**: the XAML pane and the properties panel re-render from RxJS streams, so assert with `expectXamlToContain`, `xamlWhen`, `expectProperty` or `expectPropertyNumber` instead of one-shot reads, otherwise the tests flake on CI.
+- **Canvas coordinates**: the canvas sits inside a zoomable wrapper - convert client coordinates with `toCanvasPoint` (divide by `viewport.zoom`) in components, and avoid canvas x > ~400 in tests because the right panel overlaps it.
 - **Linting**: Use `ng lint` if ESLint is configured, or standard TypeScript compiler checks
 
 ### Browser Compatibility
@@ -75,6 +79,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Important Directories
 - **src/app/components/**: Angular components for the designer interface
+  - **canvas-toolbar/**: Device, zoom, theme, grid, align and clipboard toolbar
   - **designer-canvas/**: Main design surface component
   - **hierarchy-panel/**: Element tree view component
   - **properties-panel/**: Property editor component
@@ -86,6 +91,9 @@ Always reference these instructions first and fallback to search or bash command
   - **layout-designer.ts**: Layout calculation service
   - **xaml-generator.ts**: XAML code generation
   - **xaml-parser.ts**: XAML parsing service
+  - **alignment.ts**: Align, distribute, snap-to-grid and smart guides
+  - **viewport.ts**: Zoom, pan, device preset, theme and grid state (persisted in localStorage)
+  - **clipboard.ts**: Copy/cut/paste, component templates and starter pages
 - **src/app/models/**: Data models and interfaces
   - **maui-element.ts**: MAUI element definitions
   - **toolbox.ts**: Toolbox item definitions
@@ -113,6 +121,8 @@ typescript (5.5.4)
 - **Focus on XAML designer workflow**: Test element creation, property editing, and layout generation
 - **Angular CLI**: Use `ng generate` commands for creating new components and services
 - **Hot reloading**: Development server auto-reloads on file changes
+- **Keyboard shortcuts**: `Ctrl+Z`/`Ctrl+Y` undo-redo, `Ctrl+C`/`Ctrl+X`/`Ctrl+V` clipboard, `Ctrl+A` select all, `Ctrl+D` duplicate, `Delete` remove, arrow keys nudge, `Space`+drag or middle-drag to pan, `Ctrl`+wheel to zoom
+- **Bulk operations**: wrap multi-element changes in `elementService.runAsSingleChange()` with `{ recordHistory: false }` updates so they undo as one step
 - **CI/CD**: `.github/workflows/ci.yml` builds and runs unit + e2e tests; `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages on pushes to `main`
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Keyboard Shortcuts**: `Delete` to remove, `Ctrl+D` to duplicate, arrow keys to nudge, `Esc` to deselect
 - **Local Persistence**: Save and restore your design in the browser
 
+### Multi-Selection
+- **Shift/Ctrl+Click**: Add or remove elements from the selection
+- **Marquee Selection**: Rubber-band across the canvas to grab everything it touches
+- **Select All**: `Ctrl+A` selects every child of the current layout
+- **Bulk Editing**: Shared width, height, background colour and visibility in the properties panel
+- **Bulk Actions**: Delete, duplicate, nudge and align a whole selection in one undo step
+
+### Alignment & Layout Tools
+- **Align**: Left, centre, right, top, middle and bottom for any multi-selection
+- **Distribute**: Even horizontal or vertical spacing for three or more elements
+- **Snap to Grid**: Configurable grid size with snapping while dragging
+- **Smart Guides**: Live guides when a dragged element lines up with a sibling or the page edges/centre
+- **Rulers**: Optional horizontal and vertical rulers around the design surface
+
+### Clipboard, Templates & Starter Pages
+- **Copy/Cut/Paste**: `Ctrl+C`, `Ctrl+X`, `Ctrl+V` (containers keep their children, names stay unique)
+- **Component Templates**: Save any selection as a reusable template, stored in the browser
+- **Starter Pages**: Login, list, profile and settings pages ready to drop onto the canvas
+
+### Live Preview
+- **Device Presets**: Phone, small phone, tablet, desktop or a custom surface size
+- **Zoom & Pan**: Toolbar buttons, `Ctrl` + mouse wheel, and `Space` + drag (or middle-drag) to pan
+- **Fit to Window**: One click to scale the design to the available space
+- **Dark Mode Preview**: Toggle a dark canvas to check contrast
+- **Persisted View**: Zoom, theme and grid settings survive a reload
+
 ### XAML Integration
 - **XAML Editor**: Full-featured code editor with syntax support
 - **Real-time Preview**: Instant visual updates when applying XAML changes
@@ -33,9 +59,20 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 #### Controls
 - **Label**: Text display with formatting options
 - **Button**: Interactive buttons with styling
-- **Entry**: Single-line text input fields
-- **Editor**: Multi-line text input areas
 - **Image**: Image display with positioning
+- **ProgressBar**: Determinate progress with a `Progress` value
+- **ActivityIndicator**: Busy indicator with an `IsRunning` flag
+- **CollectionView**: Repeating list with an editable `ItemTemplate`
+
+#### Inputs
+- **Entry**: Single-line text input with placeholder support
+- **Editor**: Multi-line text input areas
+- **SearchBar**: Search input with placeholder
+- **CheckBox**: Two-state check box
+- **Switch**: Toggle switch
+- **Slider**: Minimum/maximum/value slider
+- **Stepper**: Increment/decrement stepper
+- **DatePicker**: Date selection
 
 #### Layouts
 - **StackLayout**: Vertical/horizontal stacking of elements
@@ -44,6 +81,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 
 #### Views
 - **Frame**: Containers with borders and backgrounds
+- **Border**: Container with stroke, thickness and corner radius
 - **ScrollView**: Scrollable content areas
 
 ## 🛠️ Prerequisites
@@ -164,6 +202,8 @@ The Properties panel allows you to modify:
 - **Visual Properties**: Background color, text color, font family, font size
 - **Content Properties**: Text content, images, and other element-specific properties
 - **Grid Properties**: Row/column position and spanning for Grid layouts
+- **Control Properties**: Placeholder, checked/toggled state, slider range, progress, corner radius, and more
+- **Data Bindings**: Bind any supported property to a view-model path; the generated XAML emits `{Binding Path}` instead of the literal value
 
 ### 4. XAML Editor
 
@@ -235,6 +275,9 @@ The application follows Angular's standalone components architecture with a serv
 - **XamlGeneratorService**: Converts visual designs to XAML code
 - **XamlParserService**: Parses XAML code into visual elements
 - **DragDropService**: Manages drag-and-drop interactions
+- **AlignmentService**: Aligns, distributes, snaps and computes smart guides
+- **ViewportService**: Zoom, pan, device preset, theme and grid settings (persisted)
+- **ClipboardService**: Copy/cut/paste, component templates and starter pages
 
 ### Adding New MAUI Elements
 

--- a/angular.json
+++ b/angular.json
@@ -41,13 +41,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "600kB",
                   "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "16kB",
+                  "maximumError": "24kB"
                 }
               ],
               "outputHashing": "all"

--- a/e2e/alignment.spec.ts
+++ b/e2e/alignment.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+/** Adds a control and places it at an absolute position. */
+async function addAt(designer: DesignerPage, type: string, x: number, y: number) {
+  await designer.addControl(type);
+  await designer.setProperty('x', String(x));
+  await designer.setProperty('y', String(y));
+}
+
+test.describe('Alignment and layout tools', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('align left moves every selected element to the leftmost edge', async () => {
+    await addAt(designer, 'Label', 60, 40);
+    await addAt(designer, 'Button', 130, 140);
+
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await designer.alignButton('left').click();
+
+    await designer.selectFirst('Button');
+    await designer.expectProperty('x', 60);
+    await designer.selectFirst('Label');
+    await designer.expectProperty('x', 60);
+  });
+
+  test('align top moves every selected element to the topmost edge', async () => {
+    await addAt(designer, 'Label', 60, 90);
+    await addAt(designer, 'Button', 200, 30);
+
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await designer.alignButton('top').click();
+
+    await designer.selectFirst('Label');
+    await designer.expectProperty('y', 30);
+  });
+
+  test('align buttons are disabled without a multi selection', async ({ page }) => {
+    await addAt(designer, 'Label', 60, 40);
+
+    await expect(designer.alignButton('left')).toBeDisabled();
+    await expect(page.getByTestId('distribute-horizontal')).toBeDisabled();
+  });
+
+  test('distribute horizontally spaces three elements evenly', async ({ page }) => {
+    await addAt(designer, 'Label', 20, 40);
+    await addAt(designer, 'Button', 60, 120);
+    await addAt(designer, 'Image', 320, 200);
+
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await designer.toggleSelect('Image');
+    await expect(page.getByTestId('distribute-horizontal')).toBeEnabled();
+    await page.getByTestId('distribute-horizontal').click();
+
+    await designer.selectFirst('Label');
+    const left = await designer.getPropertyNumber('x');
+    await designer.selectFirst('Image');
+    const right = await designer.getPropertyNumber('x');
+    await designer.selectFirst('Button');
+    const middleX = await designer.getPropertyNumber('x');
+    const middleWidth = await designer.getPropertyNumber('width');
+
+    // The middle element's centre should sit halfway between the two anchors
+    const leftCentre = left + 100 / 2;
+    const rightCentre = right + 100 / 2;
+    expect(middleX + middleWidth / 2).toBeCloseTo((leftCentre + rightCentre) / 2, 0);
+  });
+
+  test('the align buttons in the properties panel work too', async ({ page }) => {
+    await addAt(designer, 'Label', 60, 40);
+    await addAt(designer, 'Button', 220, 140);
+
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await page.getByTestId('panel-align-right').click();
+
+    await designer.selectFirst('Label');
+    const labelRight = await designer.getPropertyNumber('x');
+    expect(labelRight).toBeGreaterThan(60);
+  });
+
+  test('aligning a multi selection is a single undo step', async () => {
+    await addAt(designer, 'Label', 60, 40);
+    await addAt(designer, 'Button', 220, 140);
+
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await designer.alignButton('left').click();
+    await designer.undoButton.click();
+
+    await designer.selectFirst('Button');
+    await designer.expectProperty('x', 220);
+    await designer.selectFirst('Label');
+    await designer.expectProperty('x', 60);
+  });
+
+  test('snap to grid rounds a dropped element to the grid size', async ({ page }) => {
+    await addAt(designer, 'Label', 33, 47);
+
+    await page.getByTestId('grid-size').fill('20');
+    await page.getByTestId('grid-size').dispatchEvent('input');
+    const snap = page.getByTestId('toggle-snap');
+    if ((await snap.getAttribute('data-active')) !== 'true') {
+      await snap.click();
+    }
+    await expect(snap).toHaveAttribute('data-active', 'true');
+
+    await designer.selectFirst('Label');
+    await designer.dragElementBy('Label', { x: 41, y: 33 });
+
+    const x = await designer.getPropertyNumber('x');
+    const y = await designer.getPropertyNumber('y');
+    expect(x % 20).toBe(0);
+    expect(y % 20).toBe(0);
+  });
+
+  test('the grid overlay can be toggled on the canvas', async ({ page }) => {
+    const toggle = page.getByTestId('toggle-grid');
+    const wasOn = (await toggle.getAttribute('data-active')) === 'true';
+    await toggle.click();
+
+    if (wasOn) {
+      await expect(designer.canvas).not.toHaveClass(/show-grid/);
+    } else {
+      await expect(designer.canvas).toHaveClass(/show-grid/);
+    }
+  });
+
+  test('rulers can be toggled', async ({ page }) => {
+    const toggle = page.getByTestId('toggle-rulers');
+    if ((await toggle.getAttribute('data-active')) === 'true') {
+      await toggle.click();
+    }
+    await expect(page.getByTestId('ruler-horizontal')).toHaveCount(0);
+
+    await toggle.click();
+    await expect(page.getByTestId('ruler-horizontal')).toBeVisible();
+    await expect(page.getByTestId('ruler-vertical')).toBeVisible();
+  });
+
+  test('smart guides appear while dragging next to a sibling', async ({ page }) => {
+    await addAt(designer, 'Label', 100, 60);
+    await addAt(designer, 'Button', 100, 260);
+
+    const snap = page.getByTestId('toggle-snap');
+    if ((await snap.getAttribute('data-active')) === 'true') {
+      await snap.click();
+    }
+
+    await designer.selectFirst('Button');
+    const element = designer.canvasElements('Button').first();
+    const box = (await element.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    // Drift a couple of pixels off the shared left edge: within the snap threshold
+    await page.mouse.move(box.x + box.width / 2 + 3, box.y + box.height / 2 - 60, { steps: 10 });
+    await page.mouse.move(box.x + box.width / 2 + 2, box.y + box.height / 2 - 60, { steps: 5 });
+
+    await expect(page.locator('[data-testid^="alignment-guide"]').first()).toBeVisible();
+    await page.mouse.up();
+
+    await expect(page.locator('[data-testid^="alignment-guide"]')).toHaveCount(0);
+  });
+});

--- a/e2e/clipboard.spec.ts
+++ b/e2e/clipboard.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Clipboard, templates and starter pages', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    await page.evaluate(() => {
+      localStorage.removeItem('maui-designer.clipboard');
+      localStorage.removeItem('maui-designer.templates');
+    });
+  });
+
+  test('Ctrl+C then Ctrl+V duplicates the selected element', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.setProperty('x', '40');
+    await designer.setProperty('y', '40');
+    // Move focus out of the property input: shortcuts are ignored while typing
+    await designer.selectFirst('Label');
+
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+
+    await expect(designer.canvasElements('Label')).toHaveCount(2);
+    // The pasted copy is selected and offset from the original
+    await designer.expectPropertyNumber('x', value => value > 40);
+  });
+
+  test('the pasted element keeps the copied properties', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.setProperty('text', 'Save changes');
+    await designer.selectFirst('Button');
+
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+
+    const xaml = await designer.xamlWhen(
+      value => (value.match(/Text="Save changes"/g) || []).length === 2
+    );
+    expect((xaml.match(/Text="Save changes"/g) || []).length).toBe(2);
+  });
+
+  test('pasting assigns unique names so the XAML stays valid', async ({ page }) => {
+    await designer.addControl('Label');
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+
+    const xaml = await designer.getXaml();
+    const names = [...xaml.matchAll(/x:Name="([^"]+)"/g)].map(match => match[1]);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test('Ctrl+X removes the element and pastes it back', async ({ page }) => {
+    await designer.addControl('Label');
+    await page.keyboard.press('Control+x');
+    await expect(designer.canvasElements('Label')).toHaveCount(0);
+
+    await page.keyboard.press('Control+v');
+    await expect(designer.canvasElements('Label')).toHaveCount(1);
+  });
+
+  test('the toolbar copy and paste buttons work', async ({ page }) => {
+    await designer.addControl('Image');
+    await designer.selectFirst('Image');
+
+    await page.getByTestId('toolbar-copy').click();
+    await page.getByTestId('toolbar-paste').click();
+
+    await expect(designer.canvasElements('Image')).toHaveCount(2);
+  });
+
+  test('copying a container also copies its children', async ({ page }) => {
+    await designer.addControl('VerticalStackLayout');
+    await designer.addControl('Label');
+
+    await designer.selectFirst('VerticalStackLayout');
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+
+    await expect(designer.canvasElements('VerticalStackLayout')).toHaveCount(2);
+    await expect(designer.canvasElements('Label')).toHaveCount(2);
+  });
+
+  test('a pasted copy can be undone in a single step', async ({ page }) => {
+    await designer.addControl('Label');
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+    await expect(designer.canvasElements('Label')).toHaveCount(2);
+
+    await designer.undoButton.click();
+    await expect(designer.canvasElements('Label')).toHaveCount(1);
+  });
+
+  test('a selection can be saved as a reusable template and inserted again', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.setProperty('text', 'Primary');
+    await designer.selectFirst('Button');
+
+    page.once('dialog', dialog => dialog.accept('PrimaryButton'));
+    await page.getByTestId('save-template').click();
+
+    await designer.openToolbox();
+    const template = page.getByTestId('template-PrimaryButton');
+    await expect(template).toBeVisible();
+
+    await template.click();
+    await expect(designer.canvasElements('Button')).toHaveCount(2);
+    const xaml = await designer.getXaml();
+    expect((xaml.match(/Text="Primary"/g) || []).length).toBe(2);
+  });
+
+  test('templates survive a reload and can be deleted', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.selectFirst('Button');
+    page.once('dialog', dialog => dialog.accept('Reusable'));
+    await page.getByTestId('save-template').click();
+
+    await page.reload();
+    await designer.openToolbox();
+    await expect(page.getByTestId('template-Reusable')).toBeVisible();
+
+    await page.getByTestId('template-delete-Reusable').click();
+    await expect(page.getByTestId('template-Reusable')).toHaveCount(0);
+  });
+
+  test('cancelling the template prompt saves nothing', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.selectFirst('Button');
+
+    page.once('dialog', dialog => dialog.dismiss());
+    await page.getByTestId('save-template').click();
+
+    await designer.openToolbox();
+    await expect(page.getByTestId('templates-section').locator('.toolbox-list-item')).toHaveCount(0);
+  });
+
+  for (const starter of ['login', 'list', 'profile', 'settings']) {
+    test(`the ${starter} starter page populates the canvas`, async ({ page }) => {
+      await designer.openToolbox();
+      await page.getByTestId(`starter-${starter}`).click();
+
+      await expect(designer.canvasElements().first()).toBeVisible();
+      expect(await designer.canvasElements().count()).toBeGreaterThan(2);
+      await designer.expectXamlToContain('<ContentPage');
+    });
+  }
+
+  test('applying a starter page can be undone', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.openToolbox();
+    await page.getByTestId('starter-login').click();
+    await expect(designer.canvasElements('Entry').first()).toBeVisible();
+
+    await designer.undoButton.click();
+    await expect(designer.canvasElements('Label')).toHaveCount(1);
+  });
+});

--- a/e2e/controls.spec.ts
+++ b/e2e/controls.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Control library', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  const controls = [
+    'SearchBar',
+    'CheckBox',
+    'Switch',
+    'Slider',
+    'Stepper',
+    'DatePicker',
+    'ProgressBar',
+    'ActivityIndicator',
+    'Border',
+    'CollectionView'
+  ];
+
+  for (const control of controls) {
+    test(`adds a ${control} and generates it into XAML`, async () => {
+      await designer.addControl(control);
+      await expect(designer.canvasElements(control)).toHaveCount(1);
+      await designer.expectXamlToContain(`<${control} `);
+    });
+  }
+
+  test('toggles a CheckBox and keeps the state in XAML', async ({ page }) => {
+    await designer.addControl('CheckBox');
+    await designer.selectFirst('CheckBox');
+
+    await page.getByTestId('prop-isChecked').check();
+    await designer.expectXamlToContain('IsChecked="True"');
+
+    await page.getByTestId('prop-isChecked').uncheck();
+    await designer.expectXamlToContain('IsChecked="False"');
+  });
+
+  test('edits the slider range and value', async ({ page }) => {
+    await designer.addControl('Slider');
+    await designer.selectFirst('Slider');
+
+    await designer.setProperty('minimum', '10');
+    await designer.setProperty('maximum', '20');
+    await designer.setProperty('value', '15');
+
+    await designer.expectXamlToContain('Minimum="10"', 'Maximum="20"', 'Value="15"');
+
+    // The preview thumb sits half way through the range
+    const fill = designer.canvasElements('Slider').locator('.slider-fill');
+    await expect(fill).toHaveAttribute('style', /width: 50%/);
+  });
+
+  test('writes an Entry placeholder separately from its text', async ({ page }) => {
+    await designer.addControl('Entry');
+    await designer.selectFirst('Entry');
+
+    await designer.setProperty('placeholder', 'Email address');
+    await designer.setProperty('text', 'me@example.com');
+
+    await designer.expectXamlToContain('Placeholder="Email address"', 'Text="me@example.com"');
+  });
+
+  test('configures a Border stroke and radius', async ({ page }) => {
+    await designer.addControl('Border');
+    await designer.selectFirst('Border');
+
+    await designer.setProperty('borderWidth', '3');
+    await designer.setProperty('cornerRadius', '12');
+
+    await designer.expectXamlToContain('StrokeThickness="3"', 'StrokeShape="RoundRectangle 12"');
+  });
+
+  test('renders repeated items for a CollectionView', async ({ page }) => {
+    await designer.addControl('CollectionView');
+    await designer.selectFirst('CollectionView');
+
+    await designer.setProperty('itemCount', '5');
+    await expect(designer.canvasElements('CollectionView').locator('.collection-item')).toHaveCount(5);
+  });
+});
+
+test.describe('Data bindings', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('binds a property and generates a Binding expression', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('binding-Text').fill('UserName');
+    await page.getByTestId('binding-Text').dispatchEvent('input');
+
+    await designer.expectXamlToContain('Text="{Binding UserName}"');
+  });
+
+  test('a binding replaces the literal value', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await designer.setProperty('text', 'Static');
+    await designer.expectXamlToContain('Text="Static"');
+
+    await page.getByTestId('binding-Text').fill('Title');
+    await page.getByTestId('binding-Text').dispatchEvent('input');
+
+    const xaml = await designer.xamlWhen(value => value.includes('{Binding Title}'));
+    expect(xaml).not.toContain('Text="Static"');
+  });
+
+  test('round trips bindings through the XAML editor', async ({ page }) => {
+    await designer.addControl('Switch');
+    await designer.selectFirst('Switch');
+
+    await page.getByTestId('binding-IsToggled').fill('IsDarkMode');
+    await page.getByTestId('binding-IsToggled').dispatchEvent('input');
+    await designer.expectXamlToContain('IsToggled="{Binding IsDarkMode}"');
+
+    await designer.applyXaml(await designer.getXaml());
+    await designer.selectFirst('Switch');
+    await expect(page.getByTestId('binding-IsToggled')).toHaveValue('IsDarkMode');
+  });
+
+  test('clearing a binding restores the literal property', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('binding-Text').fill('Name');
+    await page.getByTestId('binding-Text').dispatchEvent('input');
+    await designer.expectXamlToContain('{Binding Name}');
+
+    await page.getByTestId('binding-Text').fill('');
+    await page.getByTestId('binding-Text').dispatchEvent('input');
+
+    const xaml = await designer.xamlWhen(value => !value.includes('{Binding'));
+    expect(xaml).toContain('Text="Label"');
+  });
+});

--- a/e2e/helpers/designer-page.ts
+++ b/e2e/helpers/designer-page.ts
@@ -36,6 +36,36 @@ export class DesignerPage {
   async goto() {
     await this.page.goto('/');
     await expect(this.canvas).toBeVisible();
+    // Every spec starts from a clean, predictable viewport
+    await this.page.evaluate(() => localStorage.removeItem('maui-designer.viewport'));
+  }
+
+  /** Ctrl-clicks an element to add or remove it from the selection. */
+  async toggleSelect(type: string, index = 0) {
+    await this.canvasElements(type).nth(index).click({ modifiers: ['Shift'] });
+  }
+
+  /** Drags a rubber band rectangle over the canvas in canvas coordinates. */
+  async marquee(from: { x: number; y: number }, to: { x: number; y: number }) {
+    const box = (await this.canvas.boundingBox())!;
+    await this.page.mouse.move(box.x + from.x, box.y + from.y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(box.x + to.x, box.y + to.y, { steps: 12 });
+    await this.page.mouse.up();
+  }
+
+  /** Drags an already selected element by an offset. */
+  async dragElementBy(type: string, delta: { x: number; y: number }, index = 0) {
+    const element = this.canvasElements(type).nth(index);
+    const box = (await element.boundingBox())!;
+    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await this.page.mouse.down();
+    await this.page.mouse.move(box.x + box.width / 2 + delta.x, box.y + box.height / 2 + delta.y, { steps: 12 });
+    await this.page.mouse.up();
+  }
+
+  selectionCount(): Locator {
+    return this.page.getByTestId('selection-count');
   }
 
   async openToolbox() {
@@ -136,6 +166,16 @@ export class DesignerPage {
     await expect
       .poll(() => this.propertyValue(name).then(raw => assertion(Number(raw))), { timeout: 10_000 })
       .toBe(true);
+  }
+
+  /** Reads a numeric property input once it has settled. */
+  async getPropertyNumber(name: string): Promise<number> {
+    await expect(this.page.getByTestId(`prop-${name}`)).toBeVisible();
+    return Number(await this.propertyValue(name));
+  }
+
+  alignButton(direction: 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom'): Locator {
+    return this.page.getByTestId(`align-${direction}`);
   }
 }
 

--- a/e2e/multi-select.spec.ts
+++ b/e2e/multi-select.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Multi selection', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    // Position each control as it is added: a freshly added control is already
+    // selected, and stacking them would make the earlier one unclickable.
+    await designer.addControl('Label');
+    await designer.setProperty('x', '40');
+    await designer.setProperty('y', '40');
+    await designer.addControl('Button');
+    await designer.setProperty('x', '40');
+    await designer.setProperty('y', '140');
+  });
+
+  test('shift clicking adds elements to the selection', async () => {
+    await designer.selectFirst('Label');
+    await expect(designer.selectionCount()).toHaveText('1 selected');
+
+    await designer.toggleSelect('Button');
+    await expect(designer.selectionCount()).toHaveText('2 selected');
+    await expect(designer.selectedCanvasElement()).toHaveCount(2);
+  });
+
+  test('shift clicking a selected element removes it again', async () => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+    await designer.toggleSelect('Button');
+
+    await expect(designer.selectionCount()).toHaveText('1 selected');
+  });
+
+  test('the properties panel switches to the multi selection editor', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+
+    await expect(page.getByTestId('multi-selection-panel')).toBeVisible();
+    await expect(page.getByTestId('multi-selection-title')).toHaveText('2 elements selected');
+  });
+
+  test('a marquee selects every element it touches', async () => {
+    await designer.marquee({ x: 20, y: 20 }, { x: 320, y: 260 });
+
+    await expect(designer.selectionCount()).toHaveText('2 selected');
+  });
+
+  test('a marquee over empty space clears the selection', async () => {
+    await designer.selectFirst('Label');
+    await designer.marquee({ x: 200, y: 320 }, { x: 380, y: 460 });
+
+    await expect(designer.selectionCount()).toHaveText('0 selected');
+  });
+
+  test('Ctrl+A selects every child of the root layout', async ({ page }) => {
+    await page.getByTestId('designer-canvas').click({ position: { x: 300, y: 420 } });
+    await page.keyboard.press('Control+a');
+
+    await expect(designer.selectionCount()).toHaveText('2 selected');
+  });
+
+  test('editing a shared property updates every selected element', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+
+    await page.getByTestId('multi-width').fill('180');
+    await page.getByTestId('multi-width').dispatchEvent('input');
+
+    await designer.expectXamlToContain('WidthRequest="180"');
+    const xaml = await designer.getXaml();
+    expect((xaml.match(/WidthRequest="180"/g) || []).length).toBe(2);
+  });
+
+  test('deleting a multi selection removes every element in one undo step', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+
+    await page.keyboard.press('Delete');
+    await expect(designer.canvasElements()).toHaveCount(1); // only the root remains
+
+    await designer.undoButton.click();
+    await expect(designer.canvasElements('Label')).toHaveCount(1);
+    await expect(designer.canvasElements('Button')).toHaveCount(1);
+  });
+
+  test('arrow keys nudge every selected element', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+
+    await page.keyboard.press('Shift+ArrowRight');
+
+    await designer.selectFirst('Label');
+    await designer.expectProperty('x', 50);
+    await designer.selectFirst('Button');
+    await designer.expectProperty('x', 50);
+  });
+
+  test('duplicating a multi selection copies every element', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.toggleSelect('Button');
+
+    await page.getByTestId('multi-duplicate').click();
+
+    await expect(designer.canvasElements('Label')).toHaveCount(2);
+    await expect(designer.canvasElements('Button')).toHaveCount(2);
+  });
+
+  test('only a single selection offers resize handles', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await expect(page.getByTestId('resize-handle-se')).toHaveCount(1);
+
+    await designer.toggleSelect('Button');
+    await expect(page.getByTestId('resize-handle-se')).toHaveCount(0);
+  });
+});

--- a/e2e/viewport.spec.ts
+++ b/e2e/viewport.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Live preview viewport', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    await page.reload();
+    await expect(designer.canvas).toBeVisible();
+  });
+
+  test('zooming in and out updates the zoom readout and the canvas transform', async ({ page }) => {
+    await expect(page.getByTestId('zoom-value')).toHaveText('100%');
+
+    await page.getByTestId('zoom-in').click();
+    await expect(page.getByTestId('zoom-value')).not.toHaveText('100%');
+    const zoomed = Number(await page.getByTestId('canvas-scale').getAttribute('data-zoom'));
+    expect(zoomed).toBeGreaterThan(1);
+
+    await page.getByTestId('zoom-out').click();
+    await expect
+      .poll(async () => Number(await page.getByTestId('canvas-scale').getAttribute('data-zoom')))
+      .toBeLessThan(zoomed);
+  });
+
+  test('reset view returns the canvas to 100%', async ({ page }) => {
+    await page.getByTestId('zoom-in').click();
+    await page.getByTestId('zoom-in').click();
+    await page.getByTestId('zoom-reset').click();
+
+    await expect(page.getByTestId('zoom-value')).toHaveText('100%');
+    await expect(page.getByTestId('canvas-scale')).toHaveAttribute('data-zoom', '1');
+  });
+
+  test('fit to window picks a zoom that fits the design surface', async ({ page }) => {
+    await page.getByTestId('zoom-fit').click();
+
+    const zoom = Number(await page.getByTestId('canvas-scale').getAttribute('data-zoom'));
+    expect(zoom).toBeGreaterThan(0.25);
+    expect(zoom).toBeLessThanOrEqual(3);
+  });
+
+  test('zoom is clamped at the maximum', async ({ page }) => {
+    for (let i = 0; i < 20; i++) {
+      await page.getByTestId('zoom-in').click();
+    }
+    await expect(page.getByTestId('zoom-value')).toHaveText('300%');
+  });
+
+  test('Ctrl + wheel zooms the canvas', async ({ page }) => {
+    const box = (await designer.canvas.boundingBox())!;
+    await page.mouse.move(box.x + 200, box.y + 200);
+    await page.keyboard.down('Control');
+    await page.mouse.wheel(0, -240);
+    await page.keyboard.up('Control');
+
+    await expect
+      .poll(async () => Number(await page.getByTestId('canvas-scale').getAttribute('data-zoom')))
+      .toBeGreaterThan(1);
+  });
+
+  test('the zoom level is restored after a reload', async ({ page }) => {
+    await page.getByTestId('zoom-in').click();
+    const zoom = await page.getByTestId('zoom-value').textContent();
+
+    await page.reload();
+    await expect(page.getByTestId('zoom-value')).toHaveText(zoom!.trim());
+  });
+
+  test('choosing a device preset resizes the design surface', async ({ page }) => {
+    await page.getByTestId('device-select').selectOption('tablet');
+
+    const width = await designer.canvas.evaluate(node => (node as HTMLElement).style.width);
+    expect(width).not.toBe('');
+
+    await designer.canvas.click({ position: { x: 10, y: 10 } });
+    const rootWidth = await designer.getPropertyNumber('width');
+    expect(rootWidth).toBeGreaterThan(700);
+    await designer.expectXamlToContain(`WidthRequest="${rootWidth}"`);
+  });
+
+  test('switching to a phone preset makes the surface narrower', async ({ page }) => {
+    await page.getByTestId('device-select').selectOption('tablet');
+    const tabletWidth = await designer.canvas.evaluate(node =>
+      Number.parseFloat((node as HTMLElement).style.width)
+    );
+
+    await page.getByTestId('device-select').selectOption('phone');
+    await expect
+      .poll(async () =>
+        designer.canvas.evaluate(node => Number.parseFloat((node as HTMLElement).style.width))
+      )
+      .toBeLessThan(tabletWidth);
+  });
+
+  test('a device change can be undone', async ({ page }) => {
+    const original = await designer.canvas.evaluate(node =>
+      Number.parseFloat((node as HTMLElement).style.width)
+    );
+
+    await page.getByTestId('device-select').selectOption('tablet');
+    await expect
+      .poll(async () =>
+        designer.canvas.evaluate(node => Number.parseFloat((node as HTMLElement).style.width))
+      )
+      .not.toBe(original);
+
+    await designer.undoButton.click();
+    await expect
+      .poll(async () =>
+        designer.canvas.evaluate(node => Number.parseFloat((node as HTMLElement).style.width))
+      )
+      .toBe(original);
+  });
+
+  test('the dark theme preview can be toggled', async ({ page }) => {
+    const container = page.getByTestId('canvas-container');
+    await expect(container).toHaveAttribute('data-theme', 'light');
+
+    await page.getByTestId('toggle-theme').click();
+    await expect(container).toHaveAttribute('data-theme', 'dark');
+
+    await page.reload();
+    await expect(page.getByTestId('canvas-container')).toHaveAttribute('data-theme', 'dark');
+  });
+
+  test('panning with space and drag moves the canvas', async ({ page }) => {
+    const before = await page.getByTestId('canvas-scale').evaluate(node =>
+      getComputedStyle(node as HTMLElement).transform
+    );
+
+    const box = (await designer.canvas.boundingBox())!;
+    await page.keyboard.down('Space');
+    await page.mouse.move(box.x + 200, box.y + 200);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 320, box.y + 260, { steps: 10 });
+    await page.mouse.up();
+    await page.keyboard.up('Space');
+
+    await expect
+      .poll(async () =>
+        page.getByTestId('canvas-scale').evaluate(node =>
+          getComputedStyle(node as HTMLElement).transform
+        )
+      )
+      .not.toBe(before);
+  });
+
+  test('elements stay clickable while the canvas is zoomed', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.setProperty('x', '60');
+    await designer.setProperty('y', '60');
+
+    await page.getByTestId('zoom-in').click();
+    await page.getByTestId('zoom-in').click();
+
+    await designer.canvas.click({ position: { x: 5, y: 5 } });
+    await designer.selectFirst('Button');
+    await expect(designer.selectionCount()).toHaveText('1 selected');
+    await designer.expectProperty('x', 60);
+  });
+});

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -86,6 +86,7 @@
     
     <!-- Center Canvas -->
     <div class="center-panel">
+      <app-canvas-toolbar></app-canvas-toolbar>
       <app-designer-canvas></app-designer-canvas>
     </div>
     

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -39,11 +39,24 @@
 
 .center-panel {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
   background-color: #f7fafc;
   border: 1px solid #e2e8f0;
   margin: 5px;
   border-radius: 4px;
   overflow: hidden;
+
+  app-canvas-toolbar {
+    flex: 0 0 auto;
+  }
+
+  app-designer-canvas {
+    flex: 1;
+    min-height: 0;
+    display: block;
+  }
 }
 
 .bottom-panel {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -9,6 +9,7 @@ import { DesignerCanvasComponent } from './components/designer-canvas/designer-c
 import { PropertiesPanelComponent } from './components/properties-panel/properties-panel';
 import { HierarchyPanelComponent } from './components/hierarchy-panel/hierarchy-panel';
 import { XamlEditorComponent } from './components/xaml-editor/xaml-editor';
+import { CanvasToolbarComponent } from './components/canvas-toolbar/canvas-toolbar';
 
 @Component({
   selector: 'app-root',
@@ -20,7 +21,8 @@ import { XamlEditorComponent } from './components/xaml-editor/xaml-editor';
     DesignerCanvasComponent,
     PropertiesPanelComponent,
     HierarchyPanelComponent,
-    XamlEditorComponent
+    XamlEditorComponent,
+    CanvasToolbarComponent
   ],
   templateUrl: './app.html',
   styleUrl: './app.scss'

--- a/src/app/components/canvas-toolbar/canvas-toolbar.html
+++ b/src/app/components/canvas-toolbar/canvas-toolbar.html
@@ -1,0 +1,120 @@
+<div class="canvas-toolbar" data-testid="canvas-toolbar">
+  <div class="toolbar-group">
+    <label class="toolbar-label" for="device-select">Device</label>
+    <select
+      id="device-select"
+      class="toolbar-select"
+      data-testid="device-select"
+      [value]="viewport.deviceId"
+      (change)="selectDevice($any($event.target).value)">
+      <option *ngFor="let device of devices" [value]="device.id">{{ device.name }}</option>
+    </select>
+  </div>
+
+  <div class="toolbar-group">
+    <button class="toolbar-button" data-testid="zoom-out" title="Zoom out" (click)="zoomOut()">
+      <span class="material-icons">remove</span>
+    </button>
+    <span class="zoom-value" data-testid="zoom-value">{{ zoomPercent }}%</span>
+    <button class="toolbar-button" data-testid="zoom-in" title="Zoom in" (click)="zoomIn()">
+      <span class="material-icons">add</span>
+    </button>
+    <button class="toolbar-button" data-testid="zoom-fit" title="Fit to window" (click)="zoomToFit()">
+      <span class="material-icons">fit_screen</span>
+    </button>
+    <button class="toolbar-button" data-testid="zoom-reset" title="Reset zoom and pan" (click)="resetView()">
+      <span class="material-icons">restart_alt</span>
+    </button>
+  </div>
+
+  <div class="toolbar-group">
+    <button
+      class="toolbar-button"
+      data-testid="toggle-theme"
+      [attr.data-active]="viewport.theme === 'dark'"
+      [title]="viewport.theme === 'dark' ? 'Switch to light preview' : 'Switch to dark preview'"
+      (click)="toggleTheme()">
+      <span class="material-icons">{{ viewport.theme === 'dark' ? 'dark_mode' : 'light_mode' }}</span>
+    </button>
+
+    <button
+      class="toolbar-button"
+      data-testid="toggle-snap"
+      [attr.data-active]="viewport.snapToGrid"
+      title="Snap to grid"
+      (click)="toggleSnap()">
+      <span class="material-icons">grid_goldenratio</span>
+    </button>
+
+    <button
+      class="toolbar-button"
+      data-testid="toggle-grid"
+      [attr.data-active]="viewport.showGrid"
+      title="Show grid"
+      (click)="toggleGrid()">
+      <span class="material-icons">grid_on</span>
+    </button>
+
+    <button
+      class="toolbar-button"
+      data-testid="toggle-rulers"
+      [attr.data-active]="viewport.showRulers"
+      title="Show rulers"
+      (click)="toggleRulers()">
+      <span class="material-icons">straighten</span>
+    </button>
+
+    <input
+      type="number"
+      class="toolbar-number"
+      data-testid="grid-size"
+      min="2"
+      max="200"
+      title="Grid size in pixels"
+      [value]="viewport.gridSize"
+      (input)="setGridSize(+$any($event.target).value)">
+  </div>
+
+  <div class="toolbar-group" data-testid="align-group">
+    <button class="toolbar-button" data-testid="align-left" title="Align left" [disabled]="!canAlign" (click)="align('left')">
+      <span class="material-icons">align_horizontal_left</span>
+    </button>
+    <button class="toolbar-button" data-testid="align-center" title="Align centre" [disabled]="!canAlign" (click)="align('center')">
+      <span class="material-icons">align_horizontal_center</span>
+    </button>
+    <button class="toolbar-button" data-testid="align-right" title="Align right" [disabled]="!canAlign" (click)="align('right')">
+      <span class="material-icons">align_horizontal_right</span>
+    </button>
+    <button class="toolbar-button" data-testid="align-top" title="Align top" [disabled]="!canAlign" (click)="align('top')">
+      <span class="material-icons">align_vertical_top</span>
+    </button>
+    <button class="toolbar-button" data-testid="align-middle" title="Align middle" [disabled]="!canAlign" (click)="align('middle')">
+      <span class="material-icons">align_vertical_center</span>
+    </button>
+    <button class="toolbar-button" data-testid="align-bottom" title="Align bottom" [disabled]="!canAlign" (click)="align('bottom')">
+      <span class="material-icons">align_vertical_bottom</span>
+    </button>
+    <button class="toolbar-button" data-testid="distribute-horizontal" title="Distribute horizontally" [disabled]="!canDistribute" (click)="distribute('horizontal')">
+      <span class="material-icons">horizontal_distribute</span>
+    </button>
+    <button class="toolbar-button" data-testid="distribute-vertical" title="Distribute vertically" [disabled]="!canDistribute" (click)="distribute('vertical')">
+      <span class="material-icons">vertical_distribute</span>
+    </button>
+  </div>
+
+  <div class="toolbar-group">
+    <button class="toolbar-button" data-testid="toolbar-copy" title="Copy (Ctrl+C)" [disabled]="!hasSelection" (click)="copy()">
+      <span class="material-icons">content_copy</span>
+    </button>
+    <button class="toolbar-button" data-testid="toolbar-paste" title="Paste (Ctrl+V)" (click)="paste()">
+      <span class="material-icons">content_paste</span>
+    </button>
+    <button class="toolbar-button" data-testid="save-template" title="Save selection as a template" [disabled]="!hasSelection" (click)="saveAsTemplate()">
+      <span class="material-icons">bookmark_add</span>
+    </button>
+  </div>
+
+  <div class="toolbar-group selection-count" data-testid="selection-count">
+    {{ selection.length }} selected
+  </div>
+</div>

--- a/src/app/components/canvas-toolbar/canvas-toolbar.scss
+++ b/src/app/components/canvas-toolbar/canvas-toolbar.scss
@@ -1,0 +1,84 @@
+.canvas-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 10px;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 12px;
+  color: #334155;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  & + .toolbar-group {
+    padding-left: 12px;
+    border-left: 1px solid #e2e8f0;
+  }
+}
+
+.toolbar-label {
+  color: #64748b;
+}
+
+.toolbar-select,
+.toolbar-number {
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 12px;
+  background: #fff;
+  color: #0f172a;
+}
+
+.toolbar-number {
+  width: 56px;
+}
+
+.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: #334155;
+  cursor: pointer;
+
+  .material-icons {
+    font-size: 18px;
+  }
+
+  &:hover:not(:disabled) {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &[data-active='true'] {
+    background: #dbeafe;
+    border-color: #93c5fd;
+    color: #1d4ed8;
+  }
+}
+
+.zoom-value {
+  min-width: 42px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.selection-count {
+  margin-left: auto;
+  color: #64748b;
+}

--- a/src/app/components/canvas-toolbar/canvas-toolbar.ts
+++ b/src/app/components/canvas-toolbar/canvas-toolbar.ts
@@ -1,0 +1,148 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { ElementService } from '../../services/element';
+import { AlignmentService, AlignMode, DistributeMode } from '../../services/alignment';
+import { ClipboardService } from '../../services/clipboard';
+import { ViewportService, ViewportState, DEVICE_PRESETS } from '../../services/viewport';
+import { MauiElement } from '../../models/maui-element';
+
+@Component({
+  selector: 'app-canvas-toolbar',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './canvas-toolbar.html',
+  styleUrl: './canvas-toolbar.scss'
+})
+export class CanvasToolbarComponent implements OnInit, OnDestroy {
+  readonly devices = DEVICE_PRESETS;
+
+  viewport!: ViewportState;
+  selection: MauiElement[] = [];
+
+  private subscription = new Subscription();
+
+  constructor(
+    private elementService: ElementService,
+    private alignmentService: AlignmentService,
+    private clipboardService: ClipboardService,
+    private viewportService: ViewportService
+  ) {
+    this.viewport = this.viewportService.state;
+  }
+
+  ngOnInit() {
+    this.subscription.add(this.viewportService.state$.subscribe(state => (this.viewport = state)));
+    this.subscription.add(this.elementService.selectedElements$.subscribe(selection => (this.selection = selection)));
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  // --- Device & theme ---------------------------------------------------------
+
+  get zoomPercent(): number {
+    return Math.round(this.viewport.zoom * 100);
+  }
+
+  selectDevice(deviceId: string) {
+    this.viewportService.patch({ deviceId });
+    const device = this.viewportService.getDevice(deviceId);
+    if (device && deviceId !== 'custom') {
+      this.elementService.updateElementProperties(this.elementService.getRootElement(), {
+        width: device.width,
+        height: device.height
+      });
+    }
+  }
+
+  toggleTheme() {
+    this.viewportService.toggleTheme();
+  }
+
+  toggleSnap() {
+    this.viewportService.toggleSnap();
+  }
+
+  toggleGrid() {
+    this.viewportService.toggleGrid();
+  }
+
+  toggleRulers() {
+    this.viewportService.toggleRulers();
+  }
+
+  setGridSize(value: number) {
+    this.viewportService.patch({ gridSize: value });
+  }
+
+  // --- Zoom -------------------------------------------------------------------
+
+  zoomIn() {
+    this.viewportService.zoomIn();
+  }
+
+  zoomOut() {
+    this.viewportService.zoomOut();
+  }
+
+  resetView() {
+    this.viewportService.resetView();
+  }
+
+  zoomToFit() {
+    const surface = document.querySelector('.canvas-viewport') as HTMLElement | null;
+    const root = this.elementService.getRootElement().properties;
+    if (!surface) {
+      return;
+    }
+    this.viewportService.zoomToFit(
+      surface.clientWidth - 32,
+      surface.clientHeight - 32,
+      root.width || 800,
+      root.height || 600
+    );
+  }
+
+  // --- Alignment --------------------------------------------------------------
+
+  get canAlign(): boolean {
+    return this.alignmentService.canAlign(this.selection);
+  }
+
+  get canDistribute(): boolean {
+    return this.selection.length > 2;
+  }
+
+  align(mode: AlignMode) {
+    this.alignmentService.align(this.selection, mode);
+  }
+
+  distribute(mode: DistributeMode) {
+    this.alignmentService.distribute(this.selection, mode);
+  }
+
+  // --- Clipboard --------------------------------------------------------------
+
+  get hasSelection(): boolean {
+    return this.selection.some(element => !!element.parent);
+  }
+
+  copy() {
+    this.clipboardService.copy(this.selection);
+  }
+
+  paste() {
+    this.clipboardService.paste();
+  }
+
+  saveAsTemplate() {
+    const name = window.prompt('Template name', this.selection[0]?.name || 'Component');
+    if (name) {
+      this.clipboardService.saveTemplate(name, this.selection);
+    }
+  }
+}

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -1,7 +1,32 @@
-<div class="designer-canvas-container">
+<div class="designer-canvas-container"
+     [class.theme-dark]="viewport.theme === 'dark'"
+     [class.with-rulers]="viewport.showRulers"
+     data-testid="canvas-container"
+     [attr.data-theme]="viewport.theme">
+
+  <!-- Rulers -->
+  <div class="ruler ruler-horizontal" *ngIf="viewport.showRulers" data-testid="ruler-horizontal">
+    <span class="tick" *ngFor="let tick of horizontalTicks" [style.left.px]="tick.offset">{{ tick.label }}</span>
+  </div>
+  <div class="ruler ruler-vertical" *ngIf="viewport.showRulers" data-testid="ruler-vertical">
+    <span class="tick" *ngFor="let tick of verticalTicks" [style.top.px]="tick.offset">{{ tick.label }}</span>
+  </div>
+
+  <div class="canvas-viewport"
+       data-testid="canvas-viewport"
+       (mousedown)="onViewportMouseDown($event)"
+       (wheel)="onViewportWheel($event)">
+    <div class="canvas-scale"
+         data-testid="canvas-scale"
+         [style.transform]="canvasTransform"
+         [attr.data-zoom]="viewport.zoom">
   <div 
     class="designer-canvas"
     [class.drag-over-canvas]="isDragOver"
+    [class.show-grid]="viewport.showGrid"
+    [style.width.px]="designWidth"
+    [style.height.px]="designHeight"
+    [style.background-size]="viewport.gridSize + 'px ' + viewport.gridSize + 'px'"
     data-testid="designer-canvas"
     #canvas
     cdkDropList
@@ -9,6 +34,7 @@
     (dragover)="onCanvasDragOver($event)"
     (dragleave)="onCanvasDragLeave()"
     (drop)="onCanvasDrop($event)"
+    (mousedown)="onCanvasMouseDown($event)"
     (click)="onCanvasClick()">
     
     <!-- Root element content (rendered through the recursive template) -->
@@ -16,14 +42,34 @@
       <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: rootElement }"></ng-container>
     </ng-container>
     
+    <!-- Marquee (rubber band) selection rectangle -->
+    <div class="marquee"
+         *ngIf="marquee"
+         data-testid="selection-marquee"
+         [style.left.px]="marquee.x"
+         [style.top.px]="marquee.y"
+         [style.width.px]="marquee.width"
+         [style.height.px]="marquee.height"></div>
+
     <!-- Grid overlay for visual feedback -->
     <div class="grid-overlay" [style.display]="'none'">
       <!-- Grid lines would be drawn here when needed -->
     </div>
     
+    <!-- Smart alignment guides -->
+    <div class="alignment-guide"
+         *ngFor="let guide of alignmentGuides"
+         [attr.data-testid]="'alignment-guide-' + guide.orientation"
+         [class.vertical]="guide.orientation === 'vertical'"
+         [class.horizontal]="guide.orientation === 'horizontal'"
+         [style.left.px]="guide.orientation === 'vertical' ? guide.position : 0"
+         [style.top.px]="guide.orientation === 'horizontal' ? guide.position : 0"></div>
+
     <!-- Drop zone indicator -->
     <div class="drop-zone-indicator" [style.display]="'none'">
       Drop here
+    </div>
+  </div>
     </div>
   </div>
   
@@ -51,7 +97,7 @@
     [attr.data-element-name]="element.name"
     [attr.data-selected]="isSelected(element)"
     cdkDrag
-    [cdkDragDisabled]="!isSelected(element) || element.id === 'root'"
+    [cdkDragDisabled]="!isPrimarySelection(element) || element.id === 'root'"
     (cdkDragStarted)="onDragStarted(element); setElementRef(element, elementDiv)"
     (cdkDragMoved)="onDragMoved(element, $event)"
     (cdkDragEnded)="onDragEnded(element, $event)"
@@ -61,7 +107,7 @@
     [cdkDragData]="element">
 
     <!-- Drag handle: appears only when selected; covers element so dragging can only start when selected -->
-    <div *ngIf="isSelected(element) && element.id !== 'root'" class="drag-handle" cdkDragHandle (pointerdown)="$event.stopPropagation()"></div>
+    <div *ngIf="isPrimarySelection(element) && element.id !== 'root'" class="drag-handle" cdkDragHandle (pointerdown)="$event.stopPropagation()"></div>
 
     <!-- Element content based on type -->
     <div class="element-content" [ngSwitch]="element.type">
@@ -81,14 +127,63 @@
              class="element-input" 
              type="text" 
              [value]="element.properties.text || ''"
-             placeholder="Enter text">
+             [attr.placeholder]="element.properties.placeholder || 'Enter text'"
+             readonly>
       
       <!-- Editor -->
       <textarea *ngSwitchCase="'Editor'" 
                 class="element-textarea"
                 [value]="element.properties.text || ''"
-                placeholder="Enter text">
+                [attr.placeholder]="element.properties.placeholder || 'Enter text'"
+                readonly>
       </textarea>
+
+      <!-- SearchBar -->
+      <div *ngSwitchCase="'SearchBar'" class="element-search-bar">
+        <span class="material-icons">search</span>
+        <span class="search-text">{{ element.properties.text || element.properties.placeholder || 'Search' }}</span>
+      </div>
+
+      <!-- CheckBox -->
+      <div *ngSwitchCase="'CheckBox'" class="element-check-box">
+        <span class="material-icons">{{ element.properties.isChecked ? 'check_box' : 'check_box_outline_blank' }}</span>
+      </div>
+
+      <!-- Switch -->
+      <div *ngSwitchCase="'Switch'" class="element-switch" [class.on]="element.properties.isToggled">
+        <span class="switch-thumb"></span>
+      </div>
+
+      <!-- Slider -->
+      <div *ngSwitchCase="'Slider'" class="element-slider">
+        <div class="slider-track">
+          <div class="slider-fill" [style.width.%]="sliderPercent(element)"></div>
+        </div>
+        <div class="slider-thumb" [style.left.%]="sliderPercent(element)"></div>
+      </div>
+
+      <!-- Stepper -->
+      <div *ngSwitchCase="'Stepper'" class="element-stepper">
+        <span class="stepper-button">−</span>
+        <span class="stepper-value">{{ element.properties.value || 0 }}</span>
+        <span class="stepper-button">+</span>
+      </div>
+
+      <!-- ProgressBar -->
+      <div *ngSwitchCase="'ProgressBar'" class="element-progress-bar">
+        <div class="progress-fill" [style.width.%]="progressPercent(element)"></div>
+      </div>
+
+      <!-- ActivityIndicator -->
+      <div *ngSwitchCase="'ActivityIndicator'" class="element-activity-indicator" [class.running]="element.properties.isRunning !== false">
+        <span class="material-icons">refresh</span>
+      </div>
+
+      <!-- DatePicker -->
+      <div *ngSwitchCase="'DatePicker'" class="element-date-picker">
+        <span class="material-icons">event</span>
+        <span>{{ element.properties.date || 'Select a date' }}</span>
+      </div>
       
       <!-- Image -->
       <div *ngSwitchCase="'Image'" class="element-image">
@@ -192,6 +287,43 @@
           <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: child }"></ng-container>
         </ng-container>
       </div>
+
+      <!-- Border -->
+      <div *ngSwitchCase="'Border'" class="element-border"
+           #layoutDiv
+           cdkDropList
+           [cdkDropListData]="element.children"
+           (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
+           (mouseenter)="setElementRef(element, layoutDiv)"
+           [style.border-color]="element.properties.borderColor || '#cccccc'"
+           [style.border-width.px]="element.properties.borderWidth || 1"
+           [style.border-radius.px]="element.properties.cornerRadius || 0">
+        <ng-container *ngFor="let child of element.children">
+          <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: child }"></ng-container>
+        </ng-container>
+      </div>
+
+      <!-- CollectionView -->
+      <div *ngSwitchCase="'CollectionView'" class="element-collection-view"
+           #layoutDiv
+           cdkDropList
+           [cdkDropListData]="element.children"
+           (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
+           (mouseenter)="setElementRef(element, layoutDiv)">
+        <div class="collection-item" *ngFor="let index of collectionPreviewItems(element); let i = index">
+          <ng-container *ngIf="element.children.length; else placeholderItem">
+            <ng-container *ngIf="i === 0">
+              <ng-container *ngFor="let child of element.children">
+                <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: child }"></ng-container>
+              </ng-container>
+            </ng-container>
+            <span *ngIf="i > 0" class="collection-repeat">{{ collectionItemLabel(element) }} {{ i + 1 }}</span>
+          </ng-container>
+          <ng-template #placeholderItem>
+            <span class="collection-repeat">{{ collectionItemLabel(element) }} {{ i + 1 }}</span>
+          </ng-template>
+        </div>
+      </div>
       
       <!-- Default case -->
       <div *ngSwitchDefault class="element-default">
@@ -200,7 +332,7 @@
     </div>
     
     <!-- Selection handles -->
-    <div class="selection-handles" *ngIf="isSelected(element) && element.id !== 'root'">
+    <div class="selection-handles" *ngIf="isPrimarySelection(element) && element.id !== 'root'">
       <!-- Corner handles (blue) -->
       <div class="handle handle-corner handle-nw" 
            (mousedown)="onResizeStart($event, 'nw', element)"></div>

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -1,22 +1,121 @@
 .designer-canvas-container {
   width: 100%;
   height: 100%;
-  overflow: auto;
   background: #f0f0f0;
   position: relative;
+  overflow: hidden;
+
+  &.with-rulers .canvas-viewport {
+    top: 20px;
+    left: 20px;
+    width: calc(100% - 20px);
+    height: calc(100% - 20px);
+  }
+
+  &.theme-dark {
+    background: #0f172a;
+
+    .ruler {
+      background: #1e293b;
+      color: #94a3b8;
+      border-color: #334155;
+    }
+
+    .designer-canvas {
+      box-shadow: 0 0 0 1px #334155, 0 10px 30px rgba(0, 0, 0, 0.6);
+    }
+  }
+}
+
+.canvas-viewport {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.canvas-scale {
+  transform-origin: top left;
+  width: max-content;
+  padding: 16px;
+}
+
+.ruler {
+  position: absolute;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 9px;
+  border-color: #e2e8f0;
+  z-index: 5;
+  overflow: hidden;
+
+  .tick {
+    position: absolute;
+  }
+
+  &.ruler-horizontal {
+    top: 0;
+    left: 20px;
+    right: 0;
+    height: 20px;
+    border-bottom: 1px solid #e2e8f0;
+
+    .tick {
+      top: 4px;
+      border-left: 1px solid currentColor;
+      padding-left: 2px;
+      height: 12px;
+    }
+  }
+
+  &.ruler-vertical {
+    top: 20px;
+    left: 0;
+    bottom: 0;
+    width: 20px;
+    border-right: 1px solid #e2e8f0;
+
+    .tick {
+      left: 2px;
+      border-top: 1px solid currentColor;
+      padding-top: 1px;
+      width: 16px;
+    }
+  }
 }
 
 .designer-canvas {
-  width: 100%;
-  height: 100%;
   position: relative;
   background: #ffffff;
-  min-height: 600px;
-  background-image:
-    linear-gradient(rgba(0, 0, 0, .1) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 0, 0, .1) 1px, transparent 1px);
-  background-size: 20px 20px;
-  background-position: -1px -1px;
+  box-shadow: 0 0 0 1px #e2e8f0, 0 10px 30px rgba(15, 23, 42, 0.12);
+
+  &.show-grid {
+    background-image:
+      linear-gradient(rgba(0, 0, 0, .08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(0, 0, 0, .08) 1px, transparent 1px);
+    background-position: -1px -1px;
+  }
+}
+
+.alignment-guide {
+  position: absolute;
+  background: #f43f5e;
+  pointer-events: none;
+  z-index: 9998;
+
+  &.vertical {
+    width: 1px;
+    height: 100%;
+    top: 0;
+  }
+
+  &.horizontal {
+    height: 1px;
+    width: 100%;
+    left: 0;
+  }
 }
 
 .selected {
@@ -467,4 +566,168 @@
       border-color: rgba(66, 153, 225, 0.6);
     }
   }
+}
+// --- Additional control previews ---------------------------------------------
+
+.canvas-element {
+  .element-search-bar,
+  .element-date-picker {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    height: 100%;
+    padding: 0 8px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #fff;
+    font-size: 13px;
+    color: #4b5563;
+    overflow: hidden;
+    white-space: nowrap;
+    box-sizing: border-box;
+
+    .material-icons { font-size: 18px; }
+  }
+
+  .element-check-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: #2563eb;
+  }
+
+  .element-switch {
+    width: 100%;
+    height: 100%;
+    border-radius: 999px;
+    background: #cbd5e1;
+    position: relative;
+
+    .switch-thumb {
+      position: absolute;
+      top: 10%;
+      left: 4%;
+      width: 42%;
+      height: 80%;
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
+
+    &.on {
+      background: #2563eb;
+      .switch-thumb { left: 54%; }
+    }
+  }
+
+  .element-slider {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+
+    .slider-track {
+      width: 100%;
+      height: 4px;
+      border-radius: 2px;
+      background: #cbd5e1;
+      overflow: hidden;
+    }
+
+    .slider-fill { height: 100%; background: #2563eb; }
+
+    .slider-thumb {
+      position: absolute;
+      width: 14px;
+      height: 14px;
+      margin-left: -7px;
+      border-radius: 50%;
+      background: #2563eb;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
+  }
+
+  .element-stepper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #fff;
+    font-size: 14px;
+    box-sizing: border-box;
+
+    .stepper-button {
+      width: 30%;
+      text-align: center;
+      color: #2563eb;
+      font-weight: 700;
+    }
+  }
+
+  .element-progress-bar {
+    width: 100%;
+    height: 100%;
+    border-radius: 999px;
+    background: #e5e7eb;
+    overflow: hidden;
+
+    .progress-fill { height: 100%; background: #2563eb; }
+  }
+
+  .element-activity-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: #2563eb;
+
+    &.running .material-icons { animation: maui-spin 1.4s linear infinite; }
+  }
+
+  .element-border {
+    width: 100%;
+    height: 100%;
+    border-style: solid;
+    position: relative;
+    box-sizing: border-box;
+  }
+
+  .element-collection-view {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border: 1px dashed #cbd5e0;
+    border-radius: 4px;
+    background: rgba(248, 250, 252, 0.6);
+
+    .collection-item {
+      position: relative;
+      min-height: 26px;
+      padding: 4px 6px;
+      border-bottom: 1px solid #e5e7eb;
+      font-size: 12px;
+      color: #64748b;
+    }
+  }
+}
+
+@keyframes maui-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.marquee {
+  position: absolute;
+  border: 1px solid #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+  pointer-events: none;
+  z-index: 10000;
 }

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -1,11 +1,14 @@
-import { Component, OnInit, ElementRef, ViewChild, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DragDropModule, CdkDropList, CdkDragDrop, CdkDragEnd, CdkDragMove } from '@angular/cdk/drag-drop';
 import { ElementService } from '../../services/element';
 import { DragDropService, TOOLBOX_DRAG_MIME } from '../../services/drag-drop';
 import { LayoutDesignerService } from '../../services/layout-designer';
 import { MauiElement, ElementType } from '../../models/maui-element';
-import { Observable } from 'rxjs';
+import { AlignmentService, AlignmentGuide } from '../../services/alignment';
+import { ClipboardService } from '../../services/clipboard';
+import { ViewportService, ViewportState } from '../../services/viewport';
+import { Observable, Subscription } from 'rxjs';
 
 type ResizeDirection = 'nw' | 'ne' | 'sw' | 'se' | 'n' | 's' | 'w' | 'e';
 
@@ -16,7 +19,7 @@ type ResizeDirection = 'nw' | 'ne' | 'sw' | 'se' | 'n' | 's' | 'w' | 'e';
   templateUrl: './designer-canvas.html',
   styleUrl: './designer-canvas.scss'
 })
-export class DesignerCanvasComponent implements OnInit {
+export class DesignerCanvasComponent implements OnInit, OnDestroy {
   @ViewChild('canvas', { static: true }) canvas!: ElementRef<HTMLDivElement>;
   
   rootElement$: Observable<MauiElement>;
@@ -48,29 +51,235 @@ export class DesignerCanvasComponent implements OnInit {
   // True while a toolbox control is dragged over the canvas
   isDragOver = false;
 
+  // Marquee selection state
+  marquee: { x: number, y: number, width: number, height: number } | null = null;
+  private marqueeOrigin = { x: 0, y: 0 };
+  private isMarqueeSelecting = false;
+  private marqueeAdditive = false;
+  private suppressNextCanvasClick = false;
+
   // Constants
   private readonly MIN_SIZE = 20;
+
+  // Viewport (zoom / pan / theme / grid) state
+  viewport!: ViewportState;
+  designWidth = 800;
+  designHeight = 600;
+  horizontalTicks: { offset: number, label: number }[] = [];
+  verticalTicks: { offset: number, label: number }[] = [];
+  alignmentGuides: AlignmentGuide[] = [];
+
+  private isPanning = false;
+  private panOrigin = { x: 0, y: 0 };
+  private spacePressed = false;
+  private subscription = new Subscription();
 
   constructor(
     private elementService: ElementService,
     private dragDropService: DragDropService,
-    private layoutDesigner: LayoutDesignerService
+    private layoutDesigner: LayoutDesignerService,
+    private alignmentService: AlignmentService,
+    private clipboardService: ClipboardService,
+    private viewportService: ViewportService
   ) {
     this.rootElement$ = this.elementService.elements$;
     this.selectedElement$ = this.elementService.selectedElement$;
+    this.viewport = this.viewportService.state;
   }
 
   ngOnInit() {
-    // Initialize the canvas
+    this.subscription.add(
+      this.viewportService.state$.subscribe(state => {
+        this.viewport = state;
+        this.rebuildRulers();
+      })
+    );
+
+    this.subscription.add(
+      this.elementService.elements$.subscribe(root => {
+        this.designWidth = root.properties.width || 800;
+        this.designHeight = root.properties.height || 600;
+        this.rebuildRulers();
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  get canvasTransform(): string {
+    const { panX, panY, zoom } = this.viewport;
+    return `translate(${panX}px, ${panY}px) scale(${zoom})`;
+  }
+
+  /** Ruler ticks are spaced by the grid size, scaled by the current zoom. */
+  private rebuildRulers() {
+    if (!this.viewport.showRulers) {
+      this.horizontalTicks = [];
+      this.verticalTicks = [];
+      return;
+    }
+
+    const step = Math.max(this.viewport.gridSize * 5, 40);
+    const zoom = this.viewport.zoom;
+
+    this.horizontalTicks = this.buildTicks(this.designWidth, step, zoom, this.viewport.panX);
+    this.verticalTicks = this.buildTicks(this.designHeight, step, zoom, this.viewport.panY);
+  }
+
+  private buildTicks(size: number, step: number, zoom: number, pan: number) {
+    const ticks: { offset: number, label: number }[] = [];
+    for (let value = 0; value <= size; value += step) {
+      ticks.push({ offset: Math.round(value * zoom + pan), label: value });
+    }
+    return ticks;
+  }
+
+  /** Converts a client point into unscaled canvas coordinates. */
+  private toCanvasPoint(clientX: number, clientY: number): { x: number, y: number } {
+    const rect = this.canvas.nativeElement.getBoundingClientRect();
+    const zoom = this.viewport.zoom || 1;
+    return {
+      x: (clientX - rect.left) / zoom,
+      y: (clientY - rect.top) / zoom
+    };
+  }
+
+  // --- Pan & wheel zoom -------------------------------------------------------
+
+  onViewportMouseDown(event: MouseEvent) {
+    // Middle button or Space + drag pans the design surface
+    if (event.button !== 1 && !(event.button === 0 && this.spacePressed)) {
+      return;
+    }
+    event.preventDefault();
+    this.isPanning = true;
+    this.panOrigin = { x: event.clientX, y: event.clientY };
+  }
+
+  onViewportWheel(event: WheelEvent) {
+    if (!event.ctrlKey && !event.metaKey) {
+      return;
+    }
+    event.preventDefault();
+    const factor = event.deltaY < 0 ? 1.1 : 0.9;
+    this.viewportService.setZoom(this.viewport.zoom * factor);
   }
 
   onElementClick(element: MauiElement, event: MouseEvent) {
     event.stopPropagation();
+    // A marquee that started on the root layout still emits a click on it
+    if (this.suppressNextCanvasClick) {
+      this.suppressNextCanvasClick = false;
+      return;
+    }
+    if (event.shiftKey || event.ctrlKey || event.metaKey) {
+      this.elementService.toggleSelection(element);
+      return;
+    }
     this.elementService.selectElement(element);
   }
 
   onCanvasClick() {
+    if (this.suppressNextCanvasClick) {
+      this.suppressNextCanvasClick = false;
+      return;
+    }
     this.elementService.selectElement(null);
+  }
+
+  // --- Marquee (rubber band) selection ---------------------------------------
+
+  onCanvasMouseDown(event: MouseEvent) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
+    const owner = target.closest('[data-element-id]') as HTMLElement | null;
+
+    // Only start a marquee on the empty canvas or on the root layout itself
+    if (owner && owner.getAttribute('data-element-id') !== 'root') {
+      return;
+    }
+
+    this.marqueeOrigin = this.toCanvasPoint(event.clientX, event.clientY);
+    this.marquee = { x: this.marqueeOrigin.x, y: this.marqueeOrigin.y, width: 0, height: 0 };
+    this.isMarqueeSelecting = true;
+    this.marqueeAdditive = event.shiftKey || event.ctrlKey || event.metaKey;
+  }
+
+  private updateMarquee(event: MouseEvent) {
+    const { x: currentX, y: currentY } = this.toCanvasPoint(event.clientX, event.clientY);
+
+    this.marquee = {
+      x: Math.min(this.marqueeOrigin.x, currentX),
+      y: Math.min(this.marqueeOrigin.y, currentY),
+      width: Math.abs(currentX - this.marqueeOrigin.x),
+      height: Math.abs(currentY - this.marqueeOrigin.y)
+    };
+  }
+
+  private finishMarquee() {
+    const marquee = this.marquee;
+    this.isMarqueeSelecting = false;
+    this.marquee = null;
+
+    if (!marquee || (marquee.width < 4 && marquee.height < 4)) {
+      return;
+    }
+
+    // A marquee drag must not also clear the selection through the click handler
+    this.suppressNextCanvasClick = true;
+
+    const canvasRect = this.canvas.nativeElement.getBoundingClientRect();
+    const zoom = this.viewport.zoom || 1;
+    const hits: MauiElement[] = [];
+
+    this.canvas.nativeElement.querySelectorAll('[data-element-id]').forEach(node => {
+      const id = node.getAttribute('data-element-id');
+      if (!id || id === 'root') {
+        return;
+      }
+
+      const rect = (node as HTMLElement).getBoundingClientRect();
+      const left = (rect.left - canvasRect.left) / zoom;
+      const top = (rect.top - canvasRect.top) / zoom;
+      const width = rect.width / zoom;
+      const height = rect.height / zoom;
+      const intersects =
+        left < marquee.x + marquee.width &&
+        left + width > marquee.x &&
+        top < marquee.y + marquee.height &&
+        top + height > marquee.y;
+
+      if (!intersects) {
+        return;
+      }
+
+      const element = this.elementService.findElementById(id);
+      // Selecting a container implicitly covers its children, so skip nested hits
+      if (element && !hits.some(hit => this.isDescendantOf(element, hit))) {
+        hits.push(element);
+      }
+    });
+
+    const selection = this.marqueeAdditive
+      ? [...this.elementService.getSelectedElements(), ...hits]
+      : hits;
+    this.elementService.setSelection(selection);
+  }
+
+  private isDescendantOf(candidate: MauiElement, ancestor: MauiElement): boolean {
+    let current = candidate.parent;
+    while (current) {
+      if (current === ancestor) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
   }
 
   // --- Native drag from the toolbox -----------------------------------------
@@ -95,11 +304,10 @@ export class DesignerCanvasComponent implements OnInit {
     }
     event.preventDefault();
 
-    const canvasRect = this.canvas.nativeElement.getBoundingClientRect();
-    const x = event.clientX - canvasRect.left;
-    const y = event.clientY - canvasRect.top;
+    const { x, y } = this.toCanvasPoint(event.clientX, event.clientY);
+    const snapped = this.applyGridSnap(x, y);
 
-    this.dragDropService.createElementAtPosition(type, x, y, this.canvas.nativeElement);
+    this.dragDropService.createElementAtPosition(type, snapped.x, snapped.y, this.canvas.nativeElement);
     this.dragDropService.endDrag();
   }
 
@@ -112,6 +320,34 @@ export class DesignerCanvasComponent implements OnInit {
     }
 
     const ctrl = event.ctrlKey || event.metaKey;
+
+    if (event.code === 'Space') {
+      this.spacePressed = true;
+    }
+
+    if (ctrl && event.key.toLowerCase() === 'c') {
+      event.preventDefault();
+      this.clipboardService.copy(this.elementService.getSelectedElements());
+      return;
+    }
+
+    if (ctrl && event.key.toLowerCase() === 'x') {
+      event.preventDefault();
+      this.clipboardService.cut(this.elementService.getSelectedElements());
+      return;
+    }
+
+    if (ctrl && event.key.toLowerCase() === 'v') {
+      event.preventDefault();
+      this.clipboardService.paste();
+      return;
+    }
+
+    if (ctrl && event.key.toLowerCase() === 'a') {
+      event.preventDefault();
+      this.selectAll();
+      return;
+    }
 
     if (ctrl && event.key.toLowerCase() === 'z' && !event.shiftKey) {
       event.preventDefault();
@@ -138,7 +374,7 @@ export class DesignerCanvasComponent implements OnInit {
 
     if (event.key === 'Delete' || event.key === 'Backspace') {
       event.preventDefault();
-      this.elementService.removeElement(selected);
+      this.elementService.removeSelectedElements();
       return;
     }
 
@@ -156,13 +392,56 @@ export class DesignerCanvasComponent implements OnInit {
     };
 
     const nudge = nudges[event.key];
-    if (nudge && selected.parent?.type === ElementType.AbsoluteLayout) {
+    if (nudge) {
       event.preventDefault();
-      this.elementService.updateElementProperties(selected, {
-        x: (selected.properties.x || 0) + nudge.x,
-        y: (selected.properties.y || 0) + nudge.y
-      });
+      this.elementService.nudgeSelection(nudge.x, nudge.y);
     }
+  }
+
+  /** Applies grid snapping when it is enabled. */
+  private applyGridSnap(x: number, y: number): { x: number, y: number } {
+    if (!this.viewport.snapToGrid) {
+      return { x: Math.round(x), y: Math.round(y) };
+    }
+    return {
+      x: this.alignmentService.snapToGrid(x, this.viewport.gridSize),
+      y: this.alignmentService.snapToGrid(y, this.viewport.gridSize)
+    };
+  }
+
+  /**
+   * Turns a raw cdkDrag position into the final canvas position, applying
+   * smart guides first and the grid afterwards.
+   */
+  private resolveDragPosition(element: MauiElement, rawX: number, rawY: number): { x: number, y: number } {
+    const zoom = this.viewport.zoom || 1;
+    let x = rawX / zoom;
+    let y = rawY / zoom;
+
+    if (element.parent?.type === ElementType.AbsoluteLayout) {
+      if (this.viewport.showGuides) {
+        const snapped = this.alignmentService.computeGuides(element, x, y);
+        x = snapped.x;
+        y = snapped.y;
+      }
+      const grid = this.applyGridSnap(x, y);
+      x = grid.x;
+      y = grid.y;
+    }
+
+    return { x, y };
+  }
+
+  @HostListener('document:keyup', ['$event'])
+  onKeyUp(event: KeyboardEvent) {
+    if (event.code === 'Space') {
+      this.spacePressed = false;
+    }
+  }
+
+  /** Selects every direct child of the root layout. */
+  selectAll() {
+    this.elementService.setSelection([...this.elementService.getRootElement().children]);
   }
 
   private isEditingText(target: EventTarget | null): boolean {
@@ -221,13 +500,46 @@ export class DesignerCanvasComponent implements OnInit {
       ElementType.AbsoluteLayout,
       ElementType.VerticalStackLayout,
       ElementType.Frame,
+      ElementType.Border,
+      ElementType.CollectionView,
       ElementType.ScrollView
     ].includes(element.type);
   }
 
+  // --- Control previews -------------------------------------------------------
+
+  sliderPercent(element: MauiElement): number {
+    const props = element.properties;
+    const min = props.minimum ?? 0;
+    const max = props.maximum ?? 100;
+    const value = props.value ?? min;
+    if (max === min) {
+      return 0;
+    }
+    return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+  }
+
+  progressPercent(element: MauiElement): number {
+    return Math.min(100, Math.max(0, (element.properties.progress ?? 0) * 100));
+  }
+
+  collectionPreviewItems(element: MauiElement): number[] {
+    const count = Math.min(20, Math.max(1, element.properties.itemCount ?? 3));
+    return Array.from({ length: count }, (_, index) => index);
+  }
+
+  collectionItemLabel(element: MauiElement): string {
+    return element.properties.itemTemplateText || 'Item';
+  }
+
   isSelected(element: MauiElement): boolean {
-    const selected = this.elementService.getSelectedElement();
-    return selected === element;
+    return this.elementService.isElementSelected(element);
+  }
+
+  /** Handles (and dragging) are only offered for a single selected element. */
+  isPrimarySelection(element: MauiElement): boolean {
+    return this.elementService.getSelectedElement() === element
+      && this.elementService.getSelectedElements().length === 1;
   }
 
   // Select element on pointerdown so cdkDrag will be enabled when drag starts.
@@ -240,12 +552,13 @@ export class DesignerCanvasComponent implements OnInit {
   }
 
   onDragEnded(element: MauiElement, event: CdkDragEnd) {
-    console.log("Drag released for element:", element, event);
     document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
+    this.alignmentGuides = [];
 
-    var dropPoint = event.source.getFreeDragPosition();
+    const dropPoint = event.source.getFreeDragPosition();
+    const target = this.resolveDragPosition(element, dropPoint.x, dropPoint.y);
 
-    this.dragDropService.handleCanvasDrop(element,dropPoint.x,  dropPoint.y, this.canvas.nativeElement);
+    this.dragDropService.handleCanvasDrop(element, target.x, target.y, this.canvas.nativeElement);
 
     //this.elementService.moveElement(element, element.parent!,  element.properties.x! + event.distance.x,  element.properties.y! + event.distance.y)
 
@@ -254,6 +567,16 @@ export class DesignerCanvasComponent implements OnInit {
 
   onDragMoved(element: MauiElement, event: CdkDragMove) {
     document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
+
+    // Smart guides follow the element while it is dragged
+    if (this.viewport.showGuides && element.parent?.type === ElementType.AbsoluteLayout) {
+      const zoom = this.viewport.zoom || 1;
+      const proposedX = (element.properties.x || 0) + event.distance.x / zoom;
+      const proposedY = (element.properties.y || 0) + event.distance.y / zoom;
+      this.alignmentGuides = this.alignmentService.computeGuides(element, proposedX, proposedY).guides;
+    } else {
+      this.alignmentGuides = [];
+    }
     // Get layout element over which we are passing currently
     var layoutOver = this.dragDropService.findLayoutAtPosition(element.properties.x! + event.distance.x, element.properties.y! + event.distance.y, this.canvas.nativeElement)!;
 
@@ -328,6 +651,17 @@ export class DesignerCanvasComponent implements OnInit {
 
   @HostListener('document:mousemove', ['$event'])
   onMouseMove(event: MouseEvent) {
+    if (this.isPanning) {
+      this.viewportService.panBy(event.clientX - this.panOrigin.x, event.clientY - this.panOrigin.y);
+      this.panOrigin = { x: event.clientX, y: event.clientY };
+      return;
+    }
+
+    if (this.isMarqueeSelecting) {
+      this.updateMarquee(event);
+      return;
+    }
+
     if (!this.isResizing || !this.resizeDirection || !this.resizeElement) return;
 
     const deltaX = event.clientX - this.startMouseX;
@@ -437,6 +771,16 @@ export class DesignerCanvasComponent implements OnInit {
 
   @HostListener('document:mouseup', ['$event'])
   onMouseUp(event: MouseEvent) {
+    if (this.isPanning) {
+      this.isPanning = false;
+      return;
+    }
+
+    if (this.isMarqueeSelecting) {
+      this.finishMarquee();
+      return;
+    }
+
     if (this.isResizing) {
       this.isResizing = false;
       this.elementService.endBatch();

--- a/src/app/components/properties-panel/properties-panel.html
+++ b/src/app/components/properties-panel/properties-panel.html
@@ -1,4 +1,65 @@
 <div class="properties-panel">
+  <!-- Multi selection editor -->
+  <div class="properties-content" *ngIf="isMultiSelection" data-testid="multi-selection-panel">
+    <div class="property-section">
+      <h3 class="section-title" data-testid="multi-selection-title">{{ selectionCount }} elements selected</h3>
+      <div class="element-actions">
+        <button class="action-button" data-testid="multi-duplicate" (click)="duplicateSelection()">
+          <span class="material-icons">content_copy</span> Duplicate
+        </button>
+        <button class="action-button danger" data-testid="multi-delete" (click)="removeSelection()">
+          <span class="material-icons">delete</span> Delete all
+        </button>
+      </div>
+    </div>
+
+    <div class="property-section">
+      <h4 class="section-header">Shared Properties</h4>
+
+      <div class="property-row">
+        <div class="property-group">
+          <label class="property-label">Width</label>
+          <input type="number" class="property-input small" data-testid="multi-width"
+                 [value]="sharedValue('width')"
+                 (input)="updateSelection('width', +$any($event.target).value)">
+        </div>
+        <div class="property-group">
+          <label class="property-label">Height</label>
+          <input type="number" class="property-input small" data-testid="multi-height"
+                 [value]="sharedValue('height')"
+                 (input)="updateSelection('height', +$any($event.target).value)">
+        </div>
+      </div>
+
+      <div class="property-group">
+        <label class="property-label">Background</label>
+        <input type="color" class="property-input" data-testid="multi-backgroundColor"
+               [value]="sharedValue('backgroundColor') || '#ffffff'"
+               (input)="updateSelection('backgroundColor', $any($event.target).value)">
+      </div>
+
+      <div class="property-group checkbox-group">
+        <input type="checkbox" data-testid="multi-isVisible"
+               [checked]="sharedValue('isVisible') !== false"
+               (change)="updateSelection('isVisible', $any($event.target).checked)">
+        <label class="property-label">Is Visible</label>
+      </div>
+    </div>
+
+    <div class="property-section" data-testid="multi-align-section">
+      <h4 class="section-header">Align</h4>
+      <div class="align-buttons">
+        <button class="action-button" data-testid="panel-align-left" (click)="align('left')">Left</button>
+        <button class="action-button" data-testid="panel-align-center" (click)="align('center')">Centre</button>
+        <button class="action-button" data-testid="panel-align-right" (click)="align('right')">Right</button>
+        <button class="action-button" data-testid="panel-align-top" (click)="align('top')">Top</button>
+        <button class="action-button" data-testid="panel-align-middle" (click)="align('middle')">Middle</button>
+        <button class="action-button" data-testid="panel-align-bottom" (click)="align('bottom')">Bottom</button>
+      </div>
+    </div>
+  </div>
+
+  <ng-container *ngIf="!isMultiSelection">
   <div class="properties-content" *ngIf="selectedElement$ | async as element; else noSelection">
     <div class="property-section">
       <h3 class="section-title" data-testid="selected-element-name">Element: {{ element.name }}</h3>
@@ -184,6 +245,143 @@
           (change)="updateProperty(element, 'fontAttributes', $any($event.target).value)">
           <option *ngFor="let attribute of fontAttributes" [value]="attribute">{{ attribute }}</option>
         </select>
+      </div>
+    </div>
+
+    <!-- Control specific properties -->
+    <div class="property-section" *ngIf="hasControlProperties(element)" data-testid="control-properties-section">
+      <h4 class="section-header">{{ element.type }}</h4>
+
+      <div class="property-group" *ngIf="supportsPlaceholder(element)">
+        <label class="property-label">Placeholder</label>
+        <input
+          type="text"
+          class="property-input"
+          data-testid="prop-placeholder"
+          [value]="element.properties.placeholder || ''"
+          (input)="updateProperty(element, 'placeholder', $any($event.target).value)">
+      </div>
+
+      <div class="property-group checkbox-group" *ngIf="element.type === 'CheckBox'">
+        <input type="checkbox" data-testid="prop-isChecked"
+               [checked]="element.properties.isChecked === true"
+               (change)="updateProperty(element, 'isChecked', $any($event.target).checked)">
+        <label class="property-label">Is Checked</label>
+      </div>
+
+      <div class="property-group checkbox-group" *ngIf="element.type === 'Switch'">
+        <input type="checkbox" data-testid="prop-isToggled"
+               [checked]="element.properties.isToggled === true"
+               (change)="updateProperty(element, 'isToggled', $any($event.target).checked)">
+        <label class="property-label">Is Toggled</label>
+      </div>
+
+      <ng-container *ngIf="supportsRange(element)">
+        <div class="property-row">
+          <div class="property-group">
+            <label class="property-label">Minimum</label>
+            <input type="number" class="property-input small" data-testid="prop-minimum"
+                   [value]="element.properties.minimum ?? 0"
+                   (input)="updateProperty(element, 'minimum', +$any($event.target).value)">
+          </div>
+          <div class="property-group">
+            <label class="property-label">Maximum</label>
+            <input type="number" class="property-input small" data-testid="prop-maximum"
+                   [value]="element.properties.maximum ?? 100"
+                   (input)="updateProperty(element, 'maximum', +$any($event.target).value)">
+          </div>
+        </div>
+
+        <div class="property-row">
+          <div class="property-group">
+            <label class="property-label">Value</label>
+            <input type="number" class="property-input small" data-testid="prop-value"
+                   [value]="element.properties.value ?? 0"
+                   (input)="updateProperty(element, 'value', +$any($event.target).value)">
+          </div>
+          <div class="property-group" *ngIf="element.type === 'Stepper'">
+            <label class="property-label">Increment</label>
+            <input type="number" class="property-input small" data-testid="prop-increment"
+                   [value]="element.properties.increment ?? 1"
+                   (input)="updateProperty(element, 'increment', +$any($event.target).value)">
+          </div>
+        </div>
+      </ng-container>
+
+      <div class="property-group" *ngIf="element.type === 'ProgressBar'">
+        <label class="property-label">Progress (0-1)</label>
+        <input type="number" step="0.05" min="0" max="1" class="property-input" data-testid="prop-progress"
+               [value]="element.properties.progress ?? 0"
+               (input)="updateProperty(element, 'progress', +$any($event.target).value)">
+      </div>
+
+      <div class="property-group checkbox-group" *ngIf="element.type === 'ActivityIndicator'">
+        <input type="checkbox" data-testid="prop-isRunning"
+               [checked]="element.properties.isRunning !== false"
+               (change)="updateProperty(element, 'isRunning', $any($event.target).checked)">
+        <label class="property-label">Is Running</label>
+      </div>
+
+      <div class="property-group" *ngIf="element.type === 'DatePicker'">
+        <label class="property-label">Date</label>
+        <input type="date" class="property-input" data-testid="prop-date"
+               [value]="element.properties.date || ''"
+               (input)="updateProperty(element, 'date', $any($event.target).value)">
+      </div>
+
+      <ng-container *ngIf="supportsCornerRadius(element)">
+        <div class="property-group">
+          <label class="property-label">Corner Radius</label>
+          <input type="number" class="property-input" data-testid="prop-cornerRadius"
+                 [value]="element.properties.cornerRadius ?? 0"
+                 (input)="updateProperty(element, 'cornerRadius', +$any($event.target).value)">
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="element.type === 'Border'">
+        <div class="property-group">
+          <label class="property-label">Border Color</label>
+          <input type="color" class="property-input" data-testid="prop-borderColor"
+                 [value]="element.properties.borderColor || '#cccccc'"
+                 (input)="updateProperty(element, 'borderColor', $any($event.target).value)">
+        </div>
+        <div class="property-group">
+          <label class="property-label">Border Width</label>
+          <input type="number" class="property-input" data-testid="prop-borderWidth"
+                 [value]="element.properties.borderWidth ?? 1"
+                 (input)="updateProperty(element, 'borderWidth', +$any($event.target).value)">
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="element.type === 'CollectionView'">
+        <div class="property-group">
+          <label class="property-label">Preview Items</label>
+          <input type="number" min="1" max="20" class="property-input" data-testid="prop-itemCount"
+                 [value]="element.properties.itemCount ?? 3"
+                 (input)="updateProperty(element, 'itemCount', +$any($event.target).value)">
+        </div>
+        <div class="property-group">
+          <label class="property-label">Item Label</label>
+          <input type="text" class="property-input" data-testid="prop-itemTemplateText"
+                 [value]="element.properties.itemTemplateText || 'Item'"
+                 (input)="updateProperty(element, 'itemTemplateText', $any($event.target).value)">
+        </div>
+      </ng-container>
+    </div>
+
+    <!-- Data bindings -->
+    <div class="property-section" data-testid="bindings-section">
+      <h4 class="section-header">Data Bindings</h4>
+
+      <div class="property-group" *ngFor="let property of bindableProperties(element)">
+        <label class="property-label">{{ property }}</label>
+        <input
+          type="text"
+          class="property-input"
+          [attr.data-testid]="'binding-' + property"
+          placeholder="ViewModel path"
+          [value]="bindingValue(element, property)"
+          (input)="updateBinding(element, property, $any($event.target).value)">
       </div>
     </div>
 
@@ -415,6 +613,8 @@
       </div>
     </div>
   </div>
+
+  </ng-container>
 
   <ng-template #noSelection>
     <div class="no-selection">

--- a/src/app/components/properties-panel/properties-panel.scss
+++ b/src/app/components/properties-panel/properties-panel.scss
@@ -169,3 +169,9 @@
   font-size: 13px;
   margin-bottom: 6px;
 }
+
+.align-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ElementService } from '../../services/element';
@@ -9,9 +9,12 @@ import {
   GridLength,
   GridLengthType,
   Orientation,
-  FontAttributes
+  FontAttributes,
+  BINDABLE_PROPERTIES,
+  COMMON_BINDABLE_PROPERTIES
 } from '../../models/maui-element';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
+import { AlignmentService, AlignMode } from '../../services/alignment';
 
 @Component({
   selector: 'app-properties-panel',
@@ -20,19 +23,68 @@ import { Observable } from 'rxjs';
   templateUrl: './properties-panel.html',
   styleUrl: './properties-panel.scss'
 })
-export class PropertiesPanelComponent implements OnInit {
+export class PropertiesPanelComponent implements OnInit, OnDestroy {
   selectedElement$: Observable<MauiElement | null>;
+  selection: MauiElement[] = [];
+  private subscription = new Subscription();
 
   readonly orientations = Object.values(Orientation);
   readonly fontAttributes = Object.values(FontAttributes);
   readonly gridLengthTypes = Object.values(GridLengthType);
 
-  constructor(private elementService: ElementService) {
+  constructor(
+    private elementService: ElementService,
+    private alignmentService: AlignmentService
+  ) {
     this.selectedElement$ = this.elementService.selectedElement$;
   }
 
   ngOnInit() {
-    // Initialize properties panel
+    this.subscription.add(
+      this.elementService.selectedElements$.subscribe(selection => (this.selection = selection))
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  // --- Multi selection --------------------------------------------------------
+
+  get isMultiSelection(): boolean {
+    return this.selection.length > 1;
+  }
+
+  get selectionCount(): number {
+    return this.selection.length;
+  }
+
+  /** Returns the value shared by every selected element, or '' when they differ. */
+  sharedValue(property: keyof ElementProperties): any {
+    if (this.selection.length === 0) {
+      return '';
+    }
+    const first = this.selection[0].properties[property];
+    return this.selection.every(element => element.properties[property] === first) ? first ?? '' : '';
+  }
+
+  updateSelection(property: keyof ElementProperties, value: any) {
+    this.elementService.updateSelectionProperties({ [property]: value });
+  }
+
+  removeSelection() {
+    this.elementService.removeSelectedElements();
+  }
+
+  duplicateSelection() {
+    const targets = [...this.selection];
+    this.elementService.runAsSingleChange(() => {
+      targets.forEach(element => this.elementService.duplicateElement(element));
+    });
+  }
+
+  align(mode: AlignMode) {
+    this.alignmentService.align(this.selection, mode);
   }
 
   updateProperty(element: MauiElement, property: keyof ElementProperties, value: any) {
@@ -56,6 +108,62 @@ export class PropertiesPanelComponent implements OnInit {
   }
 
   // --- Capability helpers -----------------------------------------------------
+
+  private static readonly PLACEHOLDER_TYPES = [ElementType.Entry, ElementType.Editor, ElementType.SearchBar];
+  private static readonly RANGE_TYPES = [ElementType.Slider, ElementType.Stepper];
+  private static readonly CONTROL_PROPERTY_TYPES = [
+    ElementType.Entry,
+    ElementType.Editor,
+    ElementType.SearchBar,
+    ElementType.CheckBox,
+    ElementType.Switch,
+    ElementType.Slider,
+    ElementType.Stepper,
+    ElementType.ProgressBar,
+    ElementType.ActivityIndicator,
+    ElementType.DatePicker,
+    ElementType.Border,
+    ElementType.Frame,
+    ElementType.CollectionView
+  ];
+
+  hasControlProperties(element: MauiElement): boolean {
+    return PropertiesPanelComponent.CONTROL_PROPERTY_TYPES.includes(element.type);
+  }
+
+  supportsPlaceholder(element: MauiElement): boolean {
+    return PropertiesPanelComponent.PLACEHOLDER_TYPES.includes(element.type);
+  }
+
+  supportsRange(element: MauiElement): boolean {
+    return PropertiesPanelComponent.RANGE_TYPES.includes(element.type);
+  }
+
+  supportsCornerRadius(element: MauiElement): boolean {
+    return element.type === ElementType.Border || element.type === ElementType.Frame;
+  }
+
+  // --- Data bindings ----------------------------------------------------------
+
+  bindableProperties(element: MauiElement): string[] {
+    const specific = BINDABLE_PROPERTIES[element.type] || [];
+    return [...new Set([...specific, ...COMMON_BINDABLE_PROPERTIES])];
+  }
+
+  bindingValue(element: MauiElement, property: string): string {
+    return element.properties.bindings?.[property] || '';
+  }
+
+  updateBinding(element: MauiElement, property: string, path: string) {
+    const bindings = { ...(element.properties.bindings || {}) };
+    const trimmed = path.trim();
+    if (trimmed) {
+      bindings[property] = trimmed;
+    } else {
+      delete bindings[property];
+    }
+    this.elementService.updateElementProperties(element, { bindings });
+  }
 
   isStackLayout(element: MauiElement): boolean {
     return element.type === ElementType.StackLayout || element.type === ElementType.VerticalStackLayout;

--- a/src/app/components/toolbox/toolbox.html
+++ b/src/app/components/toolbox/toolbox.html
@@ -49,6 +49,53 @@
     </ng-container>
   </div>
 
+  <!-- Saved component templates -->
+  <div class="category-group" *ngIf="(templates$ | async) as templates" data-testid="templates-section">
+    <ng-container *ngIf="templates.length">
+      <h3 class="category-title">Templates</h3>
+      <div class="toolbox-list">
+        <div
+          class="toolbox-list-item"
+          *ngFor="let template of templates"
+          [attr.data-testid]="'template-' + template.name"
+          role="button"
+          tabindex="0"
+          (click)="insertTemplate(template)"
+          (keydown.enter)="insertTemplate(template)">
+          <span class="material-icons">bookmark</span>
+          <span class="item-name">{{ template.name }}</span>
+          <button
+            class="icon-button"
+            type="button"
+            [attr.data-testid]="'template-delete-' + template.name"
+            aria-label="Delete template"
+            (click)="deleteTemplate($event, template)">
+            <span class="material-icons">close</span>
+          </button>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+
+  <!-- Starter pages -->
+  <div class="category-group" data-testid="starter-pages-section">
+    <h3 class="category-title">Starter pages</h3>
+    <div class="toolbox-list">
+      <div
+        class="toolbox-list-item"
+        *ngFor="let page of starterPages"
+        [attr.data-testid]="'starter-' + page.id"
+        role="button"
+        tabindex="0"
+        [title]="page.description"
+        (click)="applyStarterPage(page)"
+        (keydown.enter)="applyStarterPage(page)">
+        <span class="material-icons">auto_awesome_mosaic</span>
+        <span class="item-name">{{ page.name }}</span>
+      </div>
+    </div>
+  </div>
+
   <div class="empty-state" *ngIf="!hasAnyResult" data-testid="toolbox-empty">
     <p>No controls match "{{ searchTerm }}"</p>
   </div>

--- a/src/app/components/toolbox/toolbox.scss
+++ b/src/app/components/toolbox/toolbox.scss
@@ -130,3 +130,50 @@
   color: #888;
   font-size: 13px;
 }
+
+.toolbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.toolbox-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  color: #334155;
+
+  &:hover {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+  }
+
+  .material-icons {
+    font-size: 16px;
+    color: #64748b;
+  }
+
+  .item-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .icon-button {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: #94a3b8;
+    padding: 0;
+
+    &:hover { color: #ef4444; }
+  }
+}

--- a/src/app/components/toolbox/toolbox.ts
+++ b/src/app/components/toolbox/toolbox.ts
@@ -5,6 +5,8 @@ import { MAUI_CONTROLS, ToolboxItem, ToolboxCategory } from '../../models/toolbo
 import { ElementType, MauiElement } from '../../models/maui-element';
 import { ElementService } from '../../services/element';
 import { DragDropService, TOOLBOX_DRAG_MIME } from '../../services/drag-drop';
+import { ClipboardService, ComponentTemplate, StarterPage } from '../../services/clipboard';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-toolbox',
@@ -18,10 +20,37 @@ export class ToolboxComponent {
   categories = Object.values(ToolboxCategory);
   searchTerm = '';
 
+  templates$: Observable<ComponentTemplate[]>;
+  starterPages: StarterPage[];
+
   constructor(
     private elementService: ElementService,
-    private dragDropService: DragDropService
-  ) {}
+    private dragDropService: DragDropService,
+    private clipboardService: ClipboardService
+  ) {
+    this.templates$ = this.clipboardService.templates$;
+    this.starterPages = this.clipboardService.starterPages;
+  }
+
+  // --- Templates & starter pages ---------------------------------------------
+
+  matchesSearch(text: string): boolean {
+    const term = this.searchTerm.trim().toLowerCase();
+    return !term || text.toLowerCase().includes(term);
+  }
+
+  insertTemplate(template: ComponentTemplate) {
+    this.clipboardService.insertTemplate(template.id, this.resolveTargetParent());
+  }
+
+  deleteTemplate(event: Event, template: ComponentTemplate) {
+    event.stopPropagation();
+    this.clipboardService.deleteTemplate(template.id);
+  }
+
+  applyStarterPage(page: StarterPage) {
+    this.clipboardService.applyStarterPage(page.id);
+  }
 
   getItemsByCategory(category: ToolboxCategory): ToolboxItem[] {
     const term = this.searchTerm.trim().toLowerCase();
@@ -78,7 +107,7 @@ export class ToolboxComponent {
    * New controls are added to the selected layout when one is selected,
    * so nesting does not require a drag operation.
    */
-  private resolveTargetParent(): MauiElement {
+  resolveTargetParent(): MauiElement {
     const selected = this.elementService.getSelectedElement();
     if (selected && this.dragDropService.canHaveChildren(selected.type)) {
       return selected;

--- a/src/app/integration-tests/advanced-scenarios.spec.ts
+++ b/src/app/integration-tests/advanced-scenarios.spec.ts
@@ -31,7 +31,7 @@ describe('Advanced Integration Scenarios', () => {
       
       const inputEntry = elementService.createElement(ElementType.Entry, {
         x: 10, y: 60, width: 250, height: 35,
-        text: 'Enter your name',
+        placeholder: 'Enter your name',
         backgroundColor: '#ffffff'
       });
       
@@ -70,7 +70,7 @@ describe('Advanced Integration Scenarios', () => {
       expect(parsedLayout.children.length).toBe(3);
       expect(parsedLayout.children[0].properties.text).toBe('Updated Application Title');
       expect(parsedLayout.children[0].properties.fontSize).toBe(28);
-      expect(parsedLayout.children[1].properties.text).toBe('Enter your name'); // Placeholder becomes text
+      expect(parsedLayout.children[1].properties.placeholder).toBe('Enter your name');
       expect(parsedLayout.children[2].properties.text).toBe('Submit');
       
       // Step 5: Set the parsed layout and verify service state

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -13,6 +13,14 @@ export enum ElementType {
   Button = 'Button',
   Entry = 'Entry',
   Editor = 'Editor',
+  SearchBar = 'SearchBar',
+  CheckBox = 'CheckBox',
+  Switch = 'Switch',
+  Slider = 'Slider',
+  Stepper = 'Stepper',
+  ProgressBar = 'ProgressBar',
+  ActivityIndicator = 'ActivityIndicator',
+  DatePicker = 'DatePicker',
   Image = 'Image',
   Path = 'Path',
   StackLayout = 'StackLayout',
@@ -20,7 +28,9 @@ export enum ElementType {
   Grid = 'Grid',
   AbsoluteLayout = 'AbsoluteLayout',
   Frame = 'Frame',
-  ScrollView = 'ScrollView'
+  Border = 'Border',
+  ScrollView = 'ScrollView',
+  CollectionView = 'CollectionView'
 }
 
 export const DEFAULT_ICON_PATH_DATA = 'M12 2L2 22h20L12 2Z';
@@ -43,6 +53,7 @@ export interface ElementProperties {
   
   // Content properties
   text?: string;
+  placeholder?: string;
   pathData?: string;
   fillColor?: string;
   strokeColor?: string;
@@ -59,10 +70,57 @@ export interface ElementProperties {
   orientation?: Orientation;
   spacing?: number;
   
+  // Control state properties
+  isChecked?: boolean;
+  isToggled?: boolean;
+  value?: number;
+  minimum?: number;
+  maximum?: number;
+  increment?: number;
+  progress?: number;
+  isRunning?: boolean;
+  date?: string;
+
+  // Border / frame properties
+  cornerRadius?: number;
+  borderColor?: string;
+  borderWidth?: number;
+
+  // CollectionView preview
+  itemCount?: number;
+  itemTemplateText?: string;
+
   // Other properties
   isVisible?: boolean;
   isEnabled?: boolean;
+
+  /**
+   * Data bindings keyed by MAUI property name, e.g. `{ Text: 'UserName' }`
+   * is generated as Text="{Binding UserName}".
+   */
+  bindings?: Record<string, string>;
 }
+
+/** Properties that can be bound to a view model, per element type. */
+export const BINDABLE_PROPERTIES: Record<string, string[]> = {
+  [ElementType.Label]: ['Text', 'TextColor', 'IsVisible'],
+  [ElementType.Button]: ['Text', 'Command', 'IsEnabled'],
+  [ElementType.Entry]: ['Text', 'Placeholder', 'IsEnabled'],
+  [ElementType.Editor]: ['Text', 'Placeholder'],
+  [ElementType.SearchBar]: ['Text', 'Placeholder', 'SearchCommand'],
+  [ElementType.CheckBox]: ['IsChecked'],
+  [ElementType.Switch]: ['IsToggled'],
+  [ElementType.Slider]: ['Value'],
+  [ElementType.Stepper]: ['Value'],
+  [ElementType.ProgressBar]: ['Progress'],
+  [ElementType.ActivityIndicator]: ['IsRunning'],
+  [ElementType.DatePicker]: ['Date'],
+  [ElementType.Image]: ['Source'],
+  [ElementType.CollectionView]: ['ItemsSource', 'SelectedItem']
+};
+
+/** Every element supports these bindings in addition to the type specific ones. */
+export const COMMON_BINDABLE_PROPERTIES = ['IsVisible', 'IsEnabled'];
 
 export interface Thickness {
   left: number;

--- a/src/app/models/toolbox.ts
+++ b/src/app/models/toolbox.ts
@@ -8,6 +8,7 @@ export interface ToolboxItem {
 
 export enum ToolboxCategory {
   Controls = 'Controls',
+  Inputs = 'Inputs',
   Layouts = 'Layouts',
   Views = 'Views'
 }
@@ -33,13 +34,69 @@ export const MAUI_CONTROLS: ToolboxItem[] = [
     displayName: 'Entry',
     icon: 'input',
     description: 'Single line text input',
-    category: ToolboxCategory.Controls
+    category: ToolboxCategory.Inputs
   },
   {
     type: 'Editor',
     displayName: 'Editor',
     icon: 'edit_note',
     description: 'Multi-line text input',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'SearchBar',
+    displayName: 'SearchBar',
+    icon: 'search',
+    description: 'Search input with a search button',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'CheckBox',
+    displayName: 'CheckBox',
+    icon: 'check_box',
+    description: 'Boolean check box',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'Switch',
+    displayName: 'Switch',
+    icon: 'toggle_on',
+    description: 'On/off toggle',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'Slider',
+    displayName: 'Slider',
+    icon: 'tune',
+    description: 'Selects a value from a range',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'Stepper',
+    displayName: 'Stepper',
+    icon: 'exposure',
+    description: 'Increments and decrements a value',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'DatePicker',
+    displayName: 'DatePicker',
+    icon: 'event',
+    description: 'Selects a date',
+    category: ToolboxCategory.Inputs
+  },
+  {
+    type: 'ProgressBar',
+    displayName: 'ProgressBar',
+    icon: 'linear_scale',
+    description: 'Shows progress of a task',
+    category: ToolboxCategory.Controls
+  },
+  {
+    type: 'ActivityIndicator',
+    displayName: 'ActivityIndicator',
+    icon: 'refresh',
+    description: 'Shows that work is in progress',
     category: ToolboxCategory.Controls
   },
   {
@@ -96,10 +153,24 @@ export const MAUI_CONTROLS: ToolboxItem[] = [
     category: ToolboxCategory.Views
   },
   {
+    type: 'Border',
+    displayName: 'Border',
+    icon: 'rounded_corner',
+    description: 'Container with a stroke and corner radius',
+    category: ToolboxCategory.Views
+  },
+  {
     type: 'ScrollView',
     displayName: 'ScrollView',
     icon: 'unfold_more',
     description: 'Scrollable container',
+    category: ToolboxCategory.Views
+  },
+  {
+    type: 'CollectionView',
+    displayName: 'CollectionView',
+    icon: 'view_list',
+    description: 'Repeats an item template over a bound collection',
     category: ToolboxCategory.Views
   }
 ];

--- a/src/app/services/alignment.service.spec.ts
+++ b/src/app/services/alignment.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+import { AlignmentService } from './alignment';
+import { ElementService } from './element';
+import { ElementType, MauiElement } from '../models/maui-element';
+
+describe('AlignmentService', () => {
+  let service: AlignmentService;
+  let elements: ElementService;
+
+  const add = (type: ElementType, x: number, y: number, width: number, height: number): MauiElement => {
+    const element = elements.createElement(type);
+    elements.addElement(element, elements.getRootElement());
+    elements.updateElementProperties(element, { x, y, width, height });
+    return element;
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    elements = TestBed.inject(ElementService);
+    service = TestBed.inject(AlignmentService);
+  });
+
+  it('aligns elements to the leftmost edge', () => {
+    const a = add(ElementType.Label, 50, 10, 100, 30);
+    const b = add(ElementType.Button, 120, 80, 80, 40);
+
+    service.align([a, b], 'left');
+
+    expect(a.properties.x).toBe(50);
+    expect(b.properties.x).toBe(50);
+  });
+
+  it('aligns elements to the rightmost edge using their widths', () => {
+    const a = add(ElementType.Label, 50, 10, 100, 30);
+    const b = add(ElementType.Button, 120, 80, 80, 40);
+
+    service.align([a, b], 'right');
+
+    expect(a.properties.x! + 100).toBe(200);
+    expect(b.properties.x! + 80).toBe(200);
+  });
+
+  it('centres elements on the shared horizontal centre', () => {
+    const a = add(ElementType.Label, 0, 10, 100, 30);
+    const b = add(ElementType.Button, 100, 80, 50, 40);
+
+    service.align([a, b], 'center');
+
+    expect(a.properties.x! + 50).toBe(75);
+    expect(b.properties.x! + 25).toBe(75);
+  });
+
+  it('aligns to the top and bottom edges', () => {
+    const a = add(ElementType.Label, 0, 10, 100, 30);
+    const b = add(ElementType.Button, 0, 90, 100, 50);
+
+    service.align([a, b], 'top');
+    expect(b.properties.y).toBe(10);
+
+    elements.updateElementProperties(b, { y: 90 });
+    service.align([a, b], 'bottom');
+    expect(a.properties.y! + 30).toBe(140);
+  });
+
+  it('ignores single elements', () => {
+    const a = add(ElementType.Label, 50, 10, 100, 30);
+
+    service.align([a], 'left');
+
+    expect(a.properties.x).toBe(50);
+    expect(service.canAlign([a])).toBeFalse();
+  });
+
+  it('only aligns children of an absolute layout', () => {
+    const stack = elements.createElement(ElementType.VerticalStackLayout);
+    elements.addElement(stack, elements.getRootElement());
+    const child = elements.createElement(ElementType.Label);
+    elements.addElement(child, stack);
+    elements.updateElementProperties(child, { x: 40 });
+
+    expect(service.canAlign([child, stack])).toBeFalse();
+    service.align([child, stack], 'left');
+    expect(child.properties.x).toBe(40);
+  });
+
+  it('distributes three elements with equal gaps', () => {
+    const a = add(ElementType.Label, 0, 0, 100, 30);
+    const b = add(ElementType.Label, 150, 0, 100, 30);
+    const c = add(ElementType.Label, 400, 0, 100, 30);
+
+    service.distribute([a, b, c], 'horizontal');
+
+    const gapOne = b.properties.x! - (a.properties.x! + 100);
+    const gapTwo = c.properties.x! - (b.properties.x! + 100);
+    expect(Math.abs(gapOne - gapTwo)).toBeLessThanOrEqual(1);
+  });
+
+  it('needs at least three elements to distribute', () => {
+    const a = add(ElementType.Label, 0, 0, 100, 30);
+    const b = add(ElementType.Label, 150, 0, 100, 30);
+
+    service.distribute([a, b], 'horizontal');
+
+    expect(b.properties.x).toBe(150);
+  });
+
+  it('distributes vertically', () => {
+    const a = add(ElementType.Label, 0, 0, 100, 30);
+    const b = add(ElementType.Label, 0, 50, 100, 30);
+    const c = add(ElementType.Label, 0, 300, 100, 30);
+
+    service.distribute([a, b, c], 'vertical');
+
+    const gapOne = b.properties.y! - (a.properties.y! + 30);
+    const gapTwo = c.properties.y! - (b.properties.y! + 30);
+    expect(Math.abs(gapOne - gapTwo)).toBeLessThanOrEqual(1);
+  });
+
+  it('snaps coordinates to the nearest grid intersection', () => {
+    expect(service.snapToGrid(33, 20)).toBe(40);
+    expect(service.snapToGrid(29, 20)).toBe(20);
+    expect(service.snapToGrid(12.4, 1)).toBe(12);
+    expect(service.snapToGrid(7, 0)).toBe(7);
+  });
+
+  it('produces a guide when a dragged edge is near a sibling edge', () => {
+    const anchor = add(ElementType.Label, 100, 40, 100, 30);
+    const dragged = add(ElementType.Button, 300, 300, 100, 30);
+
+    const result = service.computeGuides(dragged, 103, 300);
+
+    expect(result.x).toBe(100);
+    expect(result.guides.some(guide => guide.orientation === 'vertical')).toBeTrue();
+    expect(anchor.properties.x).toBe(100);
+  });
+
+  it('does not snap beyond the threshold', () => {
+    add(ElementType.Label, 100, 40, 100, 30);
+    const dragged = add(ElementType.Button, 300, 300, 100, 30);
+
+    // 250 avoids the parent's centre line, which is a guide of its own
+    const result = service.computeGuides(dragged, 140, 250);
+
+    expect(result.x).toBe(140);
+    expect(result.guides.length).toBe(0);
+  });
+
+  it('snaps to the parent centre line', () => {
+    const root = elements.getRootElement();
+    elements.updateElementProperties(root, { width: 800, height: 600 });
+    const dragged = add(ElementType.Button, 0, 0, 100, 30);
+
+    const result = service.computeGuides(dragged, 398, 0);
+
+    expect(result.x).toBe(400);
+  });
+
+  it('aligning a group records a single undo step', () => {
+    const a = add(ElementType.Label, 50, 10, 100, 30);
+    const b = add(ElementType.Button, 120, 80, 80, 40);
+
+    service.align([a, b], 'left');
+    elements.undo();
+
+    expect(elements.findElementById(b.id)!.properties.x).toBe(120);
+    expect(elements.findElementById(a.id)!.properties.x).toBe(50);
+  });
+});

--- a/src/app/services/alignment.ts
+++ b/src/app/services/alignment.ts
@@ -1,0 +1,197 @@
+import { Injectable } from '@angular/core';
+import { ElementService } from './element';
+import { MauiElement, ElementType } from '../models/maui-element';
+
+export type AlignMode = 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom';
+export type DistributeMode = 'horizontal' | 'vertical';
+
+export interface AlignmentGuide {
+  orientation: 'vertical' | 'horizontal';
+  /** Canvas relative position of the guide line. */
+  position: number;
+}
+
+interface Box {
+  element: MauiElement;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Aligns, distributes and snaps elements that live in an AbsoluteLayout,
+ * and computes the smart guides shown while dragging.
+ */
+@Injectable({ providedIn: 'root' })
+export class AlignmentService {
+  /** Distance (px) within which a dragged edge snaps to a sibling edge. */
+  readonly SNAP_THRESHOLD = 6;
+
+  constructor(private elementService: ElementService) {}
+
+  /** Only absolutely positioned elements can be aligned. */
+  canAlign(elements: MauiElement[]): boolean {
+    return this.positionable(elements).length > 1;
+  }
+
+  align(elements: MauiElement[], mode: AlignMode): void {
+    const boxes = this.toBoxes(this.positionable(elements));
+    if (boxes.length < 2) {
+      return;
+    }
+
+    const left = Math.min(...boxes.map(box => box.x));
+    const right = Math.max(...boxes.map(box => box.x + box.width));
+    const top = Math.min(...boxes.map(box => box.y));
+    const bottom = Math.max(...boxes.map(box => box.y + box.height));
+
+    this.elementService.runAsSingleChange(() => {
+      for (const box of boxes) {
+        const patch: { x?: number; y?: number } = {};
+        switch (mode) {
+          case 'left':
+            patch.x = left;
+            break;
+          case 'right':
+            patch.x = right - box.width;
+            break;
+          case 'center':
+            patch.x = Math.round((left + right) / 2 - box.width / 2);
+            break;
+          case 'top':
+            patch.y = top;
+            break;
+          case 'bottom':
+            patch.y = bottom - box.height;
+            break;
+          case 'middle':
+            patch.y = Math.round((top + bottom) / 2 - box.height / 2);
+            break;
+        }
+        this.elementService.updateElementProperties(box.element, patch, { recordHistory: false });
+      }
+    });
+  }
+
+  /** Spreads elements so the gaps between them are equal. */
+  distribute(elements: MauiElement[], mode: DistributeMode): void {
+    const boxes = this.toBoxes(this.positionable(elements));
+    if (boxes.length < 3) {
+      return;
+    }
+
+    const horizontal = mode === 'horizontal';
+    const sorted = [...boxes].sort((a, b) => (horizontal ? a.x - b.x : a.y - b.y));
+    const first = sorted[0];
+    const last = sorted[sorted.length - 1];
+
+    const start = horizontal ? first.x + first.width : first.y + first.height;
+    const end = horizontal ? last.x : last.y;
+    const occupied = sorted
+      .slice(1, -1)
+      .reduce((total, box) => total + (horizontal ? box.width : box.height), 0);
+    const gap = (end - start - occupied) / (sorted.length - 1);
+
+    this.elementService.runAsSingleChange(() => {
+      let cursor = start + gap;
+      for (const box of sorted.slice(1, -1)) {
+        this.elementService.updateElementProperties(
+          box.element,
+          horizontal ? { x: Math.round(cursor) } : { y: Math.round(cursor) },
+          { recordHistory: false }
+        );
+        cursor += (horizontal ? box.width : box.height) + gap;
+      }
+    });
+  }
+
+  /** Rounds a coordinate to the nearest grid intersection. */
+  snapToGrid(value: number, gridSize: number): number {
+    if (gridSize <= 1) {
+      return Math.round(value);
+    }
+    return Math.round(value / gridSize) * gridSize;
+  }
+
+  /**
+   * Returns the guides a dragged element aligns with, plus the snapped position.
+   * Edges and centres of every sibling are considered.
+   */
+  computeGuides(dragged: MauiElement, x: number, y: number): { x: number; y: number; guides: AlignmentGuide[] } {
+    const parent = dragged.parent;
+    if (!parent) {
+      return { x, y, guides: [] };
+    }
+
+    const width = dragged.properties.width || 0;
+    const height = dragged.properties.height || 0;
+    const siblings = parent.children.filter(child => child !== dragged);
+
+    const verticalTargets: number[] = [];
+    const horizontalTargets: number[] = [];
+
+    for (const sibling of siblings) {
+      const sx = sibling.properties.x || 0;
+      const sy = sibling.properties.y || 0;
+      const sw = sibling.properties.width || 0;
+      const sh = sibling.properties.height || 0;
+      verticalTargets.push(sx, sx + sw / 2, sx + sw);
+      horizontalTargets.push(sy, sy + sh / 2, sy + sh);
+    }
+
+    // The parent's own edges and centre are guides too
+    const parentWidth = parent.properties.width || 0;
+    const parentHeight = parent.properties.height || 0;
+    verticalTargets.push(0, parentWidth / 2, parentWidth);
+    horizontalTargets.push(0, parentHeight / 2, parentHeight);
+
+    const guides: AlignmentGuide[] = [];
+    const horizontalMatch = this.findSnap([x, x + width / 2, x + width], verticalTargets);
+    const verticalMatch = this.findSnap([y, y + height / 2, y + height], horizontalTargets);
+
+    let snappedX = x;
+    let snappedY = y;
+
+    if (horizontalMatch) {
+      snappedX = x + horizontalMatch.delta;
+      guides.push({ orientation: 'vertical', position: horizontalMatch.target });
+    }
+
+    if (verticalMatch) {
+      snappedY = y + verticalMatch.delta;
+      guides.push({ orientation: 'horizontal', position: verticalMatch.target });
+    }
+
+    return { x: snappedX, y: snappedY, guides };
+  }
+
+  private findSnap(candidates: number[], targets: number[]): { target: number; delta: number } | null {
+    let best: { target: number; delta: number } | null = null;
+
+    for (const candidate of candidates) {
+      for (const target of targets) {
+        const delta = target - candidate;
+        if (Math.abs(delta) <= this.SNAP_THRESHOLD && (!best || Math.abs(delta) < Math.abs(best.delta))) {
+          best = { target, delta };
+        }
+      }
+    }
+
+    return best;
+  }
+
+  private positionable(elements: MauiElement[]): MauiElement[] {
+    return elements.filter(element => element.parent?.type === ElementType.AbsoluteLayout);
+  }
+
+  private toBoxes(elements: MauiElement[]): Box[] {
+    return elements.map(element => ({
+      element,
+      x: element.properties.x || 0,
+      y: element.properties.y || 0,
+      width: element.properties.width || 0,
+      height: element.properties.height || 0
+    }));
+  }
+}

--- a/src/app/services/clipboard.service.spec.ts
+++ b/src/app/services/clipboard.service.spec.ts
@@ -1,0 +1,137 @@
+import { TestBed } from '@angular/core/testing';
+import { ClipboardService } from './clipboard';
+import { ElementService } from './element';
+import { ElementType, MauiElement } from '../models/maui-element';
+
+describe('ClipboardService', () => {
+  let service: ClipboardService;
+  let elements: ElementService;
+
+  const add = (type: ElementType, parent?: MauiElement): MauiElement => {
+    const element = elements.createElement(type);
+    elements.addElement(element, parent || elements.getRootElement());
+    return element;
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem('maui-designer.templates');
+    localStorage.removeItem('maui-designer.clipboard');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    elements = TestBed.inject(ElementService);
+    service = TestBed.inject(ClipboardService);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('maui-designer.templates');
+    localStorage.removeItem('maui-designer.clipboard');
+  });
+
+  it('copies and pastes an element with a fresh id', () => {
+    const label = add(ElementType.Label);
+    elements.updateElementProperties(label, { text: 'Hello' });
+
+    expect(service.copy([label])).toBe(1);
+    const pasted = service.paste(elements.getRootElement());
+
+    expect(pasted.length).toBe(1);
+    expect(pasted[0].id).not.toBe(label.id);
+    expect(pasted[0].properties.text).toBe('Hello');
+    expect(elements.getRootElement().children.length).toBe(2);
+  });
+
+  it('offsets the pasted copy so it is visible', () => {
+    const label = add(ElementType.Label);
+    elements.updateElementProperties(label, { x: 10, y: 20 });
+
+    service.copy([label]);
+    const [pasted] = service.paste(elements.getRootElement());
+
+    expect(pasted.properties.x).toBe(26);
+    expect(pasted.properties.y).toBe(36);
+  });
+
+  it('refuses to copy the root element', () => {
+    expect(service.copy([elements.getRootElement()])).toBe(0);
+    expect(service.hasContent()).toBeFalse();
+    expect(service.paste()).toEqual([]);
+  });
+
+  it('copies a container together with its children', () => {
+    const stack = add(ElementType.VerticalStackLayout);
+    add(ElementType.Label, stack);
+    add(ElementType.Button, stack);
+
+    service.copy([stack]);
+    const [pasted] = service.paste(elements.getRootElement());
+
+    expect(pasted.children.length).toBe(2);
+    expect(pasted.children[0].parent).toBe(pasted);
+  });
+
+  it('cuts by copying and then removing the selection', () => {
+    const label = add(ElementType.Label);
+    elements.setSelection([label]);
+
+    expect(service.cut([label])).toBe(1);
+    expect(elements.getRootElement().children.length).toBe(0);
+
+    service.paste(elements.getRootElement());
+    expect(elements.getRootElement().children.length).toBe(1);
+  });
+
+  it('saves, lists and inserts a component template', () => {
+    const button = add(ElementType.Button);
+    elements.updateElementProperties(button, { text: 'Primary' });
+
+    const template = service.saveTemplate('Primary button', [button]);
+    expect(template).toBeTruthy();
+    expect(service.getTemplates().length).toBe(1);
+
+    const inserted = service.insertTemplate(template!.id, elements.getRootElement());
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].properties.text).toBe('Primary');
+  });
+
+  it('rejects templates without a name or content', () => {
+    const button = add(ElementType.Button);
+
+    expect(service.saveTemplate('   ', [button])).toBeNull();
+    expect(service.saveTemplate('Empty', [])).toBeNull();
+    expect(service.getTemplates().length).toBe(0);
+  });
+
+  it('deletes templates and ignores unknown ids', () => {
+    const button = add(ElementType.Button);
+    const template = service.saveTemplate('Temp', [button])!;
+
+    expect(service.insertTemplate('missing')).toEqual([]);
+    service.deleteTemplate(template.id);
+    expect(service.getTemplates().length).toBe(0);
+  });
+
+  it('persists templates in localStorage', () => {
+    const button = add(ElementType.Button);
+    service.saveTemplate('Persisted', [button]);
+
+    expect(localStorage.getItem('maui-designer.templates')).toContain('Persisted');
+  });
+
+  it('applies a starter page and replaces the design', () => {
+    add(ElementType.Label);
+
+    expect(service.applyStarterPage('login')).toBeTrue();
+    expect(elements.getRootElement().children.length).toBeGreaterThan(1);
+  });
+
+  it('reports an unknown starter page', () => {
+    expect(service.applyStarterPage('nope')).toBeFalse();
+  });
+
+  it('exposes every starter page with parsable XAML', () => {
+    expect(service.starterPages.length).toBeGreaterThan(0);
+    for (const page of service.starterPages) {
+      expect(service.applyStarterPage(page.id)).toBeTrue();
+    }
+  });
+});

--- a/src/app/services/clipboard.ts
+++ b/src/app/services/clipboard.ts
@@ -1,0 +1,268 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ElementService } from './element';
+import { XamlParserService } from './xaml-parser';
+import { MauiElement, ElementType } from '../models/maui-element';
+
+export interface ComponentTemplate {
+  id: string;
+  name: string;
+  /** Serialized MauiElement array. */
+  payload: string;
+  createdAt: number;
+}
+
+export interface StarterPage {
+  id: string;
+  name: string;
+  description: string;
+  xaml: string;
+}
+
+export const STARTER_PAGES: StarterPage[] = [
+  {
+    id: 'login',
+    name: 'Login page',
+    description: 'Title, email and password entries with a sign in button',
+    xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout x:Name="LoginPage" WidthRequest="390" HeightRequest="844" BackgroundColor="#ffffff">
+        <Label x:Name="Title" Text="Welcome back" AbsoluteLayout.LayoutBounds="24,80,300,40" WidthRequest="300" HeightRequest="40" FontSize="26" FontAttributes="Bold" TextColor="#111827" />
+        <Label x:Name="Subtitle" Text="Sign in to continue" AbsoluteLayout.LayoutBounds="24,124,300,24" WidthRequest="300" HeightRequest="24" FontSize="14" TextColor="#6b7280" />
+        <Entry x:Name="EmailEntry" Placeholder="Email" Text="{Binding Email}" AbsoluteLayout.LayoutBounds="24,190,342,44" WidthRequest="342" HeightRequest="44" BackgroundColor="#ffffff" />
+        <Entry x:Name="PasswordEntry" Placeholder="Password" Text="{Binding Password}" AbsoluteLayout.LayoutBounds="24,248,342,44" WidthRequest="342" HeightRequest="44" BackgroundColor="#ffffff" />
+        <Switch x:Name="RememberSwitch" AbsoluteLayout.LayoutBounds="24,308,60,32" WidthRequest="60" HeightRequest="32" IsToggled="{Binding RememberMe}" />
+        <Label x:Name="RememberLabel" Text="Remember me" AbsoluteLayout.LayoutBounds="96,312,200,24" WidthRequest="200" HeightRequest="24" FontSize="14" TextColor="#374151" />
+        <Button x:Name="SignInButton" Text="Sign in" Command="{Binding SignInCommand}" AbsoluteLayout.LayoutBounds="24,364,342,48" WidthRequest="342" HeightRequest="48" BackgroundColor="#2563eb" TextColor="#ffffff" />
+        <ActivityIndicator x:Name="Busy" AbsoluteLayout.LayoutBounds="185,430,40,40" WidthRequest="40" HeightRequest="40" IsRunning="{Binding IsBusy}" />
+    </AbsoluteLayout>
+</ContentPage>`
+  },
+  {
+    id: 'list',
+    name: 'List page',
+    description: 'Search bar over a bound CollectionView',
+    xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout x:Name="ListPage" WidthRequest="390" HeightRequest="844" BackgroundColor="#ffffff">
+        <Label x:Name="ListTitle" Text="Inbox" AbsoluteLayout.LayoutBounds="24,56,200,36" WidthRequest="200" HeightRequest="36" FontSize="24" FontAttributes="Bold" TextColor="#111827" />
+        <SearchBar x:Name="Search" Placeholder="Search messages" Text="{Binding Query}" AbsoluteLayout.LayoutBounds="24,104,342,44" WidthRequest="342" HeightRequest="44" />
+        <CollectionView x:Name="Items" ItemsSource="{Binding Messages}" AbsoluteLayout.LayoutBounds="24,164,342,600" WidthRequest="342" HeightRequest="600">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label x:Name="ItemLabel" Text="{Binding Title}" WidthRequest="342" HeightRequest="44" FontSize="15" TextColor="#111827" />
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </AbsoluteLayout>
+</ContentPage>`
+  },
+  {
+    id: 'profile',
+    name: 'Profile card',
+    description: 'Bordered profile card with avatar, name and action',
+    xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout x:Name="ProfilePage" WidthRequest="390" HeightRequest="844" BackgroundColor="#f3f4f6">
+        <Border x:Name="Card" AbsoluteLayout.LayoutBounds="24,80,342,220" WidthRequest="342" HeightRequest="220" BackgroundColor="#ffffff" Stroke="#e5e7eb" StrokeThickness="1" StrokeShape="RoundRectangle 16" />
+        <Image x:Name="Avatar" AbsoluteLayout.LayoutBounds="48,104,80,80" WidthRequest="80" HeightRequest="80" />
+        <Label x:Name="Name" Text="{Binding DisplayName}" AbsoluteLayout.LayoutBounds="144,110,200,28" WidthRequest="200" HeightRequest="28" FontSize="20" FontAttributes="Bold" TextColor="#111827" />
+        <Label x:Name="Role" Text="{Binding Role}" AbsoluteLayout.LayoutBounds="144,142,200,22" WidthRequest="200" HeightRequest="22" FontSize="14" TextColor="#6b7280" />
+        <ProgressBar x:Name="Completion" Progress="0.7" AbsoluteLayout.LayoutBounds="48,210,294,12" WidthRequest="294" HeightRequest="12" />
+        <Button x:Name="EditButton" Text="Edit profile" Command="{Binding EditCommand}" AbsoluteLayout.LayoutBounds="48,240,294,44" WidthRequest="294" HeightRequest="44" BackgroundColor="#111827" TextColor="#ffffff" />
+    </AbsoluteLayout>
+</ContentPage>`
+  },
+  {
+    id: 'settings',
+    name: 'Settings page',
+    description: 'Grid of setting rows with switches and a slider',
+    xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout x:Name="SettingsPage" WidthRequest="390" HeightRequest="844" BackgroundColor="#ffffff">
+        <Label x:Name="SettingsTitle" Text="Settings" AbsoluteLayout.LayoutBounds="24,56,200,36" WidthRequest="200" HeightRequest="36" FontSize="24" FontAttributes="Bold" TextColor="#111827" />
+        <Label x:Name="NotificationsLabel" Text="Notifications" AbsoluteLayout.LayoutBounds="24,120,220,24" WidthRequest="220" HeightRequest="24" FontSize="16" TextColor="#374151" />
+        <Switch x:Name="NotificationsSwitch" IsToggled="{Binding NotificationsEnabled}" AbsoluteLayout.LayoutBounds="306,116,60,32" WidthRequest="60" HeightRequest="32" />
+        <Label x:Name="DarkModeLabel" Text="Dark mode" AbsoluteLayout.LayoutBounds="24,168,220,24" WidthRequest="220" HeightRequest="24" FontSize="16" TextColor="#374151" />
+        <Switch x:Name="DarkModeSwitch" IsToggled="{Binding DarkMode}" AbsoluteLayout.LayoutBounds="306,164,60,32" WidthRequest="60" HeightRequest="32" />
+        <Label x:Name="VolumeLabel" Text="Volume" AbsoluteLayout.LayoutBounds="24,216,220,24" WidthRequest="220" HeightRequest="24" FontSize="16" TextColor="#374151" />
+        <Slider x:Name="VolumeSlider" Minimum="0" Maximum="100" Value="{Binding Volume}" AbsoluteLayout.LayoutBounds="24,248,342,32" WidthRequest="342" HeightRequest="32" />
+    </AbsoluteLayout>
+</ContentPage>`
+  }
+];
+
+/**
+ * Copy/cut/paste of canvas elements plus reusable component templates and
+ * starter pages. Templates are stored in localStorage so they survive reloads.
+ */
+@Injectable({ providedIn: 'root' })
+export class ClipboardService {
+  private static readonly TEMPLATE_KEY = 'maui-designer.templates';
+  private static readonly CLIPBOARD_KEY = 'maui-designer.clipboard';
+
+  private buffer: string | null = null;
+  private templatesSubject = new BehaviorSubject<ComponentTemplate[]>(this.readTemplates());
+  templates$ = this.templatesSubject.asObservable();
+
+  constructor(
+    private elementService: ElementService,
+    private xamlParser: XamlParserService
+  ) {
+    this.buffer = this.readClipboard();
+  }
+
+  // --- Clipboard --------------------------------------------------------------
+
+  copy(elements: MauiElement[]): number {
+    const copyable = elements.filter(element => element.parent);
+    if (copyable.length === 0) {
+      return 0;
+    }
+    this.buffer = this.elementService.serializeElements(copyable);
+    this.writeClipboard(this.buffer);
+    return copyable.length;
+  }
+
+  cut(elements: MauiElement[]): number {
+    const count = this.copy(elements);
+    if (count > 0) {
+      this.elementService.removeSelectedElements();
+    }
+    return count;
+  }
+
+  hasContent(): boolean {
+    return !!this.buffer;
+  }
+
+  /** Pastes into the given parent, the selected layout, or the root. */
+  paste(parent?: MauiElement): MauiElement[] {
+    if (!this.buffer) {
+      return [];
+    }
+    return this.elementService.insertSerializedElements(this.buffer, parent || this.resolveTargetParent(), 16);
+  }
+
+  // --- Component templates ----------------------------------------------------
+
+  saveTemplate(name: string, elements: MauiElement[]): ComponentTemplate | null {
+    const savable = elements.filter(element => element.parent);
+    if (savable.length === 0 || !name.trim()) {
+      return null;
+    }
+
+    const template: ComponentTemplate = {
+      id: `template_${Date.now()}_${Math.round(Math.random() * 1000)}`,
+      name: name.trim(),
+      payload: this.elementService.serializeElements(savable),
+      createdAt: Date.now()
+    };
+
+    const templates = [...this.templatesSubject.value, template];
+    this.writeTemplates(templates);
+    return template;
+  }
+
+  deleteTemplate(id: string): void {
+    this.writeTemplates(this.templatesSubject.value.filter(template => template.id !== id));
+  }
+
+  getTemplates(): ComponentTemplate[] {
+    return this.templatesSubject.value;
+  }
+
+  insertTemplate(id: string, parent?: MauiElement): MauiElement[] {
+    const template = this.templatesSubject.value.find(candidate => candidate.id === id);
+    if (!template) {
+      return [];
+    }
+    return this.elementService.insertSerializedElements(template.payload, parent || this.resolveTargetParent(), 0);
+  }
+
+  // --- Starter pages ----------------------------------------------------------
+
+  get starterPages(): StarterPage[] {
+    return STARTER_PAGES;
+  }
+
+  /** Replaces the whole design with a starter page (undoable). */
+  applyStarterPage(id: string): boolean {
+    const page = STARTER_PAGES.find(candidate => candidate.id === id);
+    if (!page) {
+      return false;
+    }
+    try {
+      const root = this.xamlParser.parseXaml(page.xaml);
+      this.elementService.setRootElement(root);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // --- Internals --------------------------------------------------------------
+
+  private resolveTargetParent(): MauiElement {
+    const selected = this.elementService.getSelectedElement();
+    if (selected && this.canHaveChildren(selected.type)) {
+      return selected;
+    }
+    if (selected?.parent) {
+      return selected.parent;
+    }
+    return this.elementService.getRootElement();
+  }
+
+  private canHaveChildren(type: ElementType): boolean {
+    return [
+      ElementType.StackLayout,
+      ElementType.VerticalStackLayout,
+      ElementType.Grid,
+      ElementType.AbsoluteLayout,
+      ElementType.Frame,
+      ElementType.Border,
+      ElementType.ScrollView,
+      ElementType.CollectionView
+    ].includes(type);
+  }
+
+  private readTemplates(): ComponentTemplate[] {
+    try {
+      const stored = localStorage.getItem(ClipboardService.TEMPLATE_KEY);
+      const parsed = stored ? JSON.parse(stored) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeTemplates(templates: ComponentTemplate[]): void {
+    this.templatesSubject.next(templates);
+    try {
+      localStorage.setItem(ClipboardService.TEMPLATE_KEY, JSON.stringify(templates));
+    } catch {
+      // storage is optional
+    }
+  }
+
+  private readClipboard(): string | null {
+    try {
+      return localStorage.getItem(ClipboardService.CLIPBOARD_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  private writeClipboard(payload: string): void {
+    try {
+      localStorage.setItem(ClipboardService.CLIPBOARD_KEY, payload);
+    } catch {
+      // storage is optional
+    }
+  }
+}

--- a/src/app/services/drag-drop.ts
+++ b/src/app/services/drag-drop.ts
@@ -243,7 +243,9 @@ export class DragDropService {
       case ElementType.Grid:
       case ElementType.AbsoluteLayout:
       case ElementType.Frame:
+      case ElementType.Border:
       case ElementType.ScrollView:
+      case ElementType.CollectionView:
         return true;
       default:
         return false;

--- a/src/app/services/element.ts
+++ b/src/app/services/element.ts
@@ -7,12 +7,15 @@ import { BehaviorSubject, Observable } from 'rxjs';import { MauiElement, Element
 export class ElementService {
   private rootElement: MauiElement;
   private selectedElement: MauiElement | null = null;
+  private selectedElements: MauiElement[] = [];
   private elementCounter = 0;
 
   private selectedElementSubject = new BehaviorSubject<MauiElement | null>(null);
+  private selectedElementsSubject = new BehaviorSubject<MauiElement[]>([]);
   private elementsSubject: BehaviorSubject<MauiElement>;
 
   selectedElement$ = this.selectedElementSubject.asObservable();
+  selectedElements$ = this.selectedElementsSubject.asObservable();
   elements$: Observable<MauiElement>;
 
   // Undo / redo history of serialized snapshots
@@ -90,15 +93,84 @@ export class ElementService {
       case ElementType.Entry:
         return {
           ...common,
+          width: 200,
           text: '',
+          placeholder: 'Enter text',
           backgroundColor: '#ffffff',
           textColor: '#000000'
         };
       case ElementType.Editor:
         return {
           ...common,
+          width: 200,
           height: 100,
           text: '',
+          placeholder: 'Enter text',
+          backgroundColor: '#ffffff',
+          textColor: '#000000'
+        };
+      case ElementType.SearchBar:
+        return {
+          ...common,
+          width: 220,
+          height: 40,
+          placeholder: 'Search',
+          backgroundColor: '#ffffff',
+          textColor: '#000000'
+        };
+      case ElementType.CheckBox:
+        return {
+          ...common,
+          width: 40,
+          height: 40,
+          isChecked: false
+        };
+      case ElementType.Switch:
+        return {
+          ...common,
+          width: 60,
+          height: 32,
+          isToggled: false
+        };
+      case ElementType.Slider:
+        return {
+          ...common,
+          width: 200,
+          height: 32,
+          minimum: 0,
+          maximum: 100,
+          value: 50
+        };
+      case ElementType.Stepper:
+        return {
+          ...common,
+          width: 120,
+          height: 40,
+          minimum: 0,
+          maximum: 100,
+          increment: 1,
+          value: 0
+        };
+      case ElementType.ProgressBar:
+        return {
+          ...common,
+          width: 200,
+          height: 12,
+          progress: 0.5
+        };
+      case ElementType.ActivityIndicator:
+        return {
+          ...common,
+          width: 40,
+          height: 40,
+          isRunning: true
+        };
+      case ElementType.DatePicker:
+        return {
+          ...common,
+          width: 180,
+          height: 40,
+          date: new Date().toISOString().slice(0, 10),
           backgroundColor: '#ffffff',
           textColor: '#000000'
         };
@@ -152,6 +224,24 @@ export class ElementService {
           backgroundColor: '#f0f0f0',
           width: 150,
           height: 100
+        };
+      case ElementType.Border:
+        return {
+          ...common,
+          width: 150,
+          height: 100,
+          backgroundColor: '#ffffff',
+          borderColor: '#cccccc',
+          borderWidth: 1,
+          cornerRadius: 8
+        };
+      case ElementType.CollectionView:
+        return {
+          ...common,
+          width: 240,
+          height: 200,
+          itemCount: 3,
+          itemTemplateText: 'Item'
         };
       case ElementType.ScrollView:
         return {
@@ -243,9 +333,129 @@ export class ElementService {
     return clone;
   }
 
+  /** Serializes a set of elements (used by copy/paste and templates). */
+  serializeElements(elements: MauiElement[]): string {
+    return JSON.stringify(elements.map(element => ElementService.toPlainObject(element)));
+  }
+
+  /**
+   * Inserts previously serialized elements into a parent with fresh ids and
+   * names, as a single undo step. Returns the inserted elements.
+   */
+  insertSerializedElements(json: string, parent?: MauiElement, offset = 0): MauiElement[] {
+    let plain: any[];
+    try {
+      plain = JSON.parse(json);
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(plain) || plain.length === 0) {
+      return [];
+    }
+
+    const target = parent || this.rootElement;
+    const inserted: MauiElement[] = [];
+
+    this.runAsSingleChange(() => {
+      for (const item of plain) {
+        const element = ElementService.fromPlainObject(item, target);
+        this.assignFreshIds(element);
+        if (offset && target.type === ElementType.AbsoluteLayout) {
+          element.properties.x = (element.properties.x || 0) + offset;
+          element.properties.y = (element.properties.y || 0) + offset;
+        }
+        target.children.push(element);
+        inserted.push(element);
+      }
+    });
+
+    this.elementsSubject.next(this.rootElement);
+    this.setSelection(inserted);
+    return inserted;
+  }
+
+  private assignFreshIds(element: MauiElement): void {
+    this.elementCounter++;
+    const previousName = element.name;
+    element.id = `element_${this.elementCounter}`;
+    element.name = previousName && !/^element_\d+$/.test(previousName)
+      ? `${previousName}Copy${this.elementCounter}`
+      : `${element.type}${this.elementCounter}`;
+    element.domElement = undefined;
+    element.children.forEach(child => this.assignFreshIds(child));
+  }
+
   selectElement(element: MauiElement | null): void {
     this.selectedElement = element;
+    this.selectedElements = element ? [element] : [];
     this.selectedElementSubject.next(element);
+    this.selectedElementsSubject.next(this.selectedElements);
+  }
+
+  /** Replaces the whole selection. The last entry becomes the primary selection. */
+  setSelection(elements: MauiElement[]): void {
+    const unique = elements.filter((element, index) => elements.indexOf(element) === index);
+    this.selectedElements = unique;
+    this.selectedElement = unique.length ? unique[unique.length - 1] : null;
+    this.selectedElementSubject.next(this.selectedElement);
+    this.selectedElementsSubject.next(this.selectedElements);
+  }
+
+  /** Adds or removes an element from the selection (Ctrl/Shift click). */
+  toggleSelection(element: MauiElement): void {
+    const next = this.selectedElements.includes(element)
+      ? this.selectedElements.filter(candidate => candidate !== element)
+      : [...this.selectedElements, element];
+    this.setSelection(next);
+  }
+
+  isElementSelected(element: MauiElement): boolean {
+    return this.selectedElements.includes(element);
+  }
+
+  getSelectedElements(): MauiElement[] {
+    return [...this.selectedElements];
+  }
+
+  /** Deletes every selected element as a single undo step. */
+  removeSelectedElements(): void {
+    const targets = this.selectedElements.filter(element => element !== this.rootElement && element.parent);
+    if (targets.length === 0) {
+      return;
+    }
+    this.runAsSingleChange(() => {
+      targets.forEach(element => this.removeElement(element));
+    });
+    this.selectElement(null);
+  }
+
+  /** Applies the same property patch to several elements in one undo step. */
+  updateSelectionProperties(properties: Partial<ElementProperties>): void {
+    const targets = this.selectedElements;
+    if (targets.length === 0) {
+      return;
+    }
+    this.runAsSingleChange(() => {
+      targets.forEach(element =>
+        this.updateElementProperties(element, properties, { recordHistory: false })
+      );
+    });
+  }
+
+  /** Moves every selected element that lives in an AbsoluteLayout. */
+  nudgeSelection(deltaX: number, deltaY: number): void {
+    const targets = this.selectedElements.filter(element => element.parent?.type === ElementType.AbsoluteLayout);
+    if (targets.length === 0) {
+      return;
+    }
+    this.runAsSingleChange(() => {
+      targets.forEach(element =>
+        this.updateElementProperties(element, {
+          x: (element.properties.x || 0) + deltaX,
+          y: (element.properties.y || 0) + deltaY
+        }, { recordHistory: false })
+      );
+    });
   }
 
   updateElementProperties(element: MauiElement, properties: Partial<ElementProperties>, options: { recordHistory?: boolean } = {}): void {

--- a/src/app/services/viewport.service.spec.ts
+++ b/src/app/services/viewport.service.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { DEVICE_PRESETS, ViewportService } from './viewport';
+
+describe('ViewportService', () => {
+  let service: ViewportService;
+
+  beforeEach(() => {
+    localStorage.removeItem('maui-designer.viewport');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ViewportService);
+  });
+
+  afterEach(() => localStorage.removeItem('maui-designer.viewport'));
+
+  it('starts at 100% zoom with no pan', () => {
+    expect(service.state.zoom).toBe(1);
+    expect(service.state.panX).toBe(0);
+    expect(service.state.panY).toBe(0);
+  });
+
+  it('zooms in and out in 10% steps', () => {
+    service.zoomIn();
+    expect(service.state.zoom).toBeCloseTo(1.1, 5);
+
+    service.zoomOut();
+    expect(service.state.zoom).toBeCloseTo(1, 5);
+  });
+
+  it('clamps the zoom to the supported range', () => {
+    service.setZoom(99);
+    expect(service.state.zoom).toBe(3);
+
+    service.setZoom(0.01);
+    expect(service.state.zoom).toBe(0.25);
+  });
+
+  it('clamps the grid size', () => {
+    service.patch({ gridSize: 1 });
+    expect(service.state.gridSize).toBe(2);
+
+    service.patch({ gridSize: 5000 });
+    expect(service.state.gridSize).toBe(200);
+  });
+
+  it('fits the design into the viewport', () => {
+    service.zoomToFit(400, 600, 800, 600);
+    expect(service.state.zoom).toBe(0.5);
+    expect(service.state.panX).toBe(0);
+  });
+
+  it('ignores a fit request for an empty design', () => {
+    service.setZoom(2);
+    service.zoomToFit(400, 600, 0, 0);
+    expect(service.state.zoom).toBe(2);
+  });
+
+  it('accumulates pan offsets and resets them', () => {
+    service.panBy(10, -5);
+    service.panBy(4, 5);
+    expect(service.state.panX).toBe(14);
+    expect(service.state.panY).toBe(0);
+
+    service.resetView();
+    expect(service.state.panX).toBe(0);
+    expect(service.state.zoom).toBe(1);
+  });
+
+  it('toggles the preview flags', () => {
+    const { theme, snapToGrid, showGrid, showRulers } = service.state;
+
+    service.toggleTheme();
+    service.toggleSnap();
+    service.toggleGrid();
+    service.toggleRulers();
+
+    expect(service.state.theme).not.toBe(theme);
+    expect(service.state.snapToGrid).toBe(!snapToGrid);
+    expect(service.state.showGrid).toBe(!showGrid);
+    expect(service.state.showRulers).toBe(!showRulers);
+  });
+
+  it('exposes the device presets by id', () => {
+    expect(service.getDevice('tablet')!.width).toBe(768);
+    expect(service.getDevice('nope')).toBeUndefined();
+    expect(service.devices.length).toBe(DEVICE_PRESETS.length);
+  });
+
+  it('persists the state so a new instance restores it', () => {
+    service.setZoom(2);
+    service.toggleTheme();
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const restored = TestBed.inject(ViewportService);
+
+    expect(restored.state.zoom).toBe(2);
+    expect(restored.state.theme).toBe('dark');
+  });
+
+  it('publishes every change to subscribers', () => {
+    const seen: number[] = [];
+    const subscription = service.state$.subscribe(state => seen.push(state.zoom));
+
+    service.zoomIn();
+    service.zoomIn();
+    subscription.unsubscribe();
+
+    expect(seen.length).toBe(3);
+  });
+});

--- a/src/app/services/viewport.ts
+++ b/src/app/services/viewport.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface DevicePreset {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+}
+
+export type PreviewTheme = 'light' | 'dark';
+
+export interface ViewportState {
+  zoom: number;
+  panX: number;
+  panY: number;
+  snapToGrid: boolean;
+  gridSize: number;
+  showGrid: boolean;
+  showRulers: boolean;
+  showGuides: boolean;
+  theme: PreviewTheme;
+  deviceId: string;
+}
+
+export const DEVICE_PRESETS: DevicePreset[] = [
+  { id: 'phone', name: 'Phone (390 × 844)', width: 390, height: 844 },
+  { id: 'phone-small', name: 'Small phone (360 × 640)', width: 360, height: 640 },
+  { id: 'tablet', name: 'Tablet (768 × 1024)', width: 768, height: 1024 },
+  { id: 'desktop', name: 'Desktop (1280 × 800)', width: 1280, height: 800 },
+  { id: 'custom', name: 'Custom', width: 800, height: 600 }
+];
+
+const DEFAULT_STATE: ViewportState = {
+  zoom: 1,
+  panX: 0,
+  panY: 0,
+  snapToGrid: true,
+  gridSize: 8,
+  showGrid: false,
+  showRulers: true,
+  showGuides: true,
+  theme: 'light',
+  deviceId: 'custom'
+};
+
+/** Holds every "how the canvas is displayed" setting, persisted per browser. */
+@Injectable({ providedIn: 'root' })
+export class ViewportService {
+  private static readonly STORAGE_KEY = 'maui-designer.viewport';
+  private static readonly MIN_ZOOM = 0.25;
+  private static readonly MAX_ZOOM = 3;
+
+  readonly devices = DEVICE_PRESETS;
+
+  private stateSubject = new BehaviorSubject<ViewportState>({ ...DEFAULT_STATE, ...this.restore() });
+  state$ = this.stateSubject.asObservable();
+
+  get state(): ViewportState {
+    return this.stateSubject.value;
+  }
+
+  patch(patch: Partial<ViewportState>): void {
+    const next = { ...this.state, ...patch };
+    next.zoom = Math.min(ViewportService.MAX_ZOOM, Math.max(ViewportService.MIN_ZOOM, next.zoom));
+    next.gridSize = Math.min(200, Math.max(2, Math.round(next.gridSize)));
+    this.stateSubject.next(next);
+    this.persist(next);
+  }
+
+  zoomIn(): void {
+    this.patch({ zoom: this.roundZoom(this.state.zoom + 0.1) });
+  }
+
+  zoomOut(): void {
+    this.patch({ zoom: this.roundZoom(this.state.zoom - 0.1) });
+  }
+
+  setZoom(zoom: number): void {
+    this.patch({ zoom: this.roundZoom(zoom) });
+  }
+
+  /** Scales the design so it fits into the given viewport size. */
+  zoomToFit(viewportWidth: number, viewportHeight: number, designWidth: number, designHeight: number): void {
+    if (designWidth <= 0 || designHeight <= 0) {
+      return;
+    }
+    const scale = Math.min(viewportWidth / designWidth, viewportHeight / designHeight);
+    this.patch({ zoom: this.roundZoom(scale), panX: 0, panY: 0 });
+  }
+
+  resetView(): void {
+    this.patch({ zoom: 1, panX: 0, panY: 0 });
+  }
+
+  panBy(deltaX: number, deltaY: number): void {
+    this.patch({ panX: this.state.panX + deltaX, panY: this.state.panY + deltaY });
+  }
+
+  toggleTheme(): void {
+    this.patch({ theme: this.state.theme === 'light' ? 'dark' : 'light' });
+  }
+
+  toggleSnap(): void {
+    this.patch({ snapToGrid: !this.state.snapToGrid });
+  }
+
+  toggleGrid(): void {
+    this.patch({ showGrid: !this.state.showGrid });
+  }
+
+  toggleRulers(): void {
+    this.patch({ showRulers: !this.state.showRulers });
+  }
+
+  getDevice(id: string): DevicePreset | undefined {
+    return DEVICE_PRESETS.find(device => device.id === id);
+  }
+
+  private roundZoom(zoom: number): number {
+    return Math.round(zoom * 100) / 100;
+  }
+
+  private persist(state: ViewportState): void {
+    try {
+      localStorage.setItem(ViewportService.STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // storage is optional
+    }
+  }
+
+  private restore(): Partial<ViewportState> {
+    try {
+      const stored = localStorage.getItem(ViewportService.STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -38,13 +38,30 @@ ${xamlContent}
       xaml += this.generateGridDefinitions(element, indentLevel + 1);
     }
 
-    // Add children
-    for (const child of element.children) {
-      xaml += '\n' + this.generateElementXaml(child, indentLevel + 1);
+    // Add children (a CollectionView wraps them in a DataTemplate)
+    if (element.type === ElementType.CollectionView) {
+      xaml += this.generateItemTemplate(element, indentLevel + 1);
+    } else {
+      for (const child of element.children) {
+        xaml += '\n' + this.generateElementXaml(child, indentLevel + 1);
+      }
     }
 
     xaml += `\n${indent}</${elementName}>`;
 
+    return xaml;
+  }
+
+  private generateItemTemplate(element: MauiElement, indentLevel: number): string {
+    const indent = '    '.repeat(indentLevel + 1);
+    const inner = '    '.repeat(indentLevel + 2);
+    let xaml = `\n${indent}<CollectionView.ItemTemplate>`;
+    xaml += `\n${inner}<DataTemplate>`;
+    for (const child of element.children) {
+      xaml += '\n' + this.generateElementXaml(child, indentLevel + 2);
+    }
+    xaml += `\n${inner}</DataTemplate>`;
+    xaml += `\n${indent}</CollectionView.ItemTemplate>`;
     return xaml;
   }
 
@@ -84,6 +101,17 @@ ${xamlContent}
   private generateAttributes(element: MauiElement): string {
     const props = element.properties;
     const attributes: string[] = [];
+    const bindings = props.bindings || {};
+
+    /** A bound property wins over the literal designer value. */
+    const push = (name: string, value: string | number | undefined) => {
+      if (bindings[name]) {
+        return;
+      }
+      if (value !== undefined && value !== null && value !== '') {
+        attributes.push(`${name}="${value}"`);
+      }
+    };
     
     // Add name attribute
     if (element.name) {
@@ -122,13 +150,47 @@ ${xamlContent}
     }
     
     // Text content
-    if (props.text !== undefined) {
-      if (element.type === ElementType.Entry) {
-        // For Entry elements, use Placeholder attribute instead of Text
-        attributes.push(`Placeholder="${this.escapeXml(props.text)}"`);
-      } else {
-        attributes.push(`Text="${this.escapeXml(props.text)}"`);
+    if (props.text !== undefined && props.text !== '') {
+      push('Text', this.escapeXml(props.text));
+    }
+
+    if (props.placeholder) {
+      push('Placeholder', this.escapeXml(props.placeholder));
+    }
+
+    // Control state
+    if (props.isChecked !== undefined && element.type === ElementType.CheckBox) {
+      push('IsChecked', props.isChecked ? 'True' : 'False');
+    }
+    if (props.isToggled !== undefined && element.type === ElementType.Switch) {
+      push('IsToggled', props.isToggled ? 'True' : 'False');
+    }
+    if (element.type === ElementType.Slider || element.type === ElementType.Stepper) {
+      push('Minimum', props.minimum);
+      push('Maximum', props.maximum);
+      push('Value', props.value);
+      if (element.type === ElementType.Stepper) {
+        push('Increment', props.increment);
       }
+    }
+    if (element.type === ElementType.ProgressBar) {
+      push('Progress', props.progress);
+    }
+    if (element.type === ElementType.ActivityIndicator) {
+      push('IsRunning', props.isRunning === false ? 'False' : 'True');
+    }
+    if (element.type === ElementType.DatePicker && props.date) {
+      push('Date', props.date);
+    }
+    if (element.type === ElementType.Border) {
+      push('Stroke', props.borderColor);
+      push('StrokeThickness', props.borderWidth);
+      if (props.cornerRadius !== undefined) {
+        attributes.push(`StrokeShape="RoundRectangle ${props.cornerRadius}"`);
+      }
+    }
+    if (element.type === ElementType.Frame && props.cornerRadius !== undefined) {
+      push('CornerRadius', props.cornerRadius);
     }
 
     if (element.type === ElementType.Path) {
@@ -181,10 +243,10 @@ ${xamlContent}
     
     // Visibility and enabled state
     if (props.isVisible === false) {
-      attributes.push(`IsVisible="False"`);
+      push('IsVisible', 'False');
     }
     if (props.isEnabled === false) {
-      attributes.push(`IsEnabled="False"`);
+      push('IsEnabled', 'False');
     }
     
     // Layout specific attributes
@@ -203,6 +265,12 @@ ${xamlContent}
       }
     }
     
+    for (const [name, path] of Object.entries(bindings)) {
+      if (path) {
+        attributes.push(`${name}="{Binding ${this.escapeXml(path)}}"`);
+      }
+    }
+
     return attributes.length > 0 ? ' ' + attributes.join(' ') : '';
   }
 

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -67,6 +67,8 @@ export class XamlParserService {
            type === ElementType.StackLayout ||
            type === ElementType.VerticalStackLayout ||
            type === ElementType.Frame ||
+           type === ElementType.Border ||
+           type === ElementType.CollectionView ||
            type === ElementType.ScrollView;
   }
 
@@ -86,15 +88,7 @@ export class XamlParserService {
     };
 
     // Parse child elements
-    for (let i = 0; i < xmlElement.children.length; i++) {
-      const childXmlElement = xmlElement.children[i];
-
-      // Grid definitions are property elements, not children
-      if (childXmlElement.tagName.includes('.RowDefinitions') ||
-          childXmlElement.tagName.includes('.ColumnDefinitions')) {
-        continue;
-      }
-
+    for (const childXmlElement of this.getChildElements(xmlElement)) {
       const childElementType = this.getElementTypeFromTag(childXmlElement.tagName);
       if (childElementType) {
         const childElement = this.parseElement(childXmlElement, element);
@@ -107,6 +101,37 @@ export class XamlParserService {
     }
 
     return element;
+  }
+
+  /**
+   * Returns the real child views, skipping property elements such as
+   * Grid.RowDefinitions and unwrapping CollectionView.ItemTemplate/DataTemplate.
+   */
+  private getChildElements(xmlElement: Element): Element[] {
+    const children: Element[] = [];
+
+    for (let i = 0; i < xmlElement.children.length; i++) {
+      const child = xmlElement.children[i];
+      const tag = child.tagName;
+
+      if (tag.includes('.RowDefinitions') || tag.includes('.ColumnDefinitions')) {
+        continue;
+      }
+
+      if (tag.includes('.ItemTemplate') || tag.toLowerCase() === 'datatemplate') {
+        children.push(...this.getChildElements(child));
+        continue;
+      }
+
+      // Any other property element (Border.StrokeShape, Grid.Resources, ...)
+      if (tag.includes('.')) {
+        continue;
+      }
+
+      children.push(child);
+    }
+
+    return children;
   }
 
   private parseGridDefinition(gridXmlElement: Element): GridDefinition {
@@ -186,6 +211,26 @@ export class XamlParserService {
         return ElementType.Entry;
       case 'editor':
         return ElementType.Editor;
+      case 'searchbar':
+        return ElementType.SearchBar;
+      case 'checkbox':
+        return ElementType.CheckBox;
+      case 'switch':
+        return ElementType.Switch;
+      case 'slider':
+        return ElementType.Slider;
+      case 'stepper':
+        return ElementType.Stepper;
+      case 'progressbar':
+        return ElementType.ProgressBar;
+      case 'activityindicator':
+        return ElementType.ActivityIndicator;
+      case 'datepicker':
+        return ElementType.DatePicker;
+      case 'border':
+        return ElementType.Border;
+      case 'collectionview':
+        return ElementType.CollectionView;
       case 'image':
         return ElementType.Image;
       case 'path':
@@ -308,12 +353,66 @@ export class XamlParserService {
       isEnabled: true
     };
 
+    // Bindings are captured separately so they survive a round trip
+    const bindings = this.parseBindings(xmlElement);
+    if (Object.keys(bindings).length > 0) {
+      properties.bindings = bindings;
+    }
+
+    const literal = (name: string): string | null => {
+      const value = xmlElement.getAttribute(name);
+      return value === null || this.isBindingExpression(value) ? null : value;
+    };
+
     // Parse basic properties
-    const text = xmlElement.getAttribute('Text');
+    const text = literal('Text');
     if (text) properties.text = text;
 
-    const placeholder = xmlElement.getAttribute('Placeholder');
-    if (placeholder) properties.text = placeholder; // Entry placeholder becomes text property
+    const placeholder = literal('Placeholder');
+    if (placeholder) properties.placeholder = placeholder;
+
+    const isChecked = literal('IsChecked');
+    if (isChecked) properties.isChecked = isChecked.toLowerCase() === 'true';
+
+    const isToggled = literal('IsToggled');
+    if (isToggled) properties.isToggled = isToggled.toLowerCase() === 'true';
+
+    const minimum = literal('Minimum');
+    if (minimum) properties.minimum = parseFloat(minimum);
+
+    const maximum = literal('Maximum');
+    if (maximum) properties.maximum = parseFloat(maximum);
+
+    const increment = literal('Increment');
+    if (increment) properties.increment = parseFloat(increment);
+
+    const value = literal('Value');
+    if (value) properties.value = parseFloat(value);
+
+    const progress = literal('Progress');
+    if (progress) properties.progress = parseFloat(progress);
+
+    const isRunning = literal('IsRunning');
+    if (isRunning) properties.isRunning = isRunning.toLowerCase() === 'true';
+
+    const date = literal('Date');
+    if (date) properties.date = date;
+
+    const cornerRadius = literal('CornerRadius');
+    if (cornerRadius) properties.cornerRadius = parseFloat(cornerRadius);
+
+    const strokeShape = literal('StrokeShape');
+    if (strokeShape) {
+      const radius = parseFloat(strokeShape.replace(/[^0-9.]/g, ''));
+      if (!Number.isNaN(radius)) properties.cornerRadius = radius;
+    }
+
+    if (elementType === ElementType.Border) {
+      const borderColor = literal('Stroke');
+      if (borderColor) properties.borderColor = borderColor;
+      const borderWidth = literal('StrokeThickness');
+      if (borderWidth) properties.borderWidth = parseFloat(borderWidth);
+    }
 
     const pathData = xmlElement.getAttribute('Data');
     if (pathData) properties.pathData = pathData;
@@ -416,6 +515,25 @@ export class XamlParserService {
     return properties;
   }
 
+  private isBindingExpression(value: string): boolean {
+    return /^\s*\{\s*Binding\b/i.test(value);
+  }
+
+  /** Collects every attribute written as `{Binding Path}` into a map. */
+  private parseBindings(xmlElement: Element): Record<string, string> {
+    const bindings: Record<string, string> = {};
+    for (let i = 0; i < xmlElement.attributes.length; i++) {
+      const attribute = xmlElement.attributes[i];
+      if (!this.isBindingExpression(attribute.value)) {
+        continue;
+      }
+      const match = /\{\s*Binding\s+([^},]*)/i.exec(attribute.value);
+      const path = (match?.[1] || '').trim();
+      bindings[attribute.name] = path.replace(/^Path\s*=\s*/i, '');
+    }
+    return bindings;
+  }
+
   private parseThickness(value: string): Thickness {
     const values = value.split(',').map(v => parseFloat(v.trim()));
     if (values.length === 1) {
@@ -448,10 +566,54 @@ export class XamlParserService {
         if (properties.fontSize === undefined) properties.fontSize = 14;
         break;
       case ElementType.Entry:
-        if (properties.width === undefined) properties.width = 100;
-        if (properties.height === undefined) properties.height = 30;
+      case ElementType.SearchBar:
+        if (properties.width === undefined) properties.width = 200;
+        if (properties.height === undefined) properties.height = 40;
         if (properties.backgroundColor === undefined) properties.backgroundColor = '#ffffff';
         if (properties.textColor === undefined) properties.textColor = '#000000';
+        break;
+      case ElementType.CheckBox:
+        if (properties.width === undefined) properties.width = 40;
+        if (properties.height === undefined) properties.height = 40;
+        if (properties.isChecked === undefined) properties.isChecked = false;
+        break;
+      case ElementType.Switch:
+        if (properties.width === undefined) properties.width = 60;
+        if (properties.height === undefined) properties.height = 32;
+        if (properties.isToggled === undefined) properties.isToggled = false;
+        break;
+      case ElementType.Slider:
+      case ElementType.Stepper:
+        if (properties.width === undefined) properties.width = 200;
+        if (properties.height === undefined) properties.height = 32;
+        if (properties.minimum === undefined) properties.minimum = 0;
+        if (properties.maximum === undefined) properties.maximum = 100;
+        if (properties.value === undefined) properties.value = 0;
+        break;
+      case ElementType.ProgressBar:
+        if (properties.width === undefined) properties.width = 200;
+        if (properties.height === undefined) properties.height = 12;
+        if (properties.progress === undefined) properties.progress = 0;
+        break;
+      case ElementType.ActivityIndicator:
+        if (properties.width === undefined) properties.width = 40;
+        if (properties.height === undefined) properties.height = 40;
+        if (properties.isRunning === undefined) properties.isRunning = true;
+        break;
+      case ElementType.DatePicker:
+        if (properties.width === undefined) properties.width = 180;
+        if (properties.height === undefined) properties.height = 40;
+        break;
+      case ElementType.Border:
+        if (properties.width === undefined) properties.width = 150;
+        if (properties.height === undefined) properties.height = 100;
+        if (properties.borderColor === undefined) properties.borderColor = '#cccccc';
+        if (properties.borderWidth === undefined) properties.borderWidth = 1;
+        break;
+      case ElementType.CollectionView:
+        if (properties.width === undefined) properties.width = 240;
+        if (properties.height === undefined) properties.height = 200;
+        if (properties.itemCount === undefined) properties.itemCount = 3;
         break;
       case ElementType.Editor:
         if (properties.width === undefined) properties.width = 100;


### PR DESCRIPTION
Builds on #86 with five new feature areas, all client-side so the GitHub Pages build keeps working.

## 1. Richer controls + data binding
- New controls: `SearchBar`, `CheckBox`, `Switch`, `Slider`, `Stepper`, `ProgressBar`, `ActivityIndicator`, `DatePicker`, `Border`, `CollectionView` — each with a canvas preview, property editors and XAML generation/parsing.
- `Entry`/`Editor` now have a real `Placeholder` distinct from `Text`.
- **Data bindings**: bind any supported property to a view-model path; the generator emits `{Binding Path}` instead of the literal value, and the parser reads them back.
- `CollectionView` children round-trip through `CollectionView.ItemTemplate` / `DataTemplate`.

## 2. Multi-selection
- Shift/Ctrl-click toggling, marquee (rubber-band) selection, `Ctrl+A`.
- Multi-selection properties panel: shared width/height/background/visibility, bulk delete/duplicate, align buttons.
- Every bulk operation is one undo step.

## 3. Alignment & layout tools
- `AlignmentService`: align left/centre/right/top/middle/bottom, distribute horizontally/vertically, snap-to-grid, and smart guides against sibling and page edges/centres.
- Optional rulers and a configurable grid overlay.

## 4. Clipboard, templates & starter pages
- `Ctrl+C` / `Ctrl+X` / `Ctrl+V` (plus toolbar buttons): containers keep their children, ids and names stay unique, paste is offset and undoable.
- Save any selection as a reusable component template (persisted in `localStorage`), insert or delete it from the toolbox.
- Four starter pages: login, list, profile, settings.

## 5. Live preview
- Device presets (phone, small phone, tablet, desktop, custom) that actually resize the design surface (undoable, reflected in XAML).
- Zoom via toolbar, `Ctrl`+wheel and fit-to-window; pan with `Space`+drag or middle-drag; dark preview theme; all viewport settings persisted.

## Fixes found while testing
- A marquee started on the root layout re-selected the root on mouse-up, wiping the new selection.

## Testing
- `npm run e2e`: **120 passed** (53 existing + 67 new across `controls`, `multi-select`, `alignment`, `clipboard`, `viewport`).
- `npm run test:headless`: **86 passed**, including new unit specs for `AlignmentService`, `ViewportService` and `ClipboardService`.
- `npm run build`: clean production build.

## Docs
- README and `.github/copilot-instructions.md` cover the new features, keyboard shortcuts and the polling helpers required for RxJS-driven assertions.
