### PR TITLE
Support custom UI controls from NuGet packages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,9 +94,24 @@ Always reference these instructions first and fallback to search or bash command
   - **alignment.ts**: Align, distribute, snap-to-grid and smart guides
   - **viewport.ts**: Zoom, pan, device preset, theme and grid state (persisted in localStorage)
   - **clipboard.ts**: Copy/cut/paste, component templates and starter pages
+  - **custom-control-registry.ts**: Third-party (NuGet) control manifests — import/export, persistence, lookup, learning from XAML, preview interpolation
 - **src/app/models/**: Data models and interfaces
   - **maui-element.ts**: MAUI element definitions
   - **toolbox.ts**: Toolbox item definitions
+  - **custom-control.ts**: Custom control manifest schema plus the bundled CommunityToolkit.Maui pack
+
+### Custom Controls
+Third-party controls are **data, not code**. A JSON manifest (see `src/app/models/custom-control.ts`)
+drives the toolbox entry, the properties panel editors, the canvas preview and XAML generation.
+- Element identity is `prefix:Tag`; the namespace URI is stored on the element (`customNamespace`)
+  so generated XAML stays valid even if the manifest is removed.
+- `xaml-parser.ts` never throws on an unknown tag: it falls back to `ElementType.Custom`, learns the
+  control into the registry, splits attributes into manifest-declared `customValues` and
+  `rawAttributes`, and preserves property elements verbatim in `rawContentXml`.
+- `xaml-generator.ts` emits only the namespaces actually used and de-duplicates attributes
+  (first writer wins) so custom values are never emitted twice.
+- When adding a bundled pack, extend `BUNDLED_MANIFESTS`; bundled manifests are always re-merged
+  when the registry is restored from localStorage.
 
 ### Common Commands Reference
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,7 @@ Always reference these instructions first and fallback to search or bash command
 - **Build Tests**: `ng build` -- verifies TypeScript compilation and bundling
 - **E2E Tests**: `npm run e2e` -- headless Playwright suite in `e2e/`; it boots `ng serve` on port 4300 automatically. Run `npx playwright install chromium` once first. Use `E2E_BASE_URL` to target an existing server.
 - **Test hooks**: components expose `data-testid` attributes consumed by `e2e/helpers/designer-page.ts`. Preserve them when editing templates.
+- **Extension tests**: `dotnet test extension/MauiDesigner.Core.sln` -- xUnit suite for the Visual Studio extension's cross-platform core. It runs on any OS; the VSIX itself needs Windows and the VS SDK.
 - **Polling helpers**: the XAML pane and the properties panel re-render from RxJS streams, so assert with `expectXamlToContain`, `xamlWhen`, `expectProperty` or `expectPropertyNumber` instead of one-shot reads, otherwise the tests flake on CI.
 - **Canvas coordinates**: the canvas sits inside a zoomable wrapper - convert client coordinates with `toCanvasPoint` (divide by `viewport.zoom`) in components, and avoid canvas x > ~400 in tests because the right panel overlaps it.
 - **Linting**: Use `ng lint` if ESLint is configured, or standard TypeScript compiler checks
@@ -138,7 +139,8 @@ typescript (5.5.4)
 - **Hot reloading**: Development server auto-reloads on file changes
 - **Keyboard shortcuts**: `Ctrl+Z`/`Ctrl+Y` undo-redo, `Ctrl+C`/`Ctrl+X`/`Ctrl+V` clipboard, `Ctrl+A` select all, `Ctrl+D` duplicate, `Delete` remove, arrow keys nudge, `Space`+drag or middle-drag to pan, `Ctrl`+wheel to zoom
 - **Bulk operations**: wrap multi-element changes in `elementService.runAsSingleChange()` with `{ recordHistory: false }` updates so they undo as one step
-- **CI/CD**: `.github/workflows/ci.yml` builds and runs unit + e2e tests; `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages on pushes to `main`
+- **IDE hosting**: `src/app/services/host-bridge.ts` detects Visual Studio (`window.chrome.webview`) or VS Code (`acquireVsCodeApi`). When hosted, the open document replaces browser storage as the source of truth -- `App.connectToHost()` applies `document.load`, streams `document.changed` and routes save to the host. Changing a message name means changing `extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs` too.
+- **CI/CD**: `.github/workflows/ci.yml` builds and runs unit + e2e tests plus the extension's `dotnet test`; `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages on pushes to `main`
 
 ## Troubleshooting
 - **Build fails with module not found**: Run `npm install` to ensure all dependencies are installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,18 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  extension-core:
+    name: Visual Studio extension (core library)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # Only the cross-platform half is built here; the VSIX itself needs
+      # Windows and the Visual Studio SDK. See extension/README.md.
+      - name: Test
+        run: dotnet test extension/MauiDesigner.Core.sln --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ Thumbs.db
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# .NET (extension/)
+[Bb]in/
+[Oo]bj/
+*.user
+*.vsix
+.vs/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Dark Mode Preview**: Toggle a dark canvas to check contrast
 - **Persisted View**: Zoom, theme and grid settings survive a reload
 
+### Custom Controls from NuGet Packages
+- **Manifest Registry**: Describe third-party controls (Syncfusion, Telerik, DevExpress, in-house libraries) in a small JSON manifest and they appear in the toolbox, properties panel and canvas
+- **Bundled CommunityToolkit.Maui Pack**: `AvatarView`, `Expander`, `DrawingView`, `MediaElement`, `Popup` and `SemanticOrderView` work out of the box
+- **Import & Export**: Load manifests from disk, export the whole registry as one JSON file, remove packs you no longer need
+- **Lossless Round-Trip**: Unknown vendor tags in imported XAML are preserved verbatim — namespaces, attributes, property elements and nested children all survive a parse/generate cycle
+- **Learning Parser**: Controls that are not in any manifest are inferred from the XAML (including property types) and added to the toolbox automatically
+- **Raw Attribute Editor**: Any attribute the manifest does not declare is still editable in the properties panel
+
 ### XAML Integration
 - **XAML Editor**: Full-featured code editor with syntax support
 - **Real-time Preview**: Instant visual updates when applying XAML changes
@@ -217,6 +225,57 @@ The Properties panel allows you to modify:
 - View the complete element structure
 - Select elements for editing
 - Navigate complex layouts easily
+
+### 6. Custom Controls from NuGet Packages
+
+The designer does not need to reference your NuGet package — it only needs a description of the
+controls. Drop a JSON manifest into **Toolbox → Custom controls → Import**:
+
+```json
+{
+  "id": "syncfusion-inputs",
+  "package": "Syncfusion.Maui.Inputs",
+  "xmlns": {
+    "prefix": "sf",
+    "uri": "clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"
+  },
+  "controls": [
+    {
+      "tag": "SfComboBox",
+      "displayName": "Combo box",
+      "icon": "arrow_drop_down_circle",
+      "defaultWidth": 200,
+      "defaultHeight": 40,
+      "isContainer": false,
+      "preview": { "kind": "box", "label": "{Placeholder}" },
+      "properties": [
+        { "name": "Placeholder", "type": "string", "defaultValue": "Select an item" },
+        { "name": "IsEditable", "type": "boolean", "defaultValue": false },
+        { "name": "MaxDropDownHeight", "type": "number", "defaultValue": 200 }
+      ]
+    }
+  ]
+}
+```
+
+Manifest reference:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable identifier used for updates and removal |
+| `package` | NuGet package name, shown in the toolbox and properties panel |
+| `xmlns.prefix` / `xmlns.uri` | XML namespace emitted in the generated XAML |
+| `controls[].tag` | The XAML tag, e.g. `SfComboBox` |
+| `controls[].isContainer` | `true` if the control accepts child elements |
+| `controls[].preview` | Canvas rendering: `kind` of `box`, `text`, `image`, `list` or `slot`, plus `label`, `backgroundColor`, `textColor`, `borderColor`, `cornerRadius`, `icon` |
+| `controls[].properties[]` | Editable properties: `name`, `type` (`string`, `number`, `boolean`, `color`, `enum`), `defaultValue`, `options`, `bindable` |
+
+`{Property}` placeholders inside `preview.label` and the colour fields are interpolated from the
+element's current values, so the canvas preview updates as you edit.
+
+Registered manifests are stored in `localStorage` under `maui-designer.custom-controls`. The
+namespace URI is also stored on each element, so pasted XAML keeps working even if the manifest is
+removed later.
 
 ## 🏗️ Project Structure
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,13 @@ We welcome contributions! Please follow these steps:
 - Some advanced XAML features are not yet supported
 - Complex nested layouts may require manual XAML adjustments
 
+## 🧩 IDE Integration
+
+Curious whether this designer can live inside Visual Studio? See
+[docs/visual-studio-extension.md](docs/visual-studio-extension.md) for a feasibility assessment of a
+VS 2022 VSIX (WebView2 + custom `.xaml` editor + NuGet-derived control manifests) and a VS Code
+webview extension.
+
 ## 📚 Resources
 
 - [MAUI Documentation](https://docs.microsoft.com/en-us/dotnet/maui/)

--- a/README.md
+++ b/README.md
@@ -385,10 +385,19 @@ We welcome contributions! Please follow these steps:
 
 ## 🧩 IDE Integration
 
-Curious whether this designer can live inside Visual Studio? See
-[docs/visual-studio-extension.md](docs/visual-studio-extension.md) for a feasibility assessment of a
-VS 2022 VSIX (WebView2 + custom `.xaml` editor + NuGet-derived control manifests) and a VS Code
-webview extension.
+The designer also runs **inside Visual Studio 2022**. [`extension/`](extension/README.md) contains a
+VSIX that registers the designer as an alternative editor for `.xaml` files: it edits the same text
+buffer as the built-in XAML editor (so undo, the dirty marker and Ctrl+S all behave normally), and it
+generates toolbox entries from the controls in the project's own NuGet packages by inspecting
+`obj/project.assets.json` and the package assemblies.
+
+- [`extension/README.md`](extension/README.md) — how to build, test and debug the VSIX
+- [`docs/visual-studio-extension.md`](docs/visual-studio-extension.md) — the design rationale, and
+  why the classic in-process VSSDK model is required
+
+The web app detects its host at runtime (`src/app/services/host-bridge.ts`). In a plain browser
+nothing changes; inside an IDE the open document becomes the source of truth instead of browser
+storage.
 
 ## 📚 Resources
 

--- a/docs/visual-studio-extension.md
+++ b/docs/visual-studio-extension.md
@@ -1,0 +1,122 @@
+# Converting MAUI Designer into a Visual Studio extension
+
+*Feasibility assessment — verified against Microsoft Learn, WebView2 and VS Code extension docs.*
+
+## Short answer
+
+**Yes, and it fills a real gap.** Visual Studio 2022 has **no drag-and-drop XAML designer for .NET MAUI**,
+and Microsoft has stated a drag-and-drop UI designer "is not part of our direction for .NET MAUI"
+([Developer Community](https://developercommunity.visualstudio.com/t/XAML-Designer-for-Net-MAUI/10224319)).
+What ships instead is XAML Hot Reload and XAML Live Preview (design-time Live Preview arrived in
+17.14) — read-only mirrors of a running app, not layout editing.
+
+Two hosting routes are viable today. Both reuse this Angular app essentially unchanged, because the
+designer core (parser, generator, element/alignment/clipboard services, custom-control registry) is
+pure TypeScript with no server dependency.
+
+| Route | Feasible today | Rough effort | Trade-off |
+| --- | --- | --- | --- |
+| **VS Code extension** — `CustomTextEditorProvider` + webview | ✅ | ~10–15 dev-days | Cross-platform, simple file APIs; .NET type introspection is awkward from Node |
+| **VS 2022 VSIX** — classic VSSDK + WebView2 + `IVsEditorFactory` | ✅ | ~18–28 dev-days | Deepest integration and real NuGet/type discovery; COM-heavy, Windows-only |
+| **VisualStudio.Extensibility (out-of-process)** | ❌ | — | Remote UI is WPF-XAML-over-RPC with no WebView2, and custom document editors are not supported out-of-process yet |
+
+Recommended sequencing: **ship the VS Code extension first, then the VS 2022 VSIX** on the same
+Angular core.
+
+## Route A — VS 2022 VSIX
+
+### Hosting the app
+Only the **classic in-process VSSDK** model can host web content. A WPF `UserControl` containing
+`Microsoft.Web.WebView2.Wpf.WebView2` is placed in a `ToolWindowPane` (or an editor pane).
+
+```csharp
+var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
+await webView.EnsureCoreWebView2Async(env);          // never set Source/CreationProperties in XAML
+webView.CoreWebView2.SetVirtualHostNameToFolderMapping(
+    "maui-designer.local", Path.Combine(installDir, "WebApp"),
+    CoreWebView2HostResourceAccessKind.Allow);
+webView.CoreWebView2.Navigate("https://maui-designer.local/index.html");
+```
+
+`SetVirtualHostNameToFolderMapping` is the right way to serve the Angular `dist/` folder — `file://`
+is blocked, and a local HTTP server is unnecessary. Ship `dist/` as VSIX `Content`.
+
+### Editing real `.xaml` files
+- `IVsEditorFactory.CreateEditorInstance` + `IVsPersistDocData` + `IVsWindowPane` register a designer
+  view for `.xaml`.
+- `[ProvideEditorExtension(..., ".xaml", priority)]` with a **lower priority than the built-in XAML
+  editor** so the designer shows up under *Open With* instead of hijacking the default.
+- Sharing the `VsTextBuffer` with the text editor gives the classic *Design | XAML* split view.
+
+### NuGet-aware custom controls
+This is where a VS extension beats the web app: the current JSON manifests could be **generated
+automatically** from the project.
+
+1. Read `PackageReference` items from the `.csproj`, or use `IVsPackageInstallerServices`.
+2. Resolve each package to its DLLs via `obj/project.assets.json`.
+3. Enumerate types with `System.Reflection.MetadataLoadContext` (load-only, no execution) or the
+   Roslyn `VisualStudioWorkspace` compilation; keep types deriving from
+   `Microsoft.Maui.Controls.View` and their static `BindableProperty` fields.
+4. Emit the same manifest schema the designer already consumes and push it into the webview.
+
+The manifest format documented in the README is deliberately the contract for exactly this.
+
+### Main risks
+- Synchronising three states — the Angular canvas, the `IVsTextBuffer`, and VS's own undo stack — is
+  the hardest problem; the app's undo history is independent of VS's.
+- WPF "airspace" glitches when VS popups overlap WebView2 (mitigate with `WebView2CompositionControl`).
+- The WebView2 Runtime must be present (ships with Windows 11/Edge, not guaranteed on locked-down machines).
+- Classic VSSDK is maintained but is not where Microsoft is investing; the modern out-of-process
+  model cannot host this app yet.
+
+## Route B — VS Code extension
+
+Register a custom editor for `.xaml` with `"priority": "option"` and host the same bundle in a webview:
+
+```jsonc
+"contributes": {
+  "customEditors": [{
+    "viewType": "mauiDesigner.xamlEditor",
+    "displayName": "MAUI Designer",
+    "selector": [{ "filenamePattern": "*.xaml" }],
+    "priority": "option"
+  }]
+}
+```
+
+XAML flows in via `webview.postMessage` and back via `acquireVsCodeApi().postMessage`, with the
+extension applying a `WorkspaceEdit` to the `TextDocument`.
+
+Constraints:
+- VS Code enforces a strict CSP, so `index.html` must be templated to add a `nonce` to every
+  `<script>` (Angular 16+ also supports `ngCspNonce`).
+- The extension host is Node.js, so .NET reflection is not directly available. Control metadata must
+  come from a spawned .NET helper, a pre-generated manifest, or the Roslyn language server.
+
+## What changes in this repository
+
+Reusable unchanged: `xaml-parser.ts`, `xaml-generator.ts`, `element.ts`, `alignment.ts`,
+`clipboard.ts`, `drag-drop.ts`, `layout-designer.ts`, `custom-control-registry.ts`, and every
+component template.
+
+Needs work:
+
+| Area | Change |
+| --- | --- |
+| New `host-bridge.service.ts` | ~50 lines abstracting `chrome.webview.postMessage` (VS) vs `acquireVsCodeApi()` (VS Code) vs standalone browser |
+| Save/load | Route through the host bridge instead of `localStorage` and browser download/upload |
+| Custom control registry | Accept manifests pushed by the host (generated from `PackageReference`s) alongside imported and bundled ones |
+| `angular.json` | Use a relative `baseHref` (`./`) so the bundle works under a virtual host |
+| `index.html` | VS Code only: nonce injection point |
+
+A separate companion repository is the cleanest home for the C#/TypeScript host, consuming this
+project's `dist/` output as a build artifact.
+
+## Key references
+
+- [Out-of-process extensibility model overview](https://learn.microsoft.com/en-us/visualstudio/extensibility/visualstudio.extensibility/get-started/oop-extensibility-model-overview?view=visualstudio) and [Remote UI](https://learn.microsoft.com/en-us/visualstudio/extensibility/visualstudio.extensibility/inside-the-sdk/remote-ui?view=visualstudio)
+- [Creating custom editors and designers](https://learn.microsoft.com/en-us/visualstudio/extensibility/creating-custom-editors-and-designers?view=visualstudio), [Supporting multiple document views](https://learn.microsoft.com/en-us/visualstudio/extensibility/supporting-multiple-document-views?view=visualstudio)
+- [WebView2 in WPF](https://learn.microsoft.com/en-us/microsoft-edge/webview2/get-started/wpf), [`SetVirtualHostNameToFolderMapping`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.setvirtualhostnametofoldermapping)
+- [NuGet API in Visual Studio](https://learn.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio), [MetadataLoadContext](https://learn.microsoft.com/en-us/dotnet/standard/assembly/inspect-contents-using-metadataloadcontext)
+- [VS Code custom editors](https://code.visualstudio.com/api/extension-guides/custom-editors) and [webviews](https://code.visualstudio.com/api/extension-guides/webview)
+- [XAML Live Preview enhancements for .NET MAUI](https://devblogs.microsoft.com/visualstudio/enhancements-to-xaml-live-preview-in-visual-studio-for-net-maui/)

--- a/docs/visual-studio-extension.md
+++ b/docs/visual-studio-extension.md
@@ -1,6 +1,10 @@
 # Converting MAUI Designer into a Visual Studio extension
 
-*Feasibility assessment — verified against Microsoft Learn, WebView2 and VS Code extension docs.*
+*Design rationale — verified against Microsoft Learn, WebView2 and VS Code extension docs.*
+
+> **Status: Route A is implemented.** The VSIX and its cross-platform core library live in
+> [`extension/`](../extension/README.md); this document explains why it is built the way it is, and
+> what the alternatives were. Route B (VS Code) is still open.
 
 ## Short answer
 

--- a/e2e/clipboard.spec.ts
+++ b/e2e/clipboard.spec.ts
@@ -142,7 +142,8 @@ test.describe('Clipboard, templates and starter pages', () => {
       await page.getByTestId(`starter-${starter}`).click();
 
       await expect(designer.canvasElements().first()).toBeVisible();
-      expect(await designer.canvasElements().count()).toBeGreaterThan(2);
+      // The tree renders from an observable, so poll instead of taking a one-shot count
+      await expect.poll(() => designer.canvasElements().count()).toBeGreaterThan(2);
       await designer.expectXamlToContain('<ContentPage');
     });
   }

--- a/e2e/custom-controls.spec.ts
+++ b/e2e/custom-controls.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+const SYNCFUSION_MANIFEST = JSON.stringify({
+  id: 'syncfusion-inputs',
+  package: 'Syncfusion.Maui.Inputs',
+  xmlns: { prefix: 'sf', uri: 'clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs' },
+  controls: [
+    {
+      tag: 'SfComboBox',
+      displayName: 'Combo box',
+      icon: 'arrow_drop_down_circle',
+      defaultWidth: 200,
+      defaultHeight: 40,
+      preview: { kind: 'box', label: '{Placeholder}' },
+      properties: [
+        { name: 'Placeholder', type: 'string', defaultValue: 'Select an item' },
+        { name: 'IsEditable', type: 'boolean', defaultValue: false },
+        { name: 'MaxDropDownHeight', type: 'number', defaultValue: 200 }
+      ]
+    }
+  ]
+});
+
+const THIRD_PARTY_XAML = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:telerik="clr-namespace:Telerik.Maui.Controls;assembly=Telerik.Maui.Controls"
+             x:Class="YourApp.MainPage">
+    <AbsoluteLayout x:Name="RootLayout" WidthRequest="800" HeightRequest="600">
+        <telerik:RadCalendar x:Name="Calendar" SelectionMode="Single" DayCellHeight="32"
+                             AbsoluteLayout.LayoutBounds="20,20,280,240" WidthRequest="280" HeightRequest="240" />
+    </AbsoluteLayout>
+</ContentPage>`;
+
+test.describe('Custom controls from NuGet packages', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    await page.reload();
+    await expect(designer.canvas).toBeVisible();
+  });
+
+  test('the bundled CommunityToolkit controls are in the toolbox', async ({ page }) => {
+    await designer.openToolbox();
+
+    await expect(page.getByTestId('custom-controls-section')).toBeVisible();
+    await expect(page.getByTestId('custom-item-toolkit-AvatarView')).toBeVisible();
+    await expect(page.getByTestId('custom-item-toolkit-Expander')).toBeVisible();
+  });
+
+  test('adding a custom control generates the prefixed tag and its namespace', async () => {
+    await designer.addCustomControl('toolkit', 'AvatarView');
+
+    await designer.expectXamlToContain(
+      'xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"',
+      '<toolkit:AvatarView',
+      'Text="AB"',
+      'CornerRadius="24"'
+    );
+  });
+
+  test('the canvas renders a preview for the custom control', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'AvatarView');
+
+    const preview = page.locator('[data-custom-tag="AvatarView"]');
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText('AB');
+  });
+
+  test('manifest properties are editable in the properties panel', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'AvatarView');
+
+    await expect(page.getByTestId('custom-section')).toBeVisible();
+    await expect(page.getByTestId('custom-package')).toHaveText('CommunityToolkit.Maui');
+
+    const text = page.getByTestId('custom-Text');
+    await text.fill('MP');
+    await text.dispatchEvent('input');
+
+    await designer.expectXamlToContain('Text="MP"');
+    await expect(page.locator('[data-custom-preview="AvatarView"]')).toHaveText('MP');
+  });
+
+  test('boolean and enum manifest properties generate XAML', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'MediaElement');
+
+    await page.getByTestId('custom-ShouldAutoPlay').check();
+    await page.getByTestId('custom-Aspect').selectOption('AspectFill');
+
+    await designer.expectXamlToContain('ShouldAutoPlay="True"', 'Aspect="AspectFill"');
+  });
+
+  test('a custom control can be bound to a view model path', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'AvatarView');
+
+    const binding = page.getByTestId('binding-Text');
+    await binding.fill('User.Initials');
+    await binding.dispatchEvent('input');
+
+    await designer.expectXamlToContain('Text="{Binding User.Initials}"');
+    const xaml = await designer.getXaml();
+    expect(xaml).not.toContain('Text="AB"');
+  });
+
+  test('a custom container accepts child controls', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'Expander');
+    await designer.addControl('Label');
+
+    const xaml = await designer.xamlWhen(value => value.includes('</toolkit:Expander>'));
+    expect(xaml).toMatch(/<toolkit:Expander[\s\S]*<Label[\s\S]*<\/toolkit:Expander>/);
+  });
+
+  test('imported XAML keeps unknown third party controls', async ({ page }) => {
+    await designer.applyXaml(THIRD_PARTY_XAML);
+
+    await expect(page.locator('[data-custom-tag="RadCalendar"]')).toBeVisible();
+    await designer.expectXamlToContain(
+      'xmlns:telerik="clr-namespace:Telerik.Maui.Controls;assembly=Telerik.Maui.Controls"',
+      '<telerik:RadCalendar',
+      'SelectionMode="Single"',
+      'DayCellHeight="32"'
+    );
+  });
+
+  test('controls learned from XAML become available in the toolbox', async ({ page }) => {
+    await designer.applyXaml(THIRD_PARTY_XAML);
+    await designer.openToolbox();
+
+    await expect(page.getByTestId('custom-item-telerik-RadCalendar')).toBeVisible();
+
+    await page.getByTestId('custom-item-telerik-RadCalendar').click();
+    await expect(page.locator('[data-custom-tag="RadCalendar"]')).toHaveCount(2);
+  });
+
+  test('a learned control keeps its attributes editable', async ({ page }) => {
+    await designer.applyXaml(THIRD_PARTY_XAML);
+    await page.locator('[data-custom-tag="RadCalendar"]').click({ position: { x: 6, y: 6 } });
+
+    const mode = page.getByTestId('custom-SelectionMode');
+    await mode.fill('Multiple');
+    await mode.dispatchEvent('input');
+
+    await designer.expectXamlToContain('SelectionMode="Multiple"');
+  });
+
+  test('a manifest can be imported from a JSON file', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('manifest-file').setInputFiles({
+      name: 'syncfusion.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(SYNCFUSION_MANIFEST)
+    });
+
+    const item = page.getByTestId('custom-item-sf-SfComboBox');
+    await expect(item).toBeVisible();
+
+    await item.click();
+    await designer.expectXamlToContain(
+      'xmlns:sf="clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"',
+      '<sf:SfComboBox',
+      'Placeholder="Select an item"'
+    );
+  });
+
+  test('an invalid manifest reports an error', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('manifest-file').setInputFiles({
+      name: 'broken.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from('{"package":"Broken"}')
+    });
+
+    await expect(page.getByTestId('manifest-error')).toBeVisible();
+  });
+
+  test('an imported manifest survives a reload and can be removed', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('manifest-file').setInputFiles({
+      name: 'syncfusion.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(SYNCFUSION_MANIFEST)
+    });
+    await expect(page.getByTestId('custom-item-sf-SfComboBox')).toBeVisible();
+
+    await page.reload();
+    await designer.openToolbox();
+    await expect(page.getByTestId('custom-item-sf-SfComboBox')).toBeVisible();
+
+    await page.getByTestId('manifest-remove-syncfusion-inputs').click();
+    await expect(page.getByTestId('custom-item-sf-SfComboBox')).toHaveCount(0);
+  });
+
+  test('the registry can be exported as JSON', async ({ page }) => {
+    await designer.openToolbox();
+
+    const download = page.waitForEvent('download');
+    await page.getByTestId('export-manifests').click();
+    const file = await download;
+
+    expect(file.suggestedFilename()).toBe('maui-designer-controls.json');
+  });
+
+  test('custom controls can be searched in the toolbox', async ({ page }) => {
+    await designer.openToolbox();
+    await designer.toolboxSearch.fill('avatar');
+
+    await expect(page.getByTestId('custom-item-toolkit-AvatarView')).toBeVisible();
+    await expect(page.getByTestId('custom-item-toolkit-Expander')).toHaveCount(0);
+    await expect(page.getByTestId('toolbox-empty')).toHaveCount(0);
+  });
+
+  test('a custom control participates in copy, paste and undo', async ({ page }) => {
+    await designer.addCustomControl('toolkit', 'AvatarView');
+    await page.locator('[data-custom-tag="AvatarView"]').click({ position: { x: 4, y: 4 } });
+
+    await page.keyboard.press('Control+c');
+    await page.keyboard.press('Control+v');
+    await expect(page.locator('[data-custom-tag="AvatarView"]')).toHaveCount(2);
+
+    await designer.undoButton.click();
+    await expect(page.locator('[data-custom-tag="AvatarView"]')).toHaveCount(1);
+  });
+});

--- a/e2e/element-move.spec.ts
+++ b/e2e/element-move.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+/**
+ * Regression coverage for dragging elements that already live on the canvas.
+ * The drop position used to be read from the CDK drag transform, which is a delta and not a
+ * canvas coordinate, so elements jumped to seemingly random places.
+ */
+test.describe('Moving elements on the canvas', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    designer = new DesignerPage(page);
+    await designer.goto();
+    await expect(designer.canvas).toBeVisible();
+  });
+
+  async function bounds(page: any, name: string) {
+    const xaml = await new DesignerPage(page).getXaml();
+    const match = new RegExp(`x:Name="${name}"[^>]*LayoutBounds="([^"]+)"`).exec(xaml);
+    const [x, y] = (match?.[1] ?? '').split(',').map(Number);
+    return { x, y };
+  }
+
+  async function drag(page: any, name: string, dx: number, dy: number) {
+    const element = page.locator(`[data-element-name="${name}"]`);
+    await element.click({ position: { x: 6, y: 6 } });
+    const box = (await element.boundingBox())!;
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + dx / 2, cy + dy / 2, { steps: 8 });
+    await page.mouse.move(cx + dx, cy + dy, { steps: 8 });
+    await page.mouse.up();
+    await page.keyboard.press('Escape');
+  }
+
+  test('an element lands where it was dropped instead of at the drag distance', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('starter-login').click();
+
+    const before = await bounds(page, 'SignInButton');
+    expect(before).toEqual({ x: 24, y: 364 });
+
+    await drag(page, 'SignInButton', 0, -100);
+
+    const after = await bounds(page, 'SignInButton');
+    expect(after.x).toBe(24);
+    expect(Math.abs(after.y - 264)).toBeLessThanOrEqual(8);
+  });
+
+  test('dragging the same element twice does not drift', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('starter-login').click();
+
+    const start = await bounds(page, 'Busy');
+    await drag(page, 'Busy', 60, 40);
+    const once = await bounds(page, 'Busy');
+    expect(Math.abs(once.x - (start.x + 60))).toBeLessThanOrEqual(8);
+    expect(Math.abs(once.y - (start.y + 40))).toBeLessThanOrEqual(8);
+
+    await drag(page, 'Busy', -60, -40);
+    const twice = await bounds(page, 'Busy');
+    expect(Math.abs(twice.x - start.x)).toBeLessThanOrEqual(8);
+    expect(Math.abs(twice.y - start.y)).toBeLessThanOrEqual(8);
+  });
+
+  test('a move stays accurate while the canvas is zoomed', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('starter-login').click();
+    await page.getByTestId('zoom-out').click();
+    await page.getByTestId('zoom-out').click();
+
+    const start = await bounds(page, 'Title');
+    await drag(page, 'Title', 80, 60);
+    const end = await bounds(page, 'Title');
+
+    const zoom = Number(await page.getByTestId('canvas-scale').getAttribute('data-zoom'));
+    expect(Math.abs(end.x - (start.x + 80 / zoom))).toBeLessThanOrEqual(10);
+    expect(Math.abs(end.y - (start.y + 60 / zoom))).toBeLessThanOrEqual(10);
+  });
+
+  test('a move is a single undo step that restores the original position', async ({ page }) => {
+    await designer.openToolbox();
+    await page.getByTestId('starter-login').click();
+
+    const start = await bounds(page, 'Subtitle');
+    await drag(page, 'Subtitle', 40, 120);
+    expect(await bounds(page, 'Subtitle')).not.toEqual(start);
+
+    await designer.undoButton.click();
+    await expect
+      .poll(async () => (await bounds(page, 'Subtitle')).y)
+      .toBe(start.y);
+  });
+
+  test('an element dropped inside a nested layout is positioned relative to it', async ({ page }) => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout x:Name="Root" WidthRequest="600" HeightRequest="600">
+        <AbsoluteLayout x:Name="Panel" AbsoluteLayout.LayoutBounds="200,200,300,300" WidthRequest="300" HeightRequest="300" BackgroundColor="#eeeeee" />
+        <Label x:Name="Mover" Text="Move me" AbsoluteLayout.LayoutBounds="20,20,100,30" WidthRequest="100" HeightRequest="30" />
+    </AbsoluteLayout>
+</ContentPage>`);
+
+    // Drop the label near the top left corner of the nested panel
+    await drag(page, 'Mover', 210, 210);
+
+    const xaml = await designer.getXaml();
+    const nested = /<AbsoluteLayout x:Name="Panel"[\s\S]*?<Label x:Name="Mover"[^>]*LayoutBounds="([^"]+)"/.exec(xaml);
+    expect(nested, 'the label should now be a child of Panel').not.toBeNull();
+
+    const [x, y] = nested![1].split(',').map(Number);
+    // Local coordinates inside the panel, not the canvas coordinates of the drop point
+    expect(x).toBeLessThan(120);
+    expect(y).toBeLessThan(120);
+  });
+});

--- a/e2e/element-move.spec.ts
+++ b/e2e/element-move.spec.ts
@@ -16,16 +16,27 @@ test.describe('Moving elements on the canvas', () => {
     await expect(designer.canvas).toBeVisible();
   });
 
+  /** Reads an element's absolute layout bounds out of the generated XAML. */
   async function bounds(page: any, name: string) {
-    const xaml = await new DesignerPage(page).getXaml();
-    const match = new RegExp(`x:Name="${name}"[^>]*LayoutBounds="([^"]+)"`).exec(xaml);
-    const [x, y] = (match?.[1] ?? '').split(',').map(Number);
+    const pattern = new RegExp(`x:Name="${name}"[^>]*LayoutBounds="([^"]+)"`);
+    // The XAML pane is regenerated from an observable, so poll until the element shows up
+    const xaml = await new DesignerPage(page).xamlWhen(value => pattern.test(value));
+    const [x, y] = pattern.exec(xaml)![1].split(',').map(Number);
     return { x, y };
+  }
+
+  /** Applies a starter page and waits until it is fully rendered. */
+  async function applyStarter(page: any, id: string) {
+    await designer.openToolbox();
+    await page.getByTestId(`starter-${id}`).click();
+    await expect.poll(() => designer.canvasElements().count()).toBeGreaterThan(2);
   }
 
   async function drag(page: any, name: string, dx: number, dy: number) {
     const element = page.locator(`[data-element-name="${name}"]`);
+    await expect(element).toBeVisible();
     await element.click({ position: { x: 6, y: 6 } });
+    await expect(element).toHaveAttribute('data-selected', 'true');
     const box = (await element.boundingBox())!;
     const cx = box.x + box.width / 2;
     const cy = box.y + box.height / 2;
@@ -34,12 +45,23 @@ test.describe('Moving elements on the canvas', () => {
     await page.mouse.move(cx + dx / 2, cy + dy / 2, { steps: 8 });
     await page.mouse.move(cx + dx, cy + dy, { steps: 8 });
     await page.mouse.up();
+    // The element stays selected after a drop, which also means the move has been applied
+    await expect(element).toHaveAttribute('data-selected', 'true');
     await page.keyboard.press('Escape');
   }
 
+  /** Drags an element and returns its bounds once the model has caught up. */
+  async function dragAndRead(page: any, name: string, dx: number, dy: number) {
+    const before = await bounds(page, name);
+    await drag(page, name, dx, dy);
+    await expect
+      .poll(async () => JSON.stringify(await bounds(page, name)))
+      .not.toBe(JSON.stringify(before));
+    return bounds(page, name);
+  }
+
   test('an element lands where it was dropped instead of at the drag distance', async ({ page }) => {
-    await designer.openToolbox();
-    await page.getByTestId('starter-login').click();
+    await applyStarter(page, 'login');
 
     const before = await bounds(page, 'SignInButton');
     expect(before).toEqual({ x: 24, y: 364 });
@@ -52,24 +74,20 @@ test.describe('Moving elements on the canvas', () => {
   });
 
   test('dragging the same element twice does not drift', async ({ page }) => {
-    await designer.openToolbox();
-    await page.getByTestId('starter-login').click();
+    await applyStarter(page, 'login');
 
     const start = await bounds(page, 'Busy');
-    await drag(page, 'Busy', 60, 40);
-    const once = await bounds(page, 'Busy');
+    const once = await dragAndRead(page, 'Busy', 60, 40);
     expect(Math.abs(once.x - (start.x + 60))).toBeLessThanOrEqual(8);
     expect(Math.abs(once.y - (start.y + 40))).toBeLessThanOrEqual(8);
 
-    await drag(page, 'Busy', -60, -40);
-    const twice = await bounds(page, 'Busy');
+    const twice = await dragAndRead(page, 'Busy', -60, -40);
     expect(Math.abs(twice.x - start.x)).toBeLessThanOrEqual(8);
     expect(Math.abs(twice.y - start.y)).toBeLessThanOrEqual(8);
   });
 
   test('a move stays accurate while the canvas is zoomed', async ({ page }) => {
-    await designer.openToolbox();
-    await page.getByTestId('starter-login').click();
+    await applyStarter(page, 'login');
     await page.getByTestId('zoom-out').click();
     await page.getByTestId('zoom-out').click();
 
@@ -83,8 +101,7 @@ test.describe('Moving elements on the canvas', () => {
   });
 
   test('a move is a single undo step that restores the original position', async ({ page }) => {
-    await designer.openToolbox();
-    await page.getByTestId('starter-login').click();
+    await applyStarter(page, 'login');
 
     const start = await bounds(page, 'Subtitle');
     await drag(page, 'Subtitle', 40, 120);
@@ -94,6 +111,19 @@ test.describe('Moving elements on the canvas', () => {
     await expect
       .poll(async () => (await bounds(page, 'Subtitle')).y)
       .toBe(start.y);
+  });
+
+  test('an element stays selected after it has been dragged', async ({ page }) => {
+    await applyStarter(page, 'login');
+
+    const element = page.locator('[data-element-name="Busy"]');
+    await drag(page, 'Busy', 60, 40);
+    await expect(element).toHaveAttribute('data-selected', 'true');
+
+    // Dragging back must not hand the selection to the layout underneath
+    await drag(page, 'Busy', -60, -40);
+    await expect(element).toHaveAttribute('data-selected', 'true');
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(1);
   });
 
   test('an element dropped inside a nested layout is positioned relative to it', async ({ page }) => {

--- a/e2e/element-move.spec.ts
+++ b/e2e/element-move.spec.ts
@@ -47,7 +47,6 @@ test.describe('Moving elements on the canvas', () => {
     await page.mouse.up();
     // The element stays selected after a drop, which also means the move has been applied
     await expect(element).toHaveAttribute('data-selected', 'true');
-    await page.keyboard.press('Escape');
   }
 
   /** Drags an element and returns its bounds once the model has caught up. */

--- a/e2e/helpers/designer-page.ts
+++ b/e2e/helpers/designer-page.ts
@@ -81,16 +81,29 @@ export class DesignerPage {
     await expect(this.hierarchy).toBeVisible();
   }
 
-  /** Adds a control by clicking its toolbox entry. */
+  /** Adds a control by clicking its toolbox entry and waits for it to become the selection. */
   async addControl(type: string) {
     await this.openToolbox();
+    const before = await this.canvasElements().count();
     await this.page.getByTestId(`toolbox-item-${type}`).click();
+    await this.waitForNewSelection(before);
   }
 
   /** Adds a custom (third party) control from the toolbox by prefix and tag. */
   async addCustomControl(prefix: string, tag: string) {
     await this.openToolbox();
+    const before = await this.canvasElements().count();
     await this.page.getByTestId(`custom-item-${prefix}-${tag}`).click();
+    await this.waitForNewSelection(before);
+  }
+
+  /**
+   * A newly added element is rendered and selected through observables, so the properties panel
+   * can still show the previous element for a tick. Waiting here keeps setProperty deterministic.
+   */
+  private async waitForNewSelection(countBefore: number) {
+    await expect(this.canvasElements()).toHaveCount(countBefore + 1);
+    await expect(this.selectedCanvasElement()).toHaveCount(1);
   }
 
   /** Drags a control from the toolbox onto the canvas. */
@@ -117,7 +130,14 @@ export class DesignerPage {
   }
 
   async selectFirst(type: string) {
-    await this.canvasElements(type).first().click();
+    const element = this.canvasElements(type).first();
+    await element.click();
+    // The properties panel follows the selection through an observable; wait for it to catch up
+    const name = await element.getAttribute('data-element-name');
+    await expect(element).toHaveAttribute('data-selected', 'true');
+    if (name) {
+      await expect(this.page.getByTestId('prop-name')).toHaveValue(name);
+    }
   }
 
   async setXaml(xaml: string) {
@@ -162,8 +182,11 @@ export class DesignerPage {
 
   async setProperty(name: string, value: string) {
     const input = this.page.getByTestId(`prop-${name}`);
+    await expect(input).toBeVisible();
     await input.fill(value);
     await input.dispatchEvent('input');
+    // The model round-trips through an observable; make sure the edit actually stuck
+    await expect(input).toHaveValue(value);
   }
 
   /** Waits for a property input to settle on a value. */

--- a/e2e/helpers/designer-page.ts
+++ b/e2e/helpers/designer-page.ts
@@ -37,7 +37,10 @@ export class DesignerPage {
     await this.page.goto('/');
     await expect(this.canvas).toBeVisible();
     // Every spec starts from a clean, predictable viewport
-    await this.page.evaluate(() => localStorage.removeItem('maui-designer.viewport'));
+    await this.page.evaluate(() => {
+      localStorage.removeItem('maui-designer.viewport');
+      localStorage.removeItem('maui-designer.custom-controls');
+    });
   }
 
   /** Ctrl-clicks an element to add or remove it from the selection. */
@@ -82,6 +85,12 @@ export class DesignerPage {
   async addControl(type: string) {
     await this.openToolbox();
     await this.page.getByTestId(`toolbox-item-${type}`).click();
+  }
+
+  /** Adds a custom (third party) control from the toolbox by prefix and tag. */
+  async addCustomControl(prefix: string, tag: string) {
+    await this.openToolbox();
+    await this.page.getByTestId(`custom-item-${prefix}-${tag}`).click();
   }
 
   /** Drags a control from the toolbox onto the canvas. */

--- a/e2e/ide-host.spec.ts
+++ b/e2e/ide-host.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { DesignerPage } from './helpers/designer-page';
+
+/**
+ * The designer is also shipped inside Visual Studio and VS Code, where the open
+ * document — not browser storage — is the source of truth. These tests stub the
+ * WebView2 bridge so the hosted path is exercised in a plain browser.
+ */
+
+/** Installs a fake `window.chrome.webview` before the app boots. */
+async function hostAsVisualStudio(page: Page) {
+  await page.addInitScript(() => {
+    const outbound: unknown[] = [];
+    (window as any).__hostMessages = outbound;
+    (window as any).chrome = {
+      webview: {
+        postMessage: (message: string) => outbound.push(JSON.parse(message))
+      }
+    };
+    (window as any).__sendToDesigner = (message: unknown) => {
+      window.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(message) }));
+    };
+  });
+}
+
+/** Messages the designer has posted back to the host. */
+function outbound(page: Page) {
+  return page.evaluate(() => (window as any).__hostMessages as { type: string; xaml?: string }[]);
+}
+
+async function sendToDesigner(page: Page, message: unknown) {
+  await page.evaluate(msg => (window as any).__sendToDesigner(msg), message);
+}
+
+test.describe('IDE host integration', () => {
+  test('announces itself and asks the host for control manifests', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await expect
+      .poll(async () => (await outbound(page)).map(m => m.type))
+      .toContain('designer.ready');
+
+    await sendToDesigner(page, { type: 'host.ready', host: 'visual-studio', fileName: 'MainPage.xaml' });
+
+    await expect
+      .poll(async () => (await outbound(page)).map(m => m.type))
+      .toContain('manifests.request');
+  });
+
+  test('opens the document the host pushes', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await sendToDesigner(page, {
+      type: 'document.load',
+      fileName: 'LoginPage.xaml',
+      xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Label Text="Hosted label" />
+  </AbsoluteLayout>
+</ContentPage>`
+    });
+
+    await designer.expectXamlToContain('Hosted label');
+    await expect(designer.canvas.locator('[data-element-type="Label"]')).toHaveCount(1);
+  });
+
+  test('streams every edit back to the host', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Button');
+
+    await expect
+      .poll(async () => {
+        const changes = (await outbound(page)).filter(m => m.type === 'document.changed');
+        return changes.length > 0 && changes[changes.length - 1].xaml!.includes('<Button');
+      })
+      .toBe(true);
+  });
+
+  test('save writes to the host document instead of browser storage', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Label');
+    await designer.saveButton.click();
+
+    await expect
+      .poll(async () => (await outbound(page)).filter(m => m.type === 'document.save').length)
+      .toBe(1);
+
+    // The browser-only toast must not appear when a host owns the document
+    await expect(designer.toast).toHaveCount(0);
+  });
+
+  test('registers custom controls the host discovered in NuGet packages', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await sendToDesigner(page, {
+      type: 'manifests.push',
+      manifests: [
+        {
+          id: 'host.pack',
+          package: 'Contoso.Maui.Controls',
+          xmlns: {
+            prefix: 'contoso',
+            uri: 'clr-namespace:Contoso.Maui.Controls;assembly=Contoso.Maui.Controls'
+          },
+          controls: [
+            {
+              tag: 'RatingBar',
+              displayName: 'Rating Bar',
+              defaultWidth: 160,
+              defaultHeight: 40,
+              properties: []
+            }
+          ]
+        }
+      ]
+    });
+
+    await designer.openToolbox();
+    await expect(page.getByTestId('custom-item-contoso-RatingBar')).toBeVisible();
+  });
+
+  test('a plain browser is unaffected and still saves locally', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Label');
+    await designer.saveButton.click();
+
+    await expect(designer.toast).toContainText('Design saved to this browser');
+  });
+});

--- a/e2e/viewport.spec.ts
+++ b/e2e/viewport.spec.ts
@@ -62,8 +62,12 @@ test.describe('Live preview viewport', () => {
   });
 
   test('the zoom level is restored after a reload', async ({ page }) => {
+    const zoomValue = page.getByTestId('zoom-value');
+    const before = (await zoomValue.textContent())!.trim();
     await page.getByTestId('zoom-in').click();
-    const zoom = await page.getByTestId('zoom-value').textContent();
+    // The label updates through an observable, so wait for the new value before capturing it
+    await expect(zoomValue).not.toHaveText(before);
+    const zoom = await zoomValue.textContent();
 
     await page.reload();
     await expect(page.getByTestId('zoom-value')).toHaveText(zoom!.trim());

--- a/extension/MauiDesigner.Core.sln
+++ b/extension/MauiDesigner.Core.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core", "src\MauiDesigner.Core\MauiDesigner.Core.csproj", "{84A01464-33A0-41AC-B13D-1E2AB557F945}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C899E7CF-34A4-48FA-90C8-60E31F08536F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core.Tests", "tests\MauiDesigner.Core.Tests\MauiDesigner.Core.Tests.csproj", "{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Fakes", "Fakes", "{68503E8F-DC47-456D-902D-67F5DDF7C473}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Maui", "tests\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj", "{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Package", "tests\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj", "{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{68503E8F-DC47-456D-902D-67F5DDF7C473} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+	EndGlobalSection
+EndGlobal

--- a/extension/MauiDesigner.sln
+++ b/extension/MauiDesigner.sln
@@ -1,0 +1,60 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core", "src\MauiDesigner.Core\MauiDesigner.Core.csproj", "{84A01464-33A0-41AC-B13D-1E2AB557F945}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C899E7CF-34A4-48FA-90C8-60E31F08536F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core.Tests", "tests\MauiDesigner.Core.Tests\MauiDesigner.Core.Tests.csproj", "{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Fakes", "Fakes", "{68503E8F-DC47-456D-902D-67F5DDF7C473}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Maui", "tests\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj", "{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Package", "tests\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj", "{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Vsix", "src\MauiDesigner.Vsix\MauiDesigner.Vsix.csproj", "{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{68503E8F-DC47-456D-902D-67F5DDF7C473} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+	EndGlobalSection
+EndGlobal

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,106 @@
+# MAUI Designer for Visual Studio
+
+Visual Studio 2022 has no drag-and-drop designer for .NET MAUI XAML. This folder
+packages the Angular designer from this repository as a VSIX so it can edit the
+`.xaml` file that is open in the IDE, with the project's own NuGet controls in
+the toolbox.
+
+See [`../docs/visual-studio-extension.md`](../docs/visual-studio-extension.md)
+for the design rationale and the alternatives that were considered.
+
+## Layout
+
+| Project | Framework | Builds on |
+| --- | --- | --- |
+| `src/MauiDesigner.Core` | `netstandard2.0` | any OS |
+| `tests/MauiDesigner.Core.Tests` | `net8.0` | any OS |
+| `tests/Fakes/*` | `netstandard2.0` | any OS |
+| `src/MauiDesigner.Vsix` | `net472` | **Windows only** |
+
+`MauiDesigner.Core.sln` contains everything that is cross-platform and is what CI
+builds and tests. `MauiDesigner.sln` additionally contains the VSIX and requires
+Visual Studio 2022 with the *Visual Studio extension development* workload.
+
+## What the core library does
+
+* **`Projects/ProjectAssetsReader`** — reads `obj/project.assets.json` (written by
+  every NuGet restore) to find which packages a project references and where
+  their assemblies live in the global packages folder.
+* **`Manifests/ControlManifestGenerator`** — inspects those assemblies with
+  `MetadataLoadContext` (metadata only, no code is executed), finds public
+  concrete types deriving from `Microsoft.Maui.Controls.View`, reads their
+  `public static readonly BindableProperty XxxProperty` fields and emits the same
+  manifest JSON the designer already consumes for custom controls.
+* **`Protocol/DesignerSession`** — the host half of the message contract in
+  `src/app/services/host-bridge.ts`, free of any Visual Studio types so it can be
+  unit tested anywhere.
+
+### Message contract
+
+| Direction | Message | Meaning |
+| --- | --- | --- |
+| host → designer | `host.ready` | which IDE is hosting, and the open file |
+| host → designer | `document.load` | XAML to edit |
+| host → designer | `manifests.push` | controls found in the project's packages |
+| host → designer | `document.saved` | the document reached disk |
+| designer → host | `designer.ready` | the WebView finished booting |
+| designer → host | `document.changed` | the user edited the design |
+| designer → host | `document.save` | Ctrl+S inside the designer |
+| designer → host | `manifests.request` | asks for the project's controls |
+| designer → host | `designer.error` | something went wrong, for the output window |
+
+Both sides ignore malformed payloads, so a protocol mismatch degrades to "the
+designer does nothing" rather than taking down the IDE.
+
+## Building and running the tests
+
+Cross-platform (this is what CI runs):
+
+```bash
+cd extension
+dotnet test MauiDesigner.Core.sln
+```
+
+The tests build two fake assemblies — a stand-in `Microsoft.Maui.Controls` and a
+`Contoso.Maui.Controls` control package — so the reflection scanner is exercised
+for real without installing the MAUI workload.
+
+The VSIX, on Windows:
+
+```powershell
+npm ci
+npm run build            # produces dist/maui-designer/browser, embedded in the VSIX
+cd extension
+msbuild MauiDesigner.sln /p:Configuration=Release /restore
+```
+
+`bin\Release\MauiDesigner.Vsix.vsix` can then be installed, or press F5 to debug
+in the experimental instance.
+
+## How it works inside Visual Studio
+
+`MauiDesignerPackage` registers `DesignerEditorFactory` for `.xaml` at a *lower*
+priority than the built-in XAML editor, so double-clicking a file keeps the
+familiar behaviour and the designer is offered through **Open With…**.
+
+The factory reuses the document's existing `IVsTextLines` buffer when one is
+already open, which means the text editor and the designer edit the same buffer:
+changes made on the canvas appear in the XAML view immediately, undo/redo and the
+dirty indicator keep working, and Ctrl+S saves through the normal solution
+pipeline.
+
+`DesignerControl` hosts WebView2. The compiled Angular application is copied into
+`webview\` inside the VSIX and served through
+`SetVirtualHostNameToFolderMapping`, because a `file://` origin cannot use the
+storage and module loading the designer relies on. The WebView2 environment is
+created explicitly with a user data folder under `%LOCALAPPDATA%` — the Visual
+Studio install directory is read-only.
+
+## Limitations
+
+* Only Visual Studio 2022 (17.x). The out-of-process `VisualStudio.Extensibility`
+  model cannot host WebView2, so the classic in-process VSSDK model is required.
+* The designer understands the subset of XAML the web app supports; unknown tags
+  are preserved verbatim but are not editable beyond their attributes.
+* Manifest generation reads compile-time metadata, so a control's runtime
+  defaults are not known — the designer falls back to its own defaults.

--- a/extension/src/MauiDesigner.Core/Manifests/ControlManifestGenerator.cs
+++ b/extension/src/MauiDesigner.Core/Manifests/ControlManifestGenerator.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Manifests
+{
+    /// <summary>
+    /// Scans NuGet assemblies for MAUI controls and produces designer manifests.
+    /// Uses <see cref="MetadataLoadContext"/> so assemblies are inspected, never executed.
+    /// </summary>
+    public sealed class ControlManifestGenerator
+    {
+        private const string ViewTypeName = "Microsoft.Maui.Controls.View";
+        private const string LayoutTypeName = "Microsoft.Maui.Controls.Layout";
+        private const string BindablePropertyTypeName = "Microsoft.Maui.Controls.BindableProperty";
+
+        /// <summary>
+        /// Builds one manifest per CLR namespace found in <paramref name="assemblyPaths"/>.
+        /// </summary>
+        /// <param name="assemblyPaths">Assemblies to scan.</param>
+        /// <param name="referencePaths">Additional assemblies needed to resolve base types (MAUI, BCL).</param>
+        /// <param name="packageId">NuGet package the assemblies came from.</param>
+        /// <param name="packageVersion">NuGet package version.</param>
+        public IReadOnlyList<CustomControlManifest> Generate(
+            IEnumerable<string> assemblyPaths,
+            IEnumerable<string> referencePaths,
+            string packageId,
+            string? packageVersion = null)
+        {
+            var targets = assemblyPaths.Where(File.Exists).Distinct().ToList();
+            if (targets.Count == 0)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var all = targets
+                .Concat(referencePaths.Where(File.Exists))
+                .Distinct()
+                .ToList();
+
+            var resolver = new PathAssemblyResolver(all);
+            using var context = new MetadataLoadContext(resolver);
+
+            var manifests = new Dictionary<string, CustomControlManifest>(StringComparer.Ordinal);
+
+            foreach (var path in targets)
+            {
+                Assembly assembly;
+                try
+                {
+                    assembly = context.LoadFromAssemblyPath(path);
+                }
+                catch (BadImageFormatException)
+                {
+                    // Native or resource-only assembly: nothing to scan.
+                    continue;
+                }
+
+                var assemblyName = assembly.GetName().Name ?? Path.GetFileNameWithoutExtension(path);
+
+                foreach (var type in SafeGetTypes(assembly))
+                {
+                    if (!IsDesignableControl(type))
+                    {
+                        continue;
+                    }
+
+                    var clrNamespace = type.Namespace ?? string.Empty;
+                    var key = clrNamespace + "|" + assemblyName;
+
+                    if (!manifests.TryGetValue(key, out var manifest))
+                    {
+                        manifest = new CustomControlManifest
+                        {
+                            Id = $"{packageId}.{clrNamespace}".ToLowerInvariant(),
+                            Package = packageId,
+                            Version = packageVersion,
+                            Description = $"Discovered in {packageId}",
+                            Xmlns = new CustomNamespace
+                            {
+                                Prefix = SuggestPrefix(clrNamespace, packageId),
+                                Uri = $"clr-namespace:{clrNamespace};assembly={assemblyName}"
+                            }
+                        };
+                        manifests[key] = manifest;
+                    }
+
+                    manifest.Controls.Add(Describe(type));
+                }
+            }
+
+            foreach (var manifest in manifests.Values)
+            {
+                manifest.Controls.Sort((left, right) => string.CompareOrdinal(left.Tag, right.Tag));
+            }
+
+            return manifests.Values
+                .Where(manifest => manifest.Controls.Count > 0)
+                .OrderBy(manifest => manifest.Xmlns.Uri, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>A type is designable when it is a public, concrete MAUI <c>View</c>.</summary>
+        public static bool IsDesignableControl(Type type)
+        {
+            if (!type.IsPublic || type.IsAbstract || type.IsGenericTypeDefinition || type.IsInterface)
+            {
+                return false;
+            }
+
+            return InheritsFrom(type, ViewTypeName);
+        }
+
+        private static CustomControlDefinition Describe(Type type)
+        {
+            var isLayout = InheritsFrom(type, LayoutTypeName);
+
+            return new CustomControlDefinition
+            {
+                Tag = type.Name,
+                DisplayName = Humanize(type.Name),
+                Description = $"{type.FullName}",
+                Icon = isLayout ? "dashboard" : "widgets",
+                CanHaveChildren = isLayout ? true : (bool?)null,
+                DefaultWidth = isLayout ? 240 : 160,
+                DefaultHeight = isLayout ? 160 : 40,
+                Preview = new CustomPreview
+                {
+                    Kind = isLayout ? "slot" : "box",
+                    Label = Humanize(type.Name)
+                },
+                Properties = BindableProperties(type)
+            };
+        }
+
+        /// <summary>
+        /// MAUI controls expose their editable surface as
+        /// <c>public static readonly BindableProperty XxxProperty</c> fields.
+        /// </summary>
+        public static List<CustomPropertyDefinition> BindableProperties(Type type)
+        {
+            var properties = new List<CustomPropertyDefinition>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+            foreach (var field in fields)
+            {
+                if (!field.IsInitOnly ||
+                    field.FieldType.FullName != BindablePropertyTypeName ||
+                    !field.Name.EndsWith("Property", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var name = field.Name.Substring(0, field.Name.Length - "Property".Length);
+                if (name.Length == 0 || !seen.Add(name))
+                {
+                    continue;
+                }
+
+                var clrProperty = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+                properties.Add(new CustomPropertyDefinition
+                {
+                    Name = name,
+                    Type = MapType(clrProperty?.PropertyType),
+                    Options = EnumOptions(clrProperty?.PropertyType)
+                });
+            }
+
+            properties.Sort((left, right) => string.CompareOrdinal(left.Name, right.Name));
+            return properties;
+        }
+
+        /// <summary>Maps a CLR type onto the designer's property editor kinds.</summary>
+        public static string MapType(Type? type)
+        {
+            if (type is null)
+            {
+                return "string";
+            }
+
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (underlying.IsEnum)
+            {
+                return "enum";
+            }
+
+            switch (underlying.FullName)
+            {
+                case "System.Boolean":
+                    return "boolean";
+                case "System.Double":
+                case "System.Single":
+                case "System.Int32":
+                case "System.Int64":
+                case "System.Decimal":
+                    return "number";
+                case "Microsoft.Maui.Graphics.Color":
+                    return "color";
+                default:
+                    return "string";
+            }
+        }
+
+        private static List<string>? EnumOptions(Type? type)
+        {
+            var underlying = type is null ? null : Nullable.GetUnderlyingType(type) ?? type;
+            if (underlying is null || !underlying.IsEnum)
+            {
+                return null;
+            }
+
+            try
+            {
+                return underlying.GetFields(BindingFlags.Public | BindingFlags.Static)
+                    .Select(field => field.Name)
+                    .ToList();
+            }
+            catch (NotSupportedException)
+            {
+                // Enum values cannot be read in a metadata-only context for some shapes.
+                return null;
+            }
+        }
+
+        /// <summary>Derives a short, readable XML prefix, e.g. `Syncfusion.Maui.Inputs` -&gt; `inputs`.</summary>
+        public static string SuggestPrefix(string clrNamespace, string packageId)
+        {
+            var source = string.IsNullOrWhiteSpace(clrNamespace) ? packageId : clrNamespace;
+            var segments = source.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(segment => !segment.Equals("Maui", StringComparison.OrdinalIgnoreCase) &&
+                                  !segment.Equals("Controls", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var candidate = segments.Count > 0 ? segments[segments.Count - 1] : source;
+            var cleaned = new string(candidate.Where(char.IsLetterOrDigit).ToArray());
+
+            return cleaned.Length == 0 ? "custom" : cleaned.ToLowerInvariant();
+        }
+
+        /// <summary>`SfComboBox` -&gt; `Sf Combo Box`.</summary>
+        public static string Humanize(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            var builder = new System.Text.StringBuilder();
+            for (var index = 0; index < name.Length; index++)
+            {
+                var current = name[index];
+                if (index > 0 && char.IsUpper(current) && !char.IsUpper(name[index - 1]))
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(current);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool InheritsFrom(Type type, string baseTypeFullName)
+        {
+            try
+            {
+                for (var current = type.BaseType; current is not null; current = current.BaseType)
+                {
+                    if (current.FullName == baseTypeFullName)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // A base type lives in an assembly that was not supplied; treat as unrelated.
+            }
+            catch (TypeLoadException)
+            {
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException error)
+            {
+                return error.Types.Where(type => type is not null)!;
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Manifests/CustomControlManifest.cs
+++ b/extension/src/MauiDesigner.Core/Manifests/CustomControlManifest.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MauiDesigner.Core.Manifests
+{
+    /// <summary>
+    /// C# mirror of <c>src/app/models/custom-control.ts</c>. The designer running
+    /// inside the WebView consumes exactly this JSON shape.
+    /// </summary>
+    public sealed class CustomControlManifest
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>NuGet package id; shown as the toolbox group title.</summary>
+        [JsonPropertyName("package")]
+        public string Package { get; set; } = string.Empty;
+
+        [JsonPropertyName("version")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("xmlns")]
+        public CustomNamespace Xmlns { get; set; } = new CustomNamespace();
+
+        [JsonPropertyName("controls")]
+        public List<CustomControlDefinition> Controls { get; set; } = new List<CustomControlDefinition>();
+    }
+
+    public sealed class CustomNamespace
+    {
+        /// <summary>XML prefix used in the document, e.g. <c>toolkit</c>.</summary>
+        [JsonPropertyName("prefix")]
+        public string Prefix { get; set; } = string.Empty;
+
+        /// <summary>A <c>clr-namespace:</c> declaration.</summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+    }
+
+    public sealed class CustomControlDefinition
+    {
+        /// <summary>Local XAML tag without the prefix, e.g. <c>AvatarView</c>.</summary>
+        [JsonPropertyName("tag")]
+        public string Tag { get; set; } = string.Empty;
+
+        [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("icon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Icon { get; set; }
+
+        [JsonPropertyName("canHaveChildren")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? CanHaveChildren { get; set; }
+
+        [JsonPropertyName("defaultWidth")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? DefaultWidth { get; set; }
+
+        [JsonPropertyName("defaultHeight")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? DefaultHeight { get; set; }
+
+        [JsonPropertyName("preview")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public CustomPreview? Preview { get; set; }
+
+        [JsonPropertyName("properties")]
+        public List<CustomPropertyDefinition> Properties { get; set; } = new List<CustomPropertyDefinition>();
+    }
+
+    public sealed class CustomPreview
+    {
+        /// <summary>One of <c>box</c>, <c>text</c>, <c>image</c>, <c>list</c>, <c>slot</c>.</summary>
+        [JsonPropertyName("kind")]
+        public string Kind { get; set; } = "box";
+
+        /// <summary>Supports <c>{PropertyName}</c> placeholders.</summary>
+        [JsonPropertyName("label")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("icon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Icon { get; set; }
+    }
+
+    public sealed class CustomPropertyDefinition
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>One of <c>string</c>, <c>number</c>, <c>boolean</c>, <c>color</c>, <c>enum</c>.</summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "string";
+
+        [JsonPropertyName("options")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Options { get; set; }
+
+        [JsonPropertyName("bindable")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Bindable { get; set; }
+    }
+
+    /// <summary>Shared serializer options so the host and the designer agree on casing.</summary>
+    public static class ManifestJson
+    {
+        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static string Serialize(object value) => JsonSerializer.Serialize(value, Options);
+    }
+}

--- a/extension/src/MauiDesigner.Core/MauiDesigner.Core.csproj
+++ b/extension/src/MauiDesigner.Core/MauiDesigner.Core.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- netstandard2.0 so the same assembly can be consumed by the .NET Framework VSIX -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <RootNamespace>MauiDesigner.Core</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/extension/src/MauiDesigner.Core/Projects/ProjectAssetsReader.cs
+++ b/extension/src/MauiDesigner.Core/Projects/ProjectAssetsReader.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace MauiDesigner.Core.Projects
+{
+    /// <summary>A NuGet package restored for a project, with the assemblies it contributes.</summary>
+    public sealed class PackageReferenceInfo
+    {
+        public PackageReferenceInfo(string id, string version, IReadOnlyList<string> assemblyPaths)
+        {
+            Id = id;
+            Version = version;
+            AssemblyPaths = assemblyPaths;
+        }
+
+        public string Id { get; }
+
+        public string Version { get; }
+
+        /// <summary>Absolute paths to the package's reference/lib assemblies that exist on disk.</summary>
+        public IReadOnlyList<string> AssemblyPaths { get; }
+    }
+
+    /// <summary>
+    /// Reads <c>obj/project.assets.json</c> — produced by every NuGet restore — to
+    /// discover which packages a MAUI project references and where their
+    /// assemblies live in the global packages folder.
+    /// </summary>
+    public static class ProjectAssetsReader
+    {
+        /// <summary>Locates <c>obj/project.assets.json</c> next to a project file.</summary>
+        public static string? FindAssetsFile(string projectFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(projectFilePath))
+            {
+                return null;
+            }
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+            if (string.IsNullOrEmpty(directory))
+            {
+                return null;
+            }
+
+            var assets = Path.Combine(directory, "obj", "project.assets.json");
+            return File.Exists(assets) ? assets : null;
+        }
+
+        /// <summary>Reads the packages of the first (or requested) target framework.</summary>
+        public static IReadOnlyList<PackageReferenceInfo> Read(string assetsFilePath, string? targetFramework = null)
+        {
+            if (!File.Exists(assetsFilePath))
+            {
+                throw new FileNotFoundException("project.assets.json was not found.", assetsFilePath);
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(assetsFilePath));
+            return Read(document.RootElement, targetFramework);
+        }
+
+        /// <summary>Overload used by the tests to avoid touching the file system.</summary>
+        public static IReadOnlyList<PackageReferenceInfo> ReadJson(string json, string? targetFramework = null)
+        {
+            using var document = JsonDocument.Parse(json);
+            return Read(document.RootElement, targetFramework);
+        }
+
+        private static IReadOnlyList<PackageReferenceInfo> Read(JsonElement root, string? targetFramework)
+        {
+            var packages = new List<PackageReferenceInfo>();
+
+            if (!root.TryGetProperty("targets", out var targets) || targets.ValueKind != JsonValueKind.Object)
+            {
+                return packages;
+            }
+
+            var target = SelectTarget(targets, targetFramework);
+            if (target is null)
+            {
+                return packages;
+            }
+
+            var roots = PackageFolders(root);
+
+            foreach (var entry in target.Value.EnumerateObject())
+            {
+                // Keys look like "CommunityToolkit.Maui/9.0.3"
+                var separator = entry.Name.LastIndexOf('/');
+                if (separator <= 0)
+                {
+                    continue;
+                }
+
+                if (entry.Value.TryGetProperty("type", out var type) &&
+                    !string.Equals(type.GetString(), "package", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var id = entry.Name.Substring(0, separator);
+                var version = entry.Name.Substring(separator + 1);
+                var relative = RelativeAssemblyPaths(entry.Value);
+                var resolved = Resolve(roots, id, version, relative);
+
+                packages.Add(new PackageReferenceInfo(id, version, resolved));
+            }
+
+            return packages;
+        }
+
+        private static JsonElement? SelectTarget(JsonElement targets, string? targetFramework)
+        {
+            foreach (var candidate in targets.EnumerateObject())
+            {
+                if (targetFramework is null ||
+                    candidate.Name.IndexOf(targetFramework, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return candidate.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static IReadOnlyList<string> PackageFolders(JsonElement root)
+        {
+            var folders = new List<string>();
+
+            if (root.TryGetProperty("packageFolders", out var packageFolders) &&
+                packageFolders.ValueKind == JsonValueKind.Object)
+            {
+                folders.AddRange(packageFolders.EnumerateObject().Select(folder => folder.Name));
+            }
+
+            if (folders.Count == 0)
+            {
+                folders.Add(Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".nuget",
+                    "packages"));
+            }
+
+            return folders;
+        }
+
+        private static IReadOnlyList<string> RelativeAssemblyPaths(JsonElement package)
+        {
+            var paths = new List<string>();
+
+            // "compile" is the reference assembly set; fall back to "runtime".
+            foreach (var section in new[] { "compile", "runtime" })
+            {
+                if (!package.TryGetProperty(section, out var items) || items.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                foreach (var item in items.EnumerateObject())
+                {
+                    // NuGet uses "_._" as a placeholder for "no assets".
+                    if (item.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        paths.Add(item.Name.Replace('/', Path.DirectorySeparatorChar));
+                    }
+                }
+
+                if (paths.Count > 0)
+                {
+                    break;
+                }
+            }
+
+            return paths;
+        }
+
+        private static IReadOnlyList<string> Resolve(
+            IReadOnlyList<string> roots,
+            string id,
+            string version,
+            IReadOnlyList<string> relativePaths)
+        {
+            var resolved = new List<string>();
+
+            foreach (var relative in relativePaths)
+            {
+                foreach (var root in roots)
+                {
+                    var full = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant(), relative);
+                    if (File.Exists(full))
+                    {
+                        resolved.Add(full);
+                        break;
+                    }
+
+                    // Some feeds keep the original casing on disk.
+                    var cased = Path.Combine(root, id, version, relative);
+                    if (File.Exists(cased))
+                    {
+                        resolved.Add(cased);
+                        break;
+                    }
+                }
+            }
+
+            return resolved;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
+++ b/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Protocol
+{
+    /// <summary>
+    /// The message contract between the IDE host and the Angular designer.
+    /// Mirrors <c>src/app/services/host-bridge.ts</c>; changing one side requires
+    /// changing the other.
+    /// </summary>
+    public static class MessageTypes
+    {
+        // Host -> designer
+        public const string HostReady = "host.ready";
+        public const string DocumentLoad = "document.load";
+        public const string ManifestsPush = "manifests.push";
+        public const string DocumentSaved = "document.saved";
+
+        // Designer -> host
+        public const string DesignerReady = "designer.ready";
+        public const string DocumentChanged = "document.changed";
+        public const string DocumentSave = "document.save";
+        public const string ManifestsRequest = "manifests.request";
+        public const string DesignerError = "designer.error";
+    }
+
+    /// <summary>A single message in either direction.</summary>
+    public sealed class DesignerMessage
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("host")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Host { get; set; }
+
+        [JsonPropertyName("fileName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FileName { get; set; }
+
+        [JsonPropertyName("xaml")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Xaml { get; set; }
+
+        [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("manifests")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<CustomControlManifest>? Manifests { get; set; }
+    }
+
+    /// <summary>Builds and parses <see cref="DesignerMessage"/> payloads.</summary>
+    public static class DesignerProtocol
+    {
+        private static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static string HostReady(string host, string? fileName = null) =>
+            Serialize(new DesignerMessage { Type = MessageTypes.HostReady, Host = host, FileName = fileName });
+
+        public static string DocumentLoad(string xaml, string? fileName = null) =>
+            Serialize(new DesignerMessage { Type = MessageTypes.DocumentLoad, Xaml = xaml, FileName = fileName });
+
+        public static string ManifestsPush(IEnumerable<CustomControlManifest> manifests) =>
+            Serialize(new DesignerMessage
+            {
+                Type = MessageTypes.ManifestsPush,
+                Manifests = new List<CustomControlManifest>(manifests)
+            });
+
+        public static string DocumentSaved() => Serialize(new DesignerMessage { Type = MessageTypes.DocumentSaved });
+
+        public static string Serialize(DesignerMessage message) => JsonSerializer.Serialize(message, Options);
+
+        /// <summary>
+        /// Parses a message posted by the designer. Returns <c>null</c> instead of
+        /// throwing so a malformed payload can never take down the IDE.
+        /// </summary>
+        public static DesignerMessage? Parse(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            try
+            {
+                var message = JsonSerializer.Deserialize<DesignerMessage>(json!, Options);
+                return string.IsNullOrEmpty(message?.Type) ? null : message;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Protocol/DesignerSession.cs
+++ b/extension/src/MauiDesigner.Core/Protocol/DesignerSession.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Protocol
+{
+    /// <summary>
+    /// The host-side half of the designer conversation, kept free of any Visual
+    /// Studio types so it can be unit tested on any platform. The VSIX supplies
+    /// the transport (WebView2) and the document services through the callbacks.
+    /// </summary>
+    public sealed class DesignerSession
+    {
+        private readonly Action<string> _post;
+        private readonly string _hostKind;
+        private bool _designerReady;
+        private string? _pendingXaml;
+
+        /// <param name="post">Sends a JSON payload into the WebView.</param>
+        /// <param name="hostKind"><c>visual-studio</c> or <c>vscode</c>.</param>
+        public DesignerSession(Action<string> post, string hostKind = "visual-studio")
+        {
+            _post = post ?? throw new ArgumentNullException(nameof(post));
+            _hostKind = hostKind;
+        }
+
+        /// <summary>Path of the document currently shown in the designer.</summary>
+        public string? FileName { get; private set; }
+
+        /// <summary>The latest XAML the designer produced.</summary>
+        public string? CurrentXaml { get; private set; }
+
+        /// <summary>True when the designer has edits the host has not persisted.</summary>
+        public bool IsDirty { get; private set; }
+
+        /// <summary>Raised when the designer asks the host to write the document.</summary>
+        public event EventHandler<DocumentSaveRequestedEventArgs>? SaveRequested;
+
+        /// <summary>Raised on every designer edit so the host can mark the buffer dirty.</summary>
+        public event EventHandler<DocumentChangedEventArgs>? DocumentChanged;
+
+        /// <summary>Raised when the designer reports a problem, for the output window.</summary>
+        public event EventHandler<string>? ErrorReported;
+
+        /// <summary>Raised when the designer asks for the project's control manifests.</summary>
+        public event EventHandler? ManifestsRequested;
+
+        /// <summary>
+        /// Queues (or sends, once the designer is ready) the document to edit.
+        /// </summary>
+        public void OpenDocument(string xaml, string fileName)
+        {
+            FileName = fileName;
+            CurrentXaml = xaml;
+            IsDirty = false;
+
+            if (_designerReady)
+            {
+                _post(DesignerProtocol.DocumentLoad(xaml, fileName));
+            }
+            else
+            {
+                // The WebView may still be starting; replay as soon as it announces itself.
+                _pendingXaml = xaml;
+            }
+        }
+
+        /// <summary>Pushes control manifests generated from the project's NuGet packages.</summary>
+        public void PushManifests(IEnumerable<CustomControlManifest> manifests)
+        {
+            _post(DesignerProtocol.ManifestsPush(manifests));
+        }
+
+        /// <summary>Tells the designer the document reached disk.</summary>
+        public void NotifySaved()
+        {
+            IsDirty = false;
+            _post(DesignerProtocol.DocumentSaved());
+        }
+
+        /// <summary>Handles a raw message posted by the designer. Unknown payloads are ignored.</summary>
+        public void HandleMessage(string? json)
+        {
+            var message = DesignerProtocol.Parse(json);
+            if (message is null)
+            {
+                return;
+            }
+
+            switch (message.Type)
+            {
+                case MessageTypes.DesignerReady:
+                    _designerReady = true;
+                    _post(DesignerProtocol.HostReady(_hostKind, FileName));
+                    if (_pendingXaml is not null)
+                    {
+                        _post(DesignerProtocol.DocumentLoad(_pendingXaml, FileName));
+                        _pendingXaml = null;
+                    }
+                    break;
+
+                case MessageTypes.ManifestsRequest:
+                    ManifestsRequested?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case MessageTypes.DocumentChanged:
+                    if (message.Xaml is null || message.Xaml == CurrentXaml)
+                    {
+                        break;
+                    }
+
+                    CurrentXaml = message.Xaml;
+                    IsDirty = true;
+                    DocumentChanged?.Invoke(this, new DocumentChangedEventArgs(message.Xaml));
+                    break;
+
+                case MessageTypes.DocumentSave:
+                    var xaml = message.Xaml ?? CurrentXaml;
+                    if (xaml is null)
+                    {
+                        break;
+                    }
+
+                    CurrentXaml = xaml;
+                    SaveRequested?.Invoke(this, new DocumentSaveRequestedEventArgs(xaml, FileName));
+                    break;
+
+                case MessageTypes.DesignerError:
+                    ErrorReported?.Invoke(this, message.Message ?? "Unknown designer error");
+                    break;
+            }
+        }
+    }
+
+    public sealed class DocumentChangedEventArgs : EventArgs
+    {
+        public DocumentChangedEventArgs(string xaml) => Xaml = xaml;
+
+        public string Xaml { get; }
+    }
+
+    public sealed class DocumentSaveRequestedEventArgs : EventArgs
+    {
+        public DocumentSaveRequestedEventArgs(string xaml, string? fileName)
+        {
+            Xaml = xaml;
+            FileName = fileName;
+        }
+
+        public string Xaml { get; }
+
+        public string? FileName { get; }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="MauiDesigner.Vsix.DesignerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf">
+    <Grid>
+        <!-- Source is never set in XAML: the WebView2 environment is created explicitly. -->
+        <wv2:WebView2 x:Name="WebView" />
+        <TextBlock x:Name="StatusText"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Starting the MAUI designer..." />
+    </Grid>
+</UserControl>

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+using Microsoft.Web.WebView2.Core;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Hosts the Angular designer in WebView2. The compiled application is served
+    /// through a virtual host name because `file://` origins cannot use the
+    /// browser storage and module loading the designer relies on.
+    /// </summary>
+    public partial class DesignerControl : UserControl, IDisposable
+    {
+        private const string VirtualHost = "maui-designer.invalid";
+
+        private readonly TaskCompletionSource<bool> _ready =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private bool _disposed;
+
+        public DesignerControl()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>Raised for every JSON message the designer posts to the host.</summary>
+        public event EventHandler<string>? MessageReceived;
+
+        /// <summary>Boots WebView2 and navigates to the bundled designer.</summary>
+        public async Task InitializeAsync(string webRootDirectory)
+        {
+            try
+            {
+                if (!Directory.Exists(webRootDirectory))
+                {
+                    ShowStatus($"The designer web assets were not found at {webRootDirectory}.");
+                    return;
+                }
+
+                // Keep the user profile out of the VS install directory, which is read-only.
+                var userDataFolder = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "MauiDesigner",
+                    "WebView2");
+                Directory.CreateDirectory(userDataFolder);
+
+                var environment = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
+                await WebView.EnsureCoreWebView2Async(environment);
+
+                var core = WebView.CoreWebView2;
+                core.SetVirtualHostNameToFolderMapping(
+                    VirtualHost,
+                    webRootDirectory,
+                    CoreWebView2HostResourceAccessKind.Allow);
+
+                core.Settings.AreDefaultContextMenusEnabled = false;
+                core.Settings.IsStatusBarEnabled = false;
+                core.Settings.AreDevToolsEnabled = true;
+
+                core.WebMessageReceived += OnWebMessageReceived;
+
+                core.Navigate($"https://{VirtualHost}/index.html");
+
+                StatusText.Visibility = Visibility.Collapsed;
+                _ready.TrySetResult(true);
+            }
+            catch (Exception error)
+            {
+                ShowStatus($"The designer could not start: {error.Message}");
+                _ready.TrySetResult(false);
+            }
+        }
+
+        /// <summary>Posts a JSON payload to the designer. Safe to call before it is ready.</summary>
+        public void PostMessage(string json)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _ = Dispatcher.InvokeAsync(async () =>
+            {
+                if (!await _ready.Task || _disposed || WebView.CoreWebView2 is null)
+                {
+                    return;
+                }
+
+                // The designer listens for `window` message events, so the payload
+                // is delivered as a string and parsed there.
+                WebView.CoreWebView2.PostWebMessageAsString(json);
+            });
+        }
+
+        private void OnWebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs args)
+        {
+            string json;
+            try
+            {
+                json = args.TryGetWebMessageAsString();
+            }
+            catch (ArgumentException)
+            {
+                json = args.WebMessageAsJson;
+            }
+
+            MessageReceived?.Invoke(this, json);
+        }
+
+        private void ShowStatus(string message)
+        {
+            StatusText.Text = message;
+            StatusText.Visibility = Visibility.Visible;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _ready.TrySetResult(false);
+
+            if (WebView.CoreWebView2 is not null)
+            {
+                WebView.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
+            }
+
+            WebView.Dispose();
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerEditorFactory.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerEditorFactory.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Creates the designer editor for a `.xaml` document. The document data is a
+    /// standard text buffer, so the built-in XAML editor and the designer can be
+    /// open on the same file at the same time and stay in sync.
+    /// </summary>
+    [Guid(FactoryGuidString)]
+    public sealed class DesignerEditorFactory : IVsEditorFactory, IDisposable
+    {
+        /// <summary>Editor factory GUID, referenced by the registration attributes.</summary>
+        public const string FactoryGuidString = "c1e5aa5a-2f4f-4c92-9b1c-8f5a55da0e77";
+
+        private readonly AsyncPackage _package;
+        private ServiceProvider? _serviceProvider;
+
+        public DesignerEditorFactory(AsyncPackage package)
+        {
+            _package = package ?? throw new ArgumentNullException(nameof(package));
+        }
+
+        public int SetSite(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = new ServiceProvider(serviceProvider);
+            return VSConstants.S_OK;
+        }
+
+        public int Close() => VSConstants.S_OK;
+
+        public int MapLogicalView(ref Guid logicalView, out string? physicalView)
+        {
+            physicalView = null;
+
+            // Both the primary and the designer view show the drag and drop surface.
+            if (logicalView == VSConstants.LOGVIEWID_Primary || logicalView == VSConstants.LOGVIEWID_Designer)
+            {
+                return VSConstants.S_OK;
+            }
+
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int CreateEditorInstance(
+            uint createFlags,
+            string documentMoniker,
+            string? physicalView,
+            IVsHierarchy hierarchy,
+            uint itemId,
+            IntPtr existingDocData,
+            out IntPtr documentView,
+            out IntPtr documentData,
+            out string editorCaption,
+            out Guid commandUiGuid,
+            out int createDocumentWindowFlags)
+        {
+            documentView = IntPtr.Zero;
+            documentData = IntPtr.Zero;
+            editorCaption = " [Designer]";
+            commandUiGuid = Guid.Empty;
+            createDocumentWindowFlags = 0;
+
+            if ((createFlags & (uint)(__VSCREATEEDITORFLAGS.CEF_OPENFILE | __VSCREATEEDITORFLAGS.CEF_SILENT)) == 0)
+            {
+                return VSConstants.E_INVALIDARG;
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Reuse the buffer the built-in editor already opened, otherwise create one.
+            var textLines = existingDocData != IntPtr.Zero
+                ? Marshal.GetObjectForIUnknown(existingDocData) as IVsTextLines
+                : CreateTextBuffer();
+
+            if (textLines is null)
+            {
+                // Another editor owns this document with an incompatible buffer type.
+                return VSConstants.VS_E_INCOMPATIBLEDOCDATA;
+            }
+
+            if (existingDocData == IntPtr.Zero)
+            {
+                documentData = Marshal.GetIUnknownForObject(textLines);
+            }
+            else
+            {
+                documentData = existingDocData;
+                Marshal.AddRef(documentData);
+            }
+
+            var pane = new DesignerPane(_package, textLines, documentMoniker, hierarchy);
+            documentView = Marshal.GetIUnknownForObject(pane);
+
+            return VSConstants.S_OK;
+        }
+
+        private IVsTextLines? CreateTextBuffer()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var localRegistry = _serviceProvider?.GetService(typeof(SLocalRegistry)) as ILocalRegistry;
+            if (localRegistry is null)
+            {
+                return null;
+            }
+
+            var bufferGuid = typeof(IVsTextLines).GUID;
+            var hresult = localRegistry.CreateInstance(
+                typeof(VsTextBufferClass).GUID,
+                null,
+                ref bufferGuid,
+                (uint)CLSCTX.CLSCTX_INPROC_SERVER,
+                out var buffer);
+
+            if (ErrorHandler.Failed(hresult) || buffer == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                return (IVsTextLines)Marshal.GetObjectForIUnknown(buffer);
+            }
+            finally
+            {
+                Marshal.Release(buffer);
+            }
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider?.Dispose();
+            _serviceProvider = null;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Protocol;
+using MauiDesigner.Vsix.Projects;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// The document window: hosts the WebView, and keeps the Visual Studio text
+    /// buffer and the designer in sync in both directions.
+    /// </summary>
+    public sealed class DesignerPane : WindowPane
+    {
+        private readonly IVsTextLines _textLines;
+        private readonly string _documentMoniker;
+        private readonly IVsHierarchy _hierarchy;
+        private readonly DesignerControl _control;
+        private readonly DesignerSession _session;
+        private bool _applyingDesignerEdit;
+
+        public DesignerPane(
+            IServiceProvider serviceProvider,
+            IVsTextLines textLines,
+            string documentMoniker,
+            IVsHierarchy hierarchy)
+            : base(serviceProvider)
+        {
+            _textLines = textLines ?? throw new ArgumentNullException(nameof(textLines));
+            _documentMoniker = documentMoniker;
+            _hierarchy = hierarchy;
+
+            _control = new DesignerControl();
+            _session = new DesignerSession(_control.PostMessage);
+
+            _control.MessageReceived += (_, json) => _session.HandleMessage(json);
+            _session.DocumentChanged += OnDesignerEdited;
+            _session.SaveRequested += OnSaveRequested;
+            _session.ManifestsRequested += OnManifestsRequested;
+            _session.ErrorReported += (_, message) => WriteToOutput(message);
+        }
+
+        /// <inheritdoc />
+        public override object Content => _control;
+
+        /// <inheritdoc />
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            _ = _control.InitializeAsync(WebAssetLocator.WebRootDirectory);
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _session.OpenDocument(ReadBuffer(), _documentMoniker);
+        }
+
+        private void OnDesignerEdited(object sender, DocumentChangedEventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                WriteBuffer(args.Xaml);
+            });
+        }
+
+        private void OnSaveRequested(object sender, DocumentSaveRequestedEventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                WriteBuffer(args.Xaml);
+
+                if (GetService(typeof(SVsRunningDocumentTable)) is IVsRunningDocumentTable4 table &&
+                    GetService(typeof(SVsSolution)) is IVsSolution solution)
+                {
+                    var cookie = table.GetDocumentCookie(_documentMoniker);
+                    solution.SaveSolutionElement(
+                        (uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_SaveIfDirty,
+                        _hierarchy,
+                        cookie);
+                }
+
+                _session.NotifySaved();
+            });
+        }
+
+        private void OnManifestsRequested(object sender, EventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var projectFile = ProjectManifestProvider.FindProjectFile(_hierarchy, _documentMoniker);
+
+                await TaskScheduler.Default;
+                IReadOnlyList<CustomControlManifest> manifests;
+                try
+                {
+                    manifests = ProjectManifestProvider.ForProject(projectFile);
+                }
+                catch (Exception error)
+                {
+                    WriteToOutput($"Could not read the project's NuGet controls: {error.Message}");
+                    return;
+                }
+
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                _session.PushManifests(manifests);
+            });
+        }
+
+        private string ReadBuffer()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ErrorHandler.ThrowOnFailure(_textLines.GetLineCount(out var lineCount));
+            ErrorHandler.ThrowOnFailure(_textLines.GetLengthOfLine(lineCount - 1, out var lastLineLength));
+            ErrorHandler.ThrowOnFailure(
+                _textLines.GetLineText(0, 0, lineCount - 1, lastLineLength, out var text));
+
+            return text ?? string.Empty;
+        }
+
+        private void WriteBuffer(string xaml)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_applyingDesignerEdit || ReadBuffer() == xaml)
+            {
+                return;
+            }
+
+            _applyingDesignerEdit = true;
+            try
+            {
+                ErrorHandler.ThrowOnFailure(_textLines.GetLineCount(out var lineCount));
+                ErrorHandler.ThrowOnFailure(_textLines.GetLengthOfLine(lineCount - 1, out var lastLineLength));
+
+                var bytes = System.Text.Encoding.Unicode.GetBytes(xaml);
+                var buffer = System.Runtime.InteropServices.Marshal.AllocCoTaskMem(bytes.Length + 2);
+                try
+                {
+                    System.Runtime.InteropServices.Marshal.Copy(bytes, 0, buffer, bytes.Length);
+                    System.Runtime.InteropServices.Marshal.WriteInt16(buffer, bytes.Length, 0);
+
+                    ErrorHandler.ThrowOnFailure(_textLines.ReplaceLines(
+                        0, 0, lineCount - 1, lastLineLength, buffer, xaml.Length, null));
+                }
+                finally
+                {
+                    System.Runtime.InteropServices.Marshal.FreeCoTaskMem(buffer);
+                }
+            }
+            finally
+            {
+                _applyingDesignerEdit = false;
+            }
+        }
+
+        private void WriteToOutput(string message)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (GetService(typeof(SVsGeneralOutputWindowPane)) is IVsOutputWindowPane pane)
+                {
+                    pane.OutputStringThreadSafe($"MAUI Designer: {message}{Environment.NewLine}");
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _control.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/WebAssetLocator.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/WebAssetLocator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>Finds the compiled Angular application shipped inside the VSIX.</summary>
+    public static class WebAssetLocator
+    {
+        /// <summary>The folder mapped into WebView2 as a virtual host.</summary>
+        public static string WebRootDirectory
+        {
+            get
+            {
+                var assembly = Assembly.GetExecutingAssembly().Location;
+                var directory = Path.GetDirectoryName(assembly) ?? AppDomain.CurrentDomain.BaseDirectory;
+                return Path.Combine(directory, "webview");
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
+++ b/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Windows only. Requires Visual Studio 2022 with the "Visual Studio extension
+    development" workload; it cannot be built with `dotnet build` on Linux/macOS.
+    See extension/README.md.
+  -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}</ProjectGuid>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MauiDesigner.Vsix</RootNamespace>
+    <AssemblyName>MauiDesigner.Vsix</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+    <DeployExtension Condition="'$(IsBuildingVsix)' == ''">true</DeployExtension>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.11.40262" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiDesigner.Core\MauiDesigner.Core.csproj">
+      <Name>MauiDesigner.Core</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Editor\DesignerControl.xaml.cs">
+      <DependentUpon>DesignerControl.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Editor\DesignerEditorFactory.cs" />
+    <Compile Include="Editor\DesignerPane.cs" />
+    <Compile Include="Editor\WebAssetLocator.cs" />
+    <Compile Include="MauiDesignerPackage.cs" />
+    <Compile Include="Projects\ProjectManifestProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="Editor\DesignerControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <!--
+    The VSIX ships the compiled Angular application. Run `npm run build` in the
+    repository root first; the output of dist/maui-designer/browser is embedded
+    under `webview\` and served through a virtual host name.
+  -->
+  <PropertyGroup>
+    <AngularDistDirectory Condition="'$(AngularDistDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\..\dist\maui-designer\browser</AngularDistDirectory>
+  </PropertyGroup>
+
+  <Target Name="IncludeAngularApp" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <AngularAsset Include="$(AngularDistDirectory)\**\*" />
+      <Content Include="@(AngularAsset)">
+        <Link>webview\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+    </ItemGroup>
+    <Warning Condition="!Exists('$(AngularDistDirectory)')"
+             Text="The Angular application was not found at $(AngularDistDirectory). Run 'npm ci &amp;&amp; npm run build' in the repository root before building the VSIX." />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+</Project>

--- a/extension/src/MauiDesigner.Vsix/MauiDesignerPackage.cs
+++ b/extension/src/MauiDesigner.Vsix/MauiDesignerPackage.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Registers the MAUI designer as an alternative editor for `.xaml` files.
+    /// </summary>
+    /// <remarks>
+    /// The priority is deliberately lower than the built-in XAML editor so the
+    /// designer never steals the default double-click experience; it is offered
+    /// through <c>File &gt; Open With</c> and the context menu instead.
+    /// </remarks>
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [Guid(PackageGuidString)]
+    [ProvideEditorFactory(typeof(DesignerEditorFactory), 110, TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
+    [ProvideEditorExtension(typeof(DesignerEditorFactory), ".xaml", 0x10, NameResourceID = 110)]
+    [ProvideEditorLogicalView(typeof(DesignerEditorFactory), VSConstants.LOGVIEWID.Designer_string)]
+    public sealed class MauiDesignerPackage : AsyncPackage
+    {
+        /// <summary>Package GUID, referenced by the generated pkgdef.</summary>
+        public const string PackageGuidString = "3b9a7bd5-51b1-4f2a-9a1d-0f0a4a2f9c31";
+
+        /// <inheritdoc />
+        protected override async Task InitializeAsync(
+            CancellationToken cancellationToken,
+            IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress);
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            RegisterEditorFactory(new DesignerEditorFactory(this));
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Projects/ProjectManifestProvider.cs
+++ b/extension/src/MauiDesigner.Vsix/Projects/ProjectManifestProvider.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Projects;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace MauiDesigner.Vsix.Projects
+{
+    /// <summary>
+    /// Turns the NuGet packages a MAUI project restored into designer manifests,
+    /// so third party controls appear in the toolbox with their real properties.
+    /// </summary>
+    public static class ProjectManifestProvider
+    {
+        /// <summary>Finds the project file that owns an open document.</summary>
+        public static string? FindProjectFile(IVsHierarchy? hierarchy, string documentMoniker)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (hierarchy is IVsProject project &&
+                ErrorHandler.Succeeded(project.GetMkDocument(VSConstants.VSITEMID_ROOT, out var projectFile)) &&
+                File.Exists(projectFile))
+            {
+                return projectFile;
+            }
+
+            // Fall back to walking up from the document until a project file appears.
+            var directory = Path.GetDirectoryName(documentMoniker);
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Directory.EnumerateFiles(directory, "*.csproj").FirstOrDefault();
+                if (candidate is not null)
+                {
+                    return candidate;
+                }
+
+                directory = Path.GetDirectoryName(directory);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Scans every restored package of <paramref name="projectFile"/> and returns
+        /// manifests for the ones that contain MAUI controls. Never throws for a
+        /// package that cannot be inspected: it is simply skipped.
+        /// </summary>
+        public static IReadOnlyList<CustomControlManifest> ForProject(string? projectFile)
+        {
+            if (projectFile is null)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var assetsFile = ProjectAssetsReader.FindAssetsFile(projectFile);
+            if (assetsFile is null)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var packages = ProjectAssetsReader.Read(assetsFile);
+
+            // Base types must resolve, so every package assembly is offered as a reference.
+            var references = packages.SelectMany(package => package.AssemblyPaths).Distinct().ToList();
+
+            var generator = new ControlManifestGenerator();
+            var manifests = new List<CustomControlManifest>();
+
+            foreach (var package in packages)
+            {
+                if (package.AssemblyPaths.Count == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    manifests.AddRange(
+                        generator.Generate(package.AssemblyPaths, references, package.Id, package.Version));
+                }
+                catch (Exception)
+                {
+                    // A package that cannot be inspected must not break the designer.
+                }
+            }
+
+            return manifests;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
+++ b/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("MAUI Designer for Visual Studio")]
+[assembly: AssemblyDescription("Visual drag and drop designer for .NET MAUI XAML pages.")]
+[assembly: AssemblyProduct("MAUI Designer")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: ComVisible(false)]

--- a/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
+++ b/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="0.1.0" Language="en-US" Publisher="GMPrakhar" />
+    <DisplayName>MAUI Designer</DisplayName>
+    <Description xml:space="preserve">A drag and drop visual designer for .NET MAUI XAML pages, including controls that come from NuGet packages.</Description>
+    <MoreInfo>https://github.com/GMPrakhar/MAUI-Designer</MoreInfo>
+    <License>LICENSE.txt</License>
+    <Tags>maui, xaml, designer, dotnet</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+</PackageManifest>

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiDesigner.Fakes.Maui.csproj
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiDesigner.Fakes.Maui.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Stand-in for Microsoft.Maui.Controls so the scanner can be tested without the MAUI workload -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Microsoft.Maui.Controls</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiStubs.cs
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiStubs.cs
@@ -1,0 +1,30 @@
+namespace Microsoft.Maui.Graphics
+{
+    public class Color
+    {
+    }
+}
+
+namespace Microsoft.Maui.Controls
+{
+    public sealed class BindableProperty
+    {
+        public static BindableProperty Create(string name) => new BindableProperty();
+    }
+
+    public abstract class Element
+    {
+    }
+
+    public abstract class VisualElement : Element
+    {
+    }
+
+    public abstract class View : VisualElement
+    {
+    }
+
+    public abstract class Layout : View
+    {
+    }
+}

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Package/Controls.cs
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Package/Controls.cs
@@ -1,0 +1,59 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Contoso.Maui.Controls
+{
+    public enum RatingShape
+    {
+        Star,
+        Heart
+    }
+
+    public class RatingBar : View
+    {
+        public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value");
+        public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create("IsReadOnly");
+        public static readonly BindableProperty CaptionProperty = BindableProperty.Create("Caption");
+        public static readonly BindableProperty ShapeProperty = BindableProperty.Create("Shape");
+        public static readonly BindableProperty FillColorProperty = BindableProperty.Create("FillColor");
+
+        // Not a BindableProperty field: must be ignored
+        public static readonly string Documentation = "https://contoso.example";
+
+        public double Value { get; set; }
+
+        public bool IsReadOnly { get; set; }
+
+        public string? Caption { get; set; }
+
+        public RatingShape Shape { get; set; }
+
+        public Color? FillColor { get; set; }
+    }
+
+    public class CardPanel : Layout
+    {
+        public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title");
+
+        public string? Title { get; set; }
+    }
+
+    public abstract class AbstractControl : View
+    {
+    }
+
+    internal class InternalControl : View
+    {
+    }
+
+    public class NotAControl
+    {
+    }
+}
+
+namespace Contoso.Maui.Charts
+{
+    public class SparkLine : Microsoft.Maui.Controls.View
+    {
+    }
+}

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Package/MauiDesigner.Fakes.Package.csproj
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Package/MauiDesigner.Fakes.Package.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Stand-in for a third party control package such as Syncfusion or Telerik -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Contoso.Maui.Controls</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extension/tests/MauiDesigner.Core.Tests/ControlManifestGeneratorTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/ControlManifestGeneratorTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    /// <summary>
+    /// Scans the fake `Contoso.Maui.Controls` package that is built alongside the
+    /// tests, so the reflection path is exercised for real without the MAUI workload.
+    /// </summary>
+    public class ControlManifestGeneratorTests
+    {
+        private static readonly string PackageAssembly = FakeAssembly("Contoso.Maui.Controls.dll");
+        private static readonly string MauiAssembly = FakeAssembly("Microsoft.Maui.Controls.dll");
+
+        private static string FakeAssembly(string fileName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, fileName);
+            Assert.True(File.Exists(path), $"Expected the test fake '{fileName}' next to the test assembly.");
+            return path;
+        }
+
+        private static IReadOnlyList<string> RuntimeReferences()
+        {
+            var trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+            return trusted.Split(Path.PathSeparator).Where(path => path.Length > 0).ToList();
+        }
+
+        private static IReadOnlyList<CustomControlManifest> Generate()
+        {
+            var references = RuntimeReferences().Concat(new[] { MauiAssembly }).ToList();
+            return new ControlManifestGenerator()
+                .Generate(new[] { PackageAssembly }, references, "Contoso.Maui.Controls", "1.2.3");
+        }
+
+        [Fact]
+        public void Produces_one_manifest_per_clr_namespace()
+        {
+            var manifests = Generate();
+
+            Assert.Equal(2, manifests.Count);
+            Assert.Contains(manifests, manifest => manifest.Xmlns.Uri ==
+                "clr-namespace:Contoso.Maui.Controls;assembly=Contoso.Maui.Controls");
+            Assert.Contains(manifests, manifest => manifest.Xmlns.Uri ==
+                "clr-namespace:Contoso.Maui.Charts;assembly=Contoso.Maui.Controls");
+        }
+
+        [Fact]
+        public void Carries_the_package_identity()
+        {
+            var manifest = Generate().First();
+
+            Assert.Equal("Contoso.Maui.Controls", manifest.Package);
+            Assert.Equal("1.2.3", manifest.Version);
+            Assert.NotEmpty(manifest.Id);
+        }
+
+        [Fact]
+        public void Only_public_concrete_views_become_controls()
+        {
+            var controls = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Select(control => control.Tag)
+                .ToList();
+
+            Assert.Contains("RatingBar", controls);
+            Assert.Contains("CardPanel", controls);
+            Assert.Contains("SparkLine", controls);
+            Assert.DoesNotContain("AbstractControl", controls);
+            Assert.DoesNotContain("InternalControl", controls);
+            Assert.DoesNotContain("NotAControl", controls);
+        }
+
+        [Fact]
+        public void Layouts_accept_children_and_render_as_slots()
+        {
+            var controls = Generate().SelectMany(manifest => manifest.Controls).ToList();
+
+            var panel = controls.Single(control => control.Tag == "CardPanel");
+            Assert.True(panel.CanHaveChildren);
+            Assert.Equal("slot", panel.Preview!.Kind);
+
+            var rating = controls.Single(control => control.Tag == "RatingBar");
+            Assert.Null(rating.CanHaveChildren);
+            Assert.Equal("box", rating.Preview!.Kind);
+        }
+
+        [Fact]
+        public void Bindable_properties_become_editable_properties_with_mapped_types()
+        {
+            var rating = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Single(control => control.Tag == "RatingBar");
+
+            var byName = rating.Properties.ToDictionary(property => property.Name, property => property.Type);
+
+            Assert.Equal("number", byName["Value"]);
+            Assert.Equal("boolean", byName["IsReadOnly"]);
+            Assert.Equal("string", byName["Caption"]);
+            Assert.Equal("enum", byName["Shape"]);
+            Assert.Equal("color", byName["FillColor"]);
+
+            // A public static readonly field that is not a BindableProperty is ignored
+            Assert.DoesNotContain(rating.Properties, property => property.Name == "Documentation");
+        }
+
+        [Fact]
+        public void Enum_properties_expose_their_values()
+        {
+            var shape = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Single(control => control.Tag == "RatingBar")
+                .Properties
+                .Single(property => property.Name == "Shape");
+
+            Assert.Equal(new[] { "Star", "Heart" }, shape.Options);
+        }
+
+        [Fact]
+        public void Missing_assemblies_yield_no_manifests()
+        {
+            var manifests = new ControlManifestGenerator()
+                .Generate(new[] { "/does/not/exist.dll" }, Array.Empty<string>(), "Ghost");
+
+            Assert.Empty(manifests);
+        }
+
+        [Fact]
+        public void Generated_manifests_round_trip_through_the_designer_json_shape()
+        {
+            var json = ManifestJson.Serialize(Generate());
+
+            Assert.Contains("\"xmlns\"", json);
+            Assert.Contains("\"prefix\"", json);
+            Assert.Contains("\"controls\"", json);
+            Assert.Contains("\"RatingBar\"", json);
+        }
+
+        [Theory]
+        [InlineData("Syncfusion.Maui.Inputs", "Syncfusion.Maui.Inputs", "inputs")]
+        [InlineData("Telerik.Maui.Controls", "Telerik.UI.for.Maui", "telerik")]
+        [InlineData("", "CommunityToolkit.Maui", "communitytoolkit")]
+        public void Prefixes_are_short_and_readable(string clrNamespace, string packageId, string expected)
+        {
+            Assert.Equal(expected, ControlManifestGenerator.SuggestPrefix(clrNamespace, packageId));
+        }
+
+        [Theory]
+        [InlineData("SfComboBox", "Sf Combo Box")]
+        [InlineData("RatingBar", "Rating Bar")]
+        [InlineData("Label", "Label")]
+        [InlineData("", "")]
+        public void Display_names_are_humanized(string name, string expected)
+        {
+            Assert.Equal(expected, ControlManifestGenerator.Humanize(name));
+        }
+
+        [Fact]
+        public void Unknown_clr_types_fall_back_to_string_editors()
+        {
+            Assert.Equal("string", ControlManifestGenerator.MapType(null));
+            Assert.Equal("string", ControlManifestGenerator.MapType(typeof(Uri)));
+            Assert.Equal("number", ControlManifestGenerator.MapType(typeof(int?)));
+            Assert.Equal("boolean", ControlManifestGenerator.MapType(typeof(bool)));
+        }
+    }
+}

--- a/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Protocol;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    /// <summary>
+    /// The session is the host half of the contract in `src/app/services/host-bridge.ts`.
+    /// </summary>
+    public class DesignerSessionTests
+    {
+        private readonly List<string> _posted = new List<string>();
+
+        private DesignerSession CreateSession() => new DesignerSession(_posted.Add);
+
+        private IEnumerable<DesignerMessage> Posted() =>
+            _posted.Select(DesignerProtocol.Parse).Where(message => message is not null)!;
+
+        private static string FromDesigner(string type, string? xaml = null, string? message = null) =>
+            DesignerProtocol.Serialize(new DesignerMessage { Type = type, Xaml = xaml, Message = message });
+
+        [Fact]
+        public void Opening_a_document_before_the_designer_is_ready_replays_it()
+        {
+            var session = CreateSession();
+
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+            Assert.Empty(_posted);
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+
+            var types = Posted().Select(message => message.Type).ToList();
+            Assert.Equal(new[] { MessageTypes.HostReady, MessageTypes.DocumentLoad }, types);
+
+            var load = Posted().Last();
+            Assert.Equal("<ContentPage />", load.Xaml);
+            Assert.Equal("MainPage.xaml", load.FileName);
+        }
+
+        [Fact]
+        public void Opening_a_document_after_the_designer_is_ready_sends_it_immediately()
+        {
+            var session = CreateSession();
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+            _posted.Clear();
+
+            session.OpenDocument("<Grid />", "Other.xaml");
+
+            var load = Assert.Single(Posted());
+            Assert.Equal(MessageTypes.DocumentLoad, load.Type);
+            Assert.Equal("<Grid />", load.Xaml);
+        }
+
+        [Fact]
+        public void The_host_announces_which_ide_it_is()
+        {
+            var session = new DesignerSession(_posted.Add, "vscode");
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+
+            Assert.Equal("vscode", Posted().First().Host);
+        }
+
+        [Fact]
+        public void Designer_edits_mark_the_document_dirty()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            var changes = new List<string>();
+            session.DocumentChanged += (_, args) => changes.Add(args.Xaml);
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<ContentPage><Label /></ContentPage>"));
+
+            Assert.True(session.IsDirty);
+            Assert.Equal("<ContentPage><Label /></ContentPage>", session.CurrentXaml);
+            Assert.Single(changes);
+        }
+
+        [Fact]
+        public void An_echo_of_the_current_xaml_is_not_a_change()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            var changes = 0;
+            session.DocumentChanged += (_, _) => changes++;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<ContentPage />"));
+
+            Assert.False(session.IsDirty);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void Save_requests_reach_the_host_and_clear_the_dirty_flag_once_written()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<Grid />"));
+
+            DocumentSaveRequestedEventArgs? request = null;
+            session.SaveRequested += (_, args) => request = args;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentSave, "<Grid />"));
+
+            Assert.NotNull(request);
+            Assert.Equal("<Grid />", request!.Xaml);
+            Assert.Equal("MainPage.xaml", request.FileName);
+            Assert.True(session.IsDirty);
+
+            session.NotifySaved();
+
+            Assert.False(session.IsDirty);
+            Assert.Contains(Posted(), message => message.Type == MessageTypes.DocumentSaved);
+        }
+
+        [Fact]
+        public void A_save_without_xaml_falls_back_to_the_last_known_document()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            DocumentSaveRequestedEventArgs? request = null;
+            session.SaveRequested += (_, args) => request = args;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentSave));
+
+            Assert.Equal("<ContentPage />", request!.Xaml);
+        }
+
+        [Fact]
+        public void Manifest_requests_are_surfaced_to_the_host()
+        {
+            var session = CreateSession();
+            var requested = 0;
+            session.ManifestsRequested += (_, _) => requested++;
+
+            session.HandleMessage(FromDesigner(MessageTypes.ManifestsRequest));
+
+            Assert.Equal(1, requested);
+        }
+
+        [Fact]
+        public void Manifests_are_pushed_in_the_shape_the_designer_expects()
+        {
+            var session = CreateSession();
+
+            session.PushManifests(new[]
+            {
+                new CustomControlManifest
+                {
+                    Id = "contoso",
+                    Package = "Contoso.Maui.Controls",
+                    Xmlns = new CustomNamespace { Prefix = "contoso", Uri = "clr-namespace:Contoso" },
+                    Controls = { new CustomControlDefinition { Tag = "RatingBar" } }
+                }
+            });
+
+            var message = Assert.Single(Posted());
+            Assert.Equal(MessageTypes.ManifestsPush, message.Type);
+            Assert.Equal("contoso", message.Manifests!.Single().Xmlns.Prefix);
+            Assert.Contains("\"tag\":\"RatingBar\"", _posted.Single());
+        }
+
+        [Fact]
+        public void Designer_errors_are_surfaced_to_the_host()
+        {
+            var session = CreateSession();
+            string? reported = null;
+            session.ErrorReported += (_, message) => reported = message;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerError, message: "Malformed XAML"));
+
+            Assert.Equal("Malformed XAML", reported);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not json")]
+        [InlineData("{}")]
+        [InlineData("{\"type\":\"something.unknown\"}")]
+        public void Malformed_or_unknown_messages_are_ignored(string? json)
+        {
+            var session = CreateSession();
+
+            var exception = Record.Exception(() => session.HandleMessage(json));
+
+            Assert.Null(exception);
+            Assert.Empty(_posted);
+            Assert.False(session.IsDirty);
+        }
+
+        [Fact]
+        public void A_session_needs_a_transport()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DesignerSession(null!));
+        }
+    }
+}

--- a/extension/tests/MauiDesigner.Core.Tests/MauiDesigner.Core.Tests.csproj
+++ b/extension/tests/MauiDesigner.Core.Tests/MauiDesigner.Core.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MauiDesigner.Core\MauiDesigner.Core.csproj" />
+    <!-- Stand-ins for Microsoft.Maui.Controls and a third party control package -->
+    <ProjectReference Include="..\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj" />
+    <ProjectReference Include="..\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extension/tests/MauiDesigner.Core.Tests/ProjectAssetsReaderTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/ProjectAssetsReaderTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Projects;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    public class ProjectAssetsReaderTests
+    {
+        private const string Assets = @"{
+  ""version"": 3,
+  ""targets"": {
+    ""net8.0-android34.0"": {
+      ""CommunityToolkit.Maui/9.0.3"": {
+        ""type"": ""package"",
+        ""compile"": {
+          ""lib/net8.0/CommunityToolkit.Maui.dll"": {},
+          ""lib/net8.0/CommunityToolkit.Maui.Core.dll"": {}
+        },
+        ""runtime"": {
+          ""lib/net8.0/CommunityToolkit.Maui.dll"": {}
+        }
+      },
+      ""Newtonsoft.Json/13.0.3"": {
+        ""type"": ""package"",
+        ""compile"": {
+          ""lib/netstandard2.0/_._"": {}
+        }
+      },
+      ""MyApp.Shared/1.0.0"": {
+        ""type"": ""project""
+      }
+    }
+  },
+  ""packageFolders"": {
+    ""PACKAGES_ROOT"": {}
+  }
+}";
+
+        private static string WithRoot(string root) => Assets.Replace("PACKAGES_ROOT", root.Replace(@"\", @"\\"));
+
+        [Fact]
+        public void Reads_packages_from_the_first_target()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets);
+
+            Assert.Equal(2, packages.Count);
+            Assert.Contains(packages, package => package.Id == "CommunityToolkit.Maui" && package.Version == "9.0.3");
+            Assert.Contains(packages, package => package.Id == "Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void Project_references_are_not_packages()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets);
+
+            Assert.DoesNotContain(packages, package => package.Id == "MyApp.Shared");
+        }
+
+        [Fact]
+        public void Resolves_assembly_paths_that_exist_on_disk()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "maui-designer-assets-" + Guid.NewGuid().ToString("N"));
+            var libraryDirectory = Path.Combine(root, "communitytoolkit.maui", "9.0.3", "lib", "net8.0");
+            Directory.CreateDirectory(libraryDirectory);
+            File.WriteAllText(Path.Combine(libraryDirectory, "CommunityToolkit.Maui.dll"), string.Empty);
+
+            try
+            {
+                var package = ProjectAssetsReader.ReadJson(WithRoot(root))
+                    .Single(candidate => candidate.Id == "CommunityToolkit.Maui");
+
+                // Only the assembly that is actually on disk is returned
+                Assert.Equal(
+                    new[] { Path.Combine(libraryDirectory, "CommunityToolkit.Maui.dll") },
+                    package.AssemblyPaths);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Placeholder_assets_contribute_no_assemblies()
+        {
+            var package = ProjectAssetsReader.ReadJson(Assets).Single(candidate => candidate.Id == "Newtonsoft.Json");
+
+            Assert.Empty(package.AssemblyPaths);
+        }
+
+        [Fact]
+        public void A_target_framework_can_be_selected()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets, "net8.0-android");
+
+            Assert.NotEmpty(packages);
+            Assert.Empty(ProjectAssetsReader.ReadJson(Assets, "net472"));
+        }
+
+        [Fact]
+        public void An_assets_file_without_targets_is_empty_rather_than_fatal()
+        {
+            Assert.Empty(ProjectAssetsReader.ReadJson("{}"));
+        }
+
+        [Fact]
+        public void Finds_the_assets_file_next_to_a_project()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "maui-designer-project-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(root, "obj"));
+            var project = Path.Combine(root, "MyApp.csproj");
+            File.WriteAllText(project, "<Project />");
+
+            try
+            {
+                Assert.Null(ProjectAssetsReader.FindAssetsFile(project));
+
+                var assets = Path.Combine(root, "obj", "project.assets.json");
+                File.WriteAllText(assets, "{}");
+
+                Assert.Equal(assets, ProjectAssetsReader.FindAssetsFile(project));
+                Assert.Null(ProjectAssetsReader.FindAssetsFile(""));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void A_missing_assets_file_is_reported_clearly()
+        {
+            Assert.Throws<FileNotFoundException>(
+                () => ProjectAssetsReader.Read(Path.Combine(Path.GetTempPath(), "nope.assets.json")));
+        }
+    }
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,6 +4,10 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { Subscription } from 'rxjs';
 
 import { ElementService } from './services/element';
+import { HostBridgeService } from './services/host-bridge';
+import { XamlParserService } from './services/xaml-parser';
+import { XamlGeneratorService } from './services/xaml-generator';
+import { CustomControlRegistryService } from './services/custom-control-registry';
 import { ToolboxComponent } from './components/toolbox/toolbox';
 import { DesignerCanvasComponent } from './components/designer-canvas/designer-canvas';
 import { PropertiesPanelComponent } from './components/properties-panel/properties-panel';
@@ -40,6 +44,7 @@ export class App implements OnInit, OnDestroy {
   canUndo = false;
   canRedo = false;
   toastMessage = '';
+  hostFileName: string | null = null;
   private toastTimeout: any;
   private subscription = new Subscription();
 
@@ -55,7 +60,13 @@ export class App implements OnInit, OnDestroy {
   private readonly MIN_PANEL_SIZE = 50;
   private readonly MAX_PANEL_RATIO = 0.8;
 
-  constructor(private elementService: ElementService) {}
+  constructor(
+    private elementService: ElementService,
+    private hostBridge: HostBridgeService,
+    private xamlParser: XamlParserService,
+    private xamlGenerator: XamlGeneratorService,
+    private registry: CustomControlRegistryService
+  ) {}
 
   ngOnInit() {
     this.subscription.add(
@@ -64,6 +75,57 @@ export class App implements OnInit, OnDestroy {
         this.canRedo = state.canRedo;
       })
     );
+
+    if (this.hostBridge.isHosted) {
+      this.connectToHost();
+    }
+  }
+
+  /** In Visual Studio or VS Code the open .xaml document is the source of truth. */
+  private connectToHost() {
+    this.subscription.add(
+      this.hostBridge.messages$.subscribe(message => {
+        switch (message.type) {
+          case 'host.ready':
+            this.hostBridge.requestManifests();
+            break;
+          case 'document.load':
+            this.loadFromHost(message.xaml);
+            break;
+          case 'manifests.push':
+            for (const manifest of message.manifests) {
+              this.registry.register(manifest);
+            }
+            break;
+          case 'document.saved':
+            this.showToast('Saved');
+            break;
+        }
+      })
+    );
+
+    // Every change flows back so the host can keep the document in sync
+    this.subscription.add(
+      this.elementService.elements$.subscribe(root => {
+        this.hostBridge.notifyChanged(this.xamlGenerator.generateXaml(root));
+      })
+    );
+
+    this.subscription.add(this.hostBridge.fileName$.subscribe(name => (this.hostFileName = name)));
+  }
+
+  private loadFromHost(xaml: string) {
+    try {
+      this.elementService.setRootElement(this.xamlParser.parseXaml(xaml));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.hostBridge.reportError(message);
+      this.showToast(`Could not open the document: ${message}`);
+    }
+  }
+
+  get isHosted(): boolean {
+    return this.hostBridge.isHosted;
   }
 
   ngOnDestroy() {
@@ -82,6 +144,12 @@ export class App implements OnInit, OnDestroy {
   }
 
   saveDesign() {
+    if (this.hostBridge.isHosted) {
+      // Hosted in an IDE the design belongs to the open file, not to browser storage
+      this.hostBridge.save(this.xamlGenerator.generateXaml(this.elementService.getRootElement()));
+      return;
+    }
+
     this.showToast(
       this.elementService.saveToStorage()
         ? 'Design saved to this browser'

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -35,7 +35,7 @@
     (dragleave)="onCanvasDragLeave()"
     (drop)="onCanvasDrop($event)"
     (mousedown)="onCanvasMouseDown($event)"
-    (click)="onCanvasClick()">
+    (click)="onCanvasClick($event)">
     
     <!-- Root element content (rendered through the recursive template) -->
     <ng-container *ngIf="rootElement$ | async as rootElement">

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -95,6 +95,7 @@
     [attr.data-element-id]="element.id"
     [attr.data-element-type]="element.type"
     [attr.data-element-name]="element.name"
+    [attr.data-custom-tag]="element.properties.customTag"
     [attr.data-selected]="isSelected(element)"
     cdkDrag
     [cdkDragDisabled]="!isPrimarySelection(element) || element.id === 'root'"
@@ -326,6 +327,34 @@
       </div>
       
       <!-- Default case -->
+      <!-- Custom control from a NuGet package manifest -->
+      <div *ngSwitchCase="'Custom'"
+           class="element-custom"
+           [attr.data-custom-preview]="element.properties.customTag"
+           [attr.data-preview-kind]="customPreview(element).kind"
+           [class.custom-slot]="customPreview(element).kind === 'slot'"
+           [style.background]="customPreview(element).backgroundColor || null"
+           [style.color]="customPreview(element).textColor || null"
+           [style.border-color]="customPreview(element).borderColor || null"
+           [style.border-radius.px]="customCornerRadius(element)"
+           #layoutDiv
+           cdkDropList
+           [cdkDropListData]="element.children"
+           (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
+           (mouseenter)="setElementRef(element, layoutDiv)">
+
+        <ng-container *ngIf="element.children.length; else customPlaceholder">
+          <ng-container *ngFor="let child of element.children">
+            <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: child }"></ng-container>
+          </ng-container>
+        </ng-container>
+
+        <ng-template #customPlaceholder>
+          <span class="custom-icon material-icons" *ngIf="customPreview(element).icon">{{ customPreview(element).icon }}</span>
+          <span class="custom-label">{{ customLabel(element) }}</span>
+        </ng-template>
+      </div>
+
       <div *ngSwitchDefault class="element-default">
         {{ element.type }}
       </div>

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -731,3 +731,55 @@
   pointer-events: none;
   z-index: 10000;
 }
+
+/* Custom (third party) controls */
+.element-custom {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  border: 1px dashed #94a3b8;
+  border-radius: 4px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  overflow: hidden;
+
+  .custom-icon {
+    font-size: 18px;
+    line-height: 1;
+  }
+
+  .custom-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &[data-preview-kind='text'] {
+    border-style: solid;
+    font-weight: 600;
+  }
+
+  &[data-preview-kind='image'] {
+    color: #e2e8f0;
+    border-style: solid;
+  }
+
+  &[data-preview-kind='list'] {
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-direction: column;
+  }
+
+  &.custom-slot {
+    align-items: stretch;
+    justify-content: flex-start;
+    flex-direction: column;
+    padding: 8px;
+  }
+}

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -630,6 +630,12 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     // and a leftover translation would offset every following drag.
     event.source.reset();
 
+    // The browser still delivers a click after the drag. By then the element has moved, so the
+    // click can land on whatever is now under the pointer and steal the selection.
+    this.suppressNextCanvasClick = true;
+    // If no click follows (the drag ended off canvas) the flag must not swallow a later one
+    setTimeout(() => (this.suppressNextCanvasClick = false));
+
     this.dragDropService.handleCanvasDrop(element, target.x, target.y, this.canvas.nativeElement, pointer);
     this.dragDropService.endDrag();
   }

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -7,6 +7,8 @@ import { LayoutDesignerService } from '../../services/layout-designer';
 import { MauiElement, ElementType } from '../../models/maui-element';
 import { AlignmentService, AlignmentGuide } from '../../services/alignment';
 import { ClipboardService } from '../../services/clipboard';
+import { CustomControlRegistryService } from '../../services/custom-control-registry';
+import { CustomPreview } from '../../models/custom-control';
 import { ViewportService, ViewportState } from '../../services/viewport';
 import { Observable, Subscription } from 'rxjs';
 
@@ -80,7 +82,8 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     private layoutDesigner: LayoutDesignerService,
     private alignmentService: AlignmentService,
     private clipboardService: ClipboardService,
-    private viewportService: ViewportService
+    private viewportService: ViewportService,
+    private registry: CustomControlRegistryService
   ) {
     this.rootElement$ = this.elementService.elements$;
     this.selectedElement$ = this.elementService.selectedElement$;
@@ -298,8 +301,8 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
 
   onCanvasDrop(event: DragEvent) {
     this.isDragOver = false;
-    const type = event.dataTransfer?.getData(TOOLBOX_DRAG_MIME) as ElementType;
-    if (!type) {
+    const payload = event.dataTransfer?.getData(TOOLBOX_DRAG_MIME);
+    if (!payload) {
       return;
     }
     event.preventDefault();
@@ -307,7 +310,29 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     const { x, y } = this.toCanvasPoint(event.clientX, event.clientY);
     const snapped = this.applyGridSnap(x, y);
 
-    this.dragDropService.createElementAtPosition(type, snapped.x, snapped.y, this.canvas.nativeElement);
+    // Custom controls are dragged as "Custom:<prefix>:<tag>"
+    if (payload.startsWith('Custom:')) {
+      const [, prefix, tag] = payload.split(':');
+      const lookup = this.registry.find(prefix, tag);
+      if (lookup) {
+        this.dragDropService.createElementAtPosition(
+          ElementType.Custom,
+          snapped.x,
+          snapped.y,
+          this.canvas.nativeElement,
+          this.registry.defaultProperties(lookup)
+        );
+      }
+      this.dragDropService.endDrag();
+      return;
+    }
+
+    this.dragDropService.createElementAtPosition(
+      payload as ElementType,
+      snapped.x,
+      snapped.y,
+      this.canvas.nativeElement
+    );
     this.dragDropService.endDrag();
   }
 
@@ -494,6 +519,9 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   }
 
   isLayoutElement(element: MauiElement): boolean {
+    if (element.type === ElementType.Custom) {
+      return this.registry.findForElement(element)?.definition.canHaveChildren ?? false;
+    }
     return [
       ElementType.StackLayout,
       ElementType.Grid,
@@ -504,6 +532,25 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
       ElementType.CollectionView,
       ElementType.ScrollView
     ].includes(element.type);
+  }
+
+  // --- Custom control previews ------------------------------------------------
+
+  /** Preview description of a custom control, with sensible fallbacks. */
+  customPreview(element: MauiElement): CustomPreview {
+    const definition = this.registry.findForElement(element)?.definition;
+    return definition?.preview || { kind: 'box', label: element.properties.customTag || 'Custom', icon: 'extension' };
+  }
+
+  customLabel(element: MauiElement): string {
+    const preview = this.customPreview(element);
+    const label = this.registry.interpolate(preview.label, element).trim();
+    return label || element.properties.customTag || 'Custom';
+  }
+
+  customCornerRadius(element: MauiElement): number | null {
+    const radius = Number(this.registry.interpolate(this.customPreview(element).cornerRadius, element));
+    return Number.isFinite(radius) && radius > 0 ? radius : null;
   }
 
   // --- Control previews -------------------------------------------------------

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -60,9 +60,12 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   private marqueeAdditive = false;
   private dragOrigin: { x: number, y: number } | null = null;
   private suppressNextCanvasClick = false;
+  private pointerDownPoint: { x: number, y: number } | null = null;
 
   // Constants
   private readonly MIN_SIZE = 20;
+  /** A click whose pointer travelled further than this came from a drag, not from a click. */
+  private readonly CLICK_SLOP = 4;
 
   // Viewport (zoom / pan / theme / grid) state
   viewport!: ViewportState;
@@ -174,8 +177,7 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   onElementClick(element: MauiElement, event: MouseEvent) {
     event.stopPropagation();
     // A marquee that started on the root layout still emits a click on it
-    if (this.suppressNextCanvasClick) {
-      this.suppressNextCanvasClick = false;
+    if (this.shouldIgnoreClick(event)) {
       return;
     }
     if (event.shiftKey || event.ctrlKey || event.metaKey) {
@@ -185,12 +187,34 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     this.elementService.selectElement(element);
   }
 
-  onCanvasClick() {
-    if (this.suppressNextCanvasClick) {
-      this.suppressNextCanvasClick = false;
+  onCanvasClick(event: MouseEvent) {
+    if (this.shouldIgnoreClick(event)) {
       return;
     }
     this.elementService.selectElement(null);
+  }
+
+  /**
+   * True for the trailing click a marquee or a drag leaves behind. After a drop the element
+   * has moved, so that click lands on whatever is now under the pointer and would hand the
+   * selection to it. The pointer travel is used rather than a flag or a timer because the
+   * click can be delivered either before or after the drag ends.
+   */
+  private shouldIgnoreClick(event: MouseEvent): boolean {
+    const origin = this.pointerDownPoint;
+    this.pointerDownPoint = null;
+
+    if (this.suppressNextCanvasClick) {
+      this.suppressNextCanvasClick = false;
+      return true;
+    }
+
+    if (!origin) {
+      return false;
+    }
+
+    return Math.abs(event.clientX - origin.x) > this.CLICK_SLOP ||
+      Math.abs(event.clientY - origin.y) > this.CLICK_SLOP;
   }
 
   // --- Marquee (rubber band) selection ---------------------------------------
@@ -199,6 +223,13 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     if (event.button !== 0) {
       return;
     }
+
+    // A new press means any click still owed by the previous drag will never arrive
+    this.suppressNextCanvasClick = false;
+
+    // Every left press inside the canvas is remembered so the click it produces can be
+    // told apart from the one a drag leaves behind
+    this.pointerDownPoint = { x: event.clientX, y: event.clientY };
 
     const target = event.target as HTMLElement;
     const owner = target.closest('[data-element-id]') as HTMLElement | null;
@@ -630,11 +661,11 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     // and a leftover translation would offset every following drag.
     event.source.reset();
 
-    // The browser still delivers a click after the drag. By then the element has moved, so the
-    // click can land on whatever is now under the pointer and steal the selection.
+
+    // The browser still delivers a click after the drop. By then the element has moved, so the
+    // click lands on whatever is now under the pointer and would steal the selection. The flag is
+    // cleared by the next press rather than by a timer, because the click can be delivered late.
     this.suppressNextCanvasClick = true;
-    // If no click follows (the drag ended off canvas) the flag must not swallow a later one
-    setTimeout(() => (this.suppressNextCanvasClick = false));
 
     this.dragDropService.handleCanvasDrop(element, target.x, target.y, this.canvas.nativeElement, pointer);
     this.dragDropService.endDrag();

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -58,6 +58,7 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   private marqueeOrigin = { x: 0, y: 0 };
   private isMarqueeSelecting = false;
   private marqueeAdditive = false;
+  private dragOrigin: { x: number, y: number } | null = null;
   private suppressNextCanvasClick = false;
 
   // Constants
@@ -438,10 +439,10 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
    * Turns a raw cdkDrag position into the final canvas position, applying
    * smart guides first and the grid afterwards.
    */
+  /** Applies smart guides and grid snapping to a position expressed in the parent's own coordinates. */
   private resolveDragPosition(element: MauiElement, rawX: number, rawY: number): { x: number, y: number } {
-    const zoom = this.viewport.zoom || 1;
-    let x = rawX / zoom;
-    let y = rawY / zoom;
+    let x = rawX;
+    let y = rawY;
 
     if (element.parent?.type === ElementType.AbsoluteLayout) {
       if (this.viewport.showGuides) {
@@ -596,20 +597,62 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   }
   
   onDragStarted(element: MauiElement) {
+    // Remember where the element started so the drop position is origin + travelled distance
+    this.dragOrigin = { x: element.properties.x || 0, y: element.properties.y || 0 };
   }
 
   onDragEnded(element: MauiElement, event: CdkDragEnd) {
     document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
     this.alignmentGuides = [];
 
-    const dropPoint = event.source.getFreeDragPosition();
-    const target = this.resolveDragPosition(element, dropPoint.x, dropPoint.y);
+    const zoom = this.viewport.zoom || 1;
+    const origin = this.dragOrigin ?? { x: element.properties.x || 0, y: element.properties.y || 0 };
+    this.dragOrigin = null;
 
-    this.dragDropService.handleCanvasDrop(element, target.x, target.y, this.canvas.nativeElement);
+    // The pointer position decides which layout receives the element
+    const pointer = this.toCanvasPoint(event.dropPoint.x, event.dropPoint.y);
 
-    //this.elementService.moveElement(element, element.parent!,  element.properties.x! + event.distance.x,  element.properties.y! + event.distance.y)
+    let target: { x: number, y: number };
+    if (this.parentUsesAbsolutePositioning(element)) {
+      // cdkDrag reports the travelled distance in client pixels; the model stores unscaled pixels
+      const local = this.resolveDragPosition(
+        element,
+        origin.x + event.distance.x / zoom,
+        origin.y + event.distance.y / zoom
+      );
+      target = this.toCanvasSpace(element.parent, local.x, local.y);
+    } else {
+      // Stack and grid children have no pixel position of their own, so follow the pointer
+      target = pointer;
+    }
 
+    // Drop the transform cdkDrag applied - the element is repositioned through its own styles,
+    // and a leftover translation would offset every following drag.
+    event.source.reset();
+
+    this.dragDropService.handleCanvasDrop(element, target.x, target.y, this.canvas.nativeElement, pointer);
     this.dragDropService.endDrag();
+  }
+
+  private parentUsesAbsolutePositioning(element: MauiElement): boolean {
+    const parent = element.parent;
+    return !!parent && this.layoutDesigner.getLayoutInfo(parent.type).supportsAbsolutePositioning;
+  }
+
+  /** Converts a point expressed in a layout's own coordinates into canvas space. */
+  private toCanvasSpace(parent: MauiElement | undefined, localX: number, localY: number): { x: number, y: number } {
+    const dom = parent?.domElement;
+    if (!parent || parent.id === 'root' || !dom) {
+      return { x: localX, y: localY };
+    }
+
+    const zoom = this.viewport.zoom || 1;
+    const rect = dom.getBoundingClientRect();
+    const canvasRect = this.canvas.nativeElement.getBoundingClientRect();
+    return {
+      x: localX + (rect.left - canvasRect.left) / zoom,
+      y: localY + (rect.top - canvasRect.top) / zoom
+    };
   }
 
   onDragMoved(element: MauiElement, event: CdkDragMove) {
@@ -624,15 +667,16 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     } else {
       this.alignmentGuides = [];
     }
-    // Get layout element over which we are passing currently
-    var layoutOver = this.dragDropService.findLayoutAtPosition(element.properties.x! + event.distance.x, element.properties.y! + event.distance.y, this.canvas.nativeElement)!;
+    // The layout under the pointer is the drop candidate
+    const pointer = this.toCanvasPoint(event.pointerPosition.x, event.pointerPosition.y);
+    const layoutOver = this.dragDropService.findLayoutAtPosition(pointer.x, pointer.y, this.canvas.nativeElement, element)!;
 
-    if(layoutOver.type === ElementType.Grid && this.layoutDesigner.getVisualHints(layoutOver).showGrid) {
-      const rect = (event.source.getRootElement() as HTMLElement).getBoundingClientRect();
+    if(layoutOver?.type === ElementType.Grid && this.layoutDesigner.getVisualHints(layoutOver).showGrid) {
+      const zoom = this.viewport.zoom || 1;
       const parentRect = layoutOver.domElement?.getBoundingClientRect();
 
-      const x = event.pointerPosition.x - (parentRect?.left || 0);
-      const y = event.pointerPosition.y - (parentRect?.top || 0);
+      const x = (event.pointerPosition.x - (parentRect?.left || 0)) / zoom;
+      const y = (event.pointerPosition.y - (parentRect?.top || 0)) / zoom;
       const gridCell = this.layoutDesigner.getGridCellAtPosition(layoutOver, x, y, layoutOver.domElement!);
       if(gridCell) {
         this.highlightedGridCell = { element: layoutOver, row: gridCell.row, column: gridCell.column };

--- a/src/app/components/properties-panel/properties-panel.html
+++ b/src/app/components/properties-panel/properties-panel.html
@@ -369,6 +369,57 @@
       </ng-container>
     </div>
 
+    <!-- Custom (third party) control properties -->
+    <div class="property-section" *ngIf="isCustom(element)" data-testid="custom-section">
+      <h4 class="section-header">{{ element.properties.customTag }}</h4>
+      <p class="section-hint" data-testid="custom-package">{{ customPackage(element) }}</p>
+
+      <div class="property-group" *ngFor="let property of customProperties(element)">
+        <label class="property-label" [title]="property.description || property.name">{{ property.name }}</label>
+
+        <ng-container [ngSwitch]="property.type">
+          <input *ngSwitchCase="'number'" type="number" class="property-input"
+                 [attr.data-testid]="'custom-' + property.name"
+                 [value]="customValue(element, property.name)"
+                 (input)="updateCustomValue(element, property.name, $any($event.target).value)">
+
+          <input *ngSwitchCase="'color'" type="color" class="property-input color-input"
+                 [attr.data-testid]="'custom-' + property.name"
+                 [value]="customValue(element, property.name) || '#000000'"
+                 (input)="updateCustomValue(element, property.name, $any($event.target).value)">
+
+          <input *ngSwitchCase="'boolean'" type="checkbox" class="property-checkbox"
+                 [attr.data-testid]="'custom-' + property.name"
+                 [checked]="customBoolean(element, property.name)"
+                 (change)="updateCustomValue(element, property.name, $any($event.target).checked)">
+
+          <select *ngSwitchCase="'enum'" class="property-input"
+                  [attr.data-testid]="'custom-' + property.name"
+                  [value]="customValue(element, property.name)"
+                  (change)="updateCustomValue(element, property.name, $any($event.target).value)">
+            <option value="">(unset)</option>
+            <option *ngFor="let option of property.options" [value]="option">{{ option }}</option>
+          </select>
+
+          <input *ngSwitchDefault type="text" class="property-input"
+                 [attr.data-testid]="'custom-' + property.name"
+                 [value]="customValue(element, property.name)"
+                 (input)="updateCustomValue(element, property.name, $any($event.target).value)">
+        </ng-container>
+      </div>
+
+      <ng-container *ngIf="rawAttributeNames(element).length">
+        <h4 class="section-header" data-testid="raw-attributes-header">Other attributes</h4>
+        <div class="property-group" *ngFor="let name of rawAttributeNames(element)">
+          <label class="property-label">{{ name }}</label>
+          <input type="text" class="property-input"
+                 [attr.data-testid]="'raw-' + name"
+                 [value]="rawAttributeValue(element, name)"
+                 (input)="updateRawAttribute(element, name, $any($event.target).value)">
+        </div>
+      </ng-container>
+    </div>
+
     <!-- Data bindings -->
     <div class="property-section" data-testid="bindings-section">
       <h4 class="section-header">Data Bindings</h4>

--- a/src/app/components/properties-panel/properties-panel.scss
+++ b/src/app/components/properties-panel/properties-panel.scss
@@ -175,3 +175,10 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 4px;
 }
+
+/* Custom (third party) control section */
+.section-hint {
+  margin: -4px 0 8px;
+  color: #6b7280;
+  font-size: 11px;
+}

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -15,6 +15,8 @@ import {
 } from '../../models/maui-element';
 import { Observable, Subscription } from 'rxjs';
 import { AlignmentService, AlignMode } from '../../services/alignment';
+import { CustomControlRegistryService } from '../../services/custom-control-registry';
+import { CustomControlDefinition, CustomPropertyDefinition } from '../../models/custom-control';
 
 @Component({
   selector: 'app-properties-panel',
@@ -34,7 +36,8 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
 
   constructor(
     private elementService: ElementService,
-    private alignmentService: AlignmentService
+    private alignmentService: AlignmentService,
+    private registry: CustomControlRegistryService
   ) {
     this.selectedElement$ = this.elementService.selectedElement$;
   }
@@ -146,8 +149,68 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
   // --- Data bindings ----------------------------------------------------------
 
   bindableProperties(element: MauiElement): string[] {
-    const specific = BINDABLE_PROPERTIES[element.type] || [];
+    const specific = element.type === ElementType.Custom
+      ? this.registry.bindableProperties(element)
+      : BINDABLE_PROPERTIES[element.type] || [];
     return [...new Set([...specific, ...COMMON_BINDABLE_PROPERTIES])];
+  }
+
+  // --- Custom (third party) controls ------------------------------------------
+
+  isCustom(element: MauiElement): boolean {
+    return element.type === ElementType.Custom;
+  }
+
+  customDefinition(element: MauiElement): CustomControlDefinition | null {
+    return this.registry.findForElement(element)?.definition || null;
+  }
+
+  customPackage(element: MauiElement): string {
+    return this.registry.findForElement(element)?.manifest.package || 'Unknown package';
+  }
+
+  customProperties(element: MauiElement): CustomPropertyDefinition[] {
+    return this.customDefinition(element)?.properties || [];
+  }
+
+  customValue(element: MauiElement, property: string): string {
+    return element.properties.customValues?.[property] ?? '';
+  }
+
+  customBoolean(element: MauiElement, property: string): boolean {
+    return /^true$/i.test(this.customValue(element, property));
+  }
+
+  updateCustomValue(element: MauiElement, property: string, value: string | number | boolean) {
+    const customValues = { ...(element.properties.customValues || {}) };
+    const next = typeof value === 'boolean' ? (value ? 'True' : 'False') : String(value);
+
+    if (next === '') {
+      delete customValues[property];
+    } else {
+      customValues[property] = next;
+    }
+
+    this.elementService.updateElementProperties(element, { customValues });
+  }
+
+  /** Attributes kept from imported XAML that the manifest does not declare. */
+  rawAttributeNames(element: MauiElement): string[] {
+    return Object.keys(element.properties.rawAttributes || {});
+  }
+
+  rawAttributeValue(element: MauiElement, name: string): string {
+    return element.properties.rawAttributes?.[name] ?? '';
+  }
+
+  updateRawAttribute(element: MauiElement, name: string, value: string) {
+    const rawAttributes = { ...(element.properties.rawAttributes || {}) };
+    if (value === '') {
+      delete rawAttributes[name];
+    } else {
+      rawAttributes[name] = value;
+    }
+    this.elementService.updateElementProperties(element, { rawAttributes });
   }
 
   bindingValue(element: MauiElement, property: string): string {

--- a/src/app/components/toolbox/toolbox.html
+++ b/src/app/components/toolbox/toolbox.html
@@ -49,6 +49,81 @@
     </ng-container>
   </div>
 
+  <!-- Custom controls from NuGet package manifests -->
+  <div class="category-group" data-testid="custom-controls-section">
+    <div class="category-header">
+      <h3 class="category-title">Custom controls</h3>
+      <div class="category-actions">
+        <button
+          class="icon-button"
+          type="button"
+          data-testid="import-manifest"
+          title="Import a control manifest (JSON)"
+          (click)="manifestInput.click()">
+          <span class="material-icons">upload_file</span>
+        </button>
+        <button
+          class="icon-button"
+          type="button"
+          data-testid="export-manifests"
+          title="Export all control manifests"
+          (click)="exportManifests()">
+          <span class="material-icons">download</span>
+        </button>
+      </div>
+    </div>
+
+    <input
+      #manifestInput
+      type="file"
+      class="hidden-file-input"
+      accept="application/json,.json"
+      data-testid="manifest-file"
+      (change)="importManifest($event)">
+
+    <p class="manifest-error" *ngIf="manifestError" data-testid="manifest-error">{{ manifestError }}</p>
+
+    <ng-container *ngFor="let manifest of (manifests$ | async)">
+      <div class="manifest-group" *ngIf="visibleControls(manifest).length" [attr.data-testid]="'manifest-' + manifest.id">
+        <div class="manifest-header">
+          <span class="manifest-name" [title]="manifest.description || manifest.package">{{ manifest.package }}</span>
+          <button
+            class="icon-button"
+            type="button"
+            [attr.data-testid]="'manifest-remove-' + manifest.id"
+            [attr.aria-label]="'Remove ' + manifest.package"
+            (click)="removeManifest(manifest)">
+            <span class="material-icons">close</span>
+          </button>
+        </div>
+
+        <div class="toolbox-items">
+          <div
+            class="toolbox-item"
+            *ngFor="let control of visibleControls(manifest)"
+            [attr.data-testid]="'custom-item-' + manifest.xmlns.prefix + '-' + control.tag"
+            role="button"
+            tabindex="0"
+            draggable="true"
+            (dragstart)="onCustomDragStart($event, manifest, control)"
+            (dragend)="onDragEnd()"
+            (click)="onCustomItemClick(manifest, control)"
+            (keydown)="onCustomItemKeydown($event, manifest, control)"
+            [title]="control.description || control.tag">
+
+            <div class="item-icon">
+              <span class="material-icons">{{ control.icon }}</span>
+            </div>
+
+            <div class="item-label">
+              {{ control.displayName || control.tag }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+
   <!-- Saved component templates -->
   <div class="category-group" *ngIf="(templates$ | async) as templates" data-testid="templates-section">
     <ng-container *ngIf="templates.length">

--- a/src/app/components/toolbox/toolbox.scss
+++ b/src/app/components/toolbox/toolbox.scss
@@ -177,3 +177,68 @@
     &:hover { color: #ef4444; }
   }
 }
+
+/* Custom controls from NuGet package manifests */
+.category-actions .icon-button,
+.manifest-header .icon-button {
+  display: inline-flex;
+  align-items: center;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #94a3b8;
+  padding: 0;
+
+  .material-icons { font-size: 16px; }
+
+  &:hover { color: #2563eb; }
+}
+
+.manifest-header .icon-button:hover { color: #ef4444; }
+
+.category-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.category-actions {
+  display: flex;
+  gap: 2px;
+}
+
+.hidden-file-input {
+  display: none;
+}
+
+.manifest-error {
+  margin: 4px 0 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: #fdecea;
+  color: #b3261e;
+  font-size: 11px;
+}
+
+.manifest-group {
+  margin-bottom: 10px;
+}
+
+.manifest-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 2px 4px;
+  color: #6b7280;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.manifest-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/app/components/toolbox/toolbox.ts
+++ b/src/app/components/toolbox/toolbox.ts
@@ -6,6 +6,8 @@ import { ElementType, MauiElement } from '../../models/maui-element';
 import { ElementService } from '../../services/element';
 import { DragDropService, TOOLBOX_DRAG_MIME } from '../../services/drag-drop';
 import { ClipboardService, ComponentTemplate, StarterPage } from '../../services/clipboard';
+import { CustomControlRegistryService } from '../../services/custom-control-registry';
+import { CustomControlDefinition, CustomControlManifest } from '../../models/custom-control';
 import { Observable } from 'rxjs';
 
 @Component({
@@ -22,14 +24,89 @@ export class ToolboxComponent {
 
   templates$: Observable<ComponentTemplate[]>;
   starterPages: StarterPage[];
+  manifests$: Observable<CustomControlManifest[]>;
+  manifestError = '';
 
   constructor(
     private elementService: ElementService,
     private dragDropService: DragDropService,
-    private clipboardService: ClipboardService
+    private clipboardService: ClipboardService,
+    private registry: CustomControlRegistryService
   ) {
     this.templates$ = this.clipboardService.templates$;
     this.starterPages = this.clipboardService.starterPages;
+    this.manifests$ = this.registry.manifests$;
+  }
+
+  // --- Custom controls --------------------------------------------------------
+
+  /** Controls of a manifest that survive the current search filter. */
+  visibleControls(manifest: CustomControlManifest): CustomControlDefinition[] {
+    const term = this.searchTerm.trim().toLowerCase();
+    return manifest.controls.filter(control =>
+      !term ||
+      control.tag.toLowerCase().includes(term) ||
+      (control.displayName || '').toLowerCase().includes(term) ||
+      manifest.package.toLowerCase().includes(term)
+    );
+  }
+
+  onCustomItemClick(manifest: CustomControlManifest, control: CustomControlDefinition) {
+    const parent = this.resolveTargetParent();
+    const element = this.elementService.createElement(
+      ElementType.Custom,
+      this.registry.defaultProperties({ manifest, definition: control })
+    );
+    this.elementService.addElement(element, parent);
+    this.elementService.selectElement(element);
+  }
+
+  onCustomItemKeydown(event: KeyboardEvent, manifest: CustomControlManifest, control: CustomControlDefinition) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.onCustomItemClick(manifest, control);
+    }
+  }
+
+  onCustomDragStart(event: DragEvent, manifest: CustomControlManifest, control: CustomControlDefinition) {
+    const payload = `Custom:${manifest.xmlns.prefix}:${control.tag}`;
+    this.dragDropService.startDrag({ elementType: ElementType.Custom, isFromToolbox: true });
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'copy';
+      event.dataTransfer.setData(TOOLBOX_DRAG_MIME, payload);
+      event.dataTransfer.setData('text/plain', control.tag);
+    }
+  }
+
+  removeManifest(manifest: CustomControlManifest) {
+    this.registry.remove(manifest.id);
+  }
+
+  async importManifest(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      this.registry.import(await file.text());
+      this.manifestError = '';
+    } catch (error: any) {
+      this.manifestError = error?.message || 'Could not import that manifest.';
+    } finally {
+      input.value = '';
+    }
+  }
+
+  exportManifests() {
+    const blob = new Blob([this.registry.export()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'maui-designer-controls.json';
+    link.click();
+    URL.revokeObjectURL(url);
   }
 
   // --- Templates & starter pages ---------------------------------------------
@@ -69,7 +146,10 @@ export class ToolboxComponent {
   }
 
   get hasAnyResult(): boolean {
-    return this.categories.some(category => this.hasItems(category));
+    return (
+      this.categories.some(category => this.hasItems(category)) ||
+      this.registry.manifests.some(manifest => this.visibleControls(manifest).length > 0)
+    );
   }
 
   clearSearch() {
@@ -109,10 +189,10 @@ export class ToolboxComponent {
    */
   resolveTargetParent(): MauiElement {
     const selected = this.elementService.getSelectedElement();
-    if (selected && this.dragDropService.canHaveChildren(selected.type)) {
+    if (selected && this.dragDropService.canElementHaveChildren(selected)) {
       return selected;
     }
-    if (selected?.parent && this.dragDropService.canHaveChildren(selected.parent.type)) {
+    if (selected?.parent && this.dragDropService.canElementHaveChildren(selected.parent)) {
       return selected.parent;
     }
     return this.elementService.getRootElement();

--- a/src/app/models/custom-control.ts
+++ b/src/app/models/custom-control.ts
@@ -1,0 +1,183 @@
+/**
+ * Third party controls (Syncfusion, Telerik, CommunityToolkit, in-house NuGet
+ * packages, ...) are described by JSON manifests instead of code, so the
+ * designer can render, edit and generate them without knowing the package.
+ */
+
+export type CustomPropertyType = 'string' | 'number' | 'boolean' | 'color' | 'enum';
+
+export interface CustomPropertyDefinition {
+  /** XAML attribute name, e.g. `CornerRadius`. */
+  name: string;
+  type: CustomPropertyType;
+  defaultValue?: string | number | boolean;
+  /** Allowed values for `enum` properties. */
+  options?: string[];
+  /** Defaults to true: the property is offered in the Data Bindings section. */
+  bindable?: boolean;
+  description?: string;
+}
+
+/** How a custom control is drawn on the canvas. */
+export type CustomPreviewKind = 'box' | 'text' | 'image' | 'list' | 'slot';
+
+export interface CustomPreview {
+  kind: CustomPreviewKind;
+  /** Supports `{PropertyName}` placeholders, e.g. `"{Text}"`. */
+  label?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  /** Supports `{PropertyName}` placeholders. */
+  cornerRadius?: string;
+  /** Material icon name shown in the preview. */
+  icon?: string;
+}
+
+export interface CustomControlDefinition {
+  /** Local XAML tag name without the prefix, e.g. `AvatarView`. */
+  tag: string;
+  displayName?: string;
+  description?: string;
+  /** Material icon name for the toolbox entry. */
+  icon?: string;
+  canHaveChildren?: boolean;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  preview?: CustomPreview;
+  properties?: CustomPropertyDefinition[];
+}
+
+export interface CustomNamespace {
+  /** XML prefix used in the document, e.g. `toolkit`. */
+  prefix: string;
+  /** Namespace URI or `clr-namespace:` declaration. */
+  uri: string;
+}
+
+export interface CustomControlManifest {
+  id: string;
+  /** Package or library name shown as the toolbox group title. */
+  package: string;
+  version?: string;
+  description?: string;
+  xmlns: CustomNamespace;
+  controls: CustomControlDefinition[];
+  /**
+   * True when the manifest was inferred from imported XAML rather than
+   * supplied by the user, so it can be refreshed as more XAML is seen.
+   */
+  learned?: boolean;
+}
+
+/** A control together with the manifest it came from. */
+export interface CustomControlLookup {
+  manifest: CustomControlManifest;
+  definition: CustomControlDefinition;
+}
+
+/** The key used to match an element to its definition: `prefix:Tag`. */
+export function customControlKey(prefix: string | undefined, tag: string): string {
+  return prefix ? `${prefix}:${tag}` : tag;
+}
+
+/** Bundled manifest for the official .NET MAUI Community Toolkit. */
+export const COMMUNITY_TOOLKIT_MANIFEST: CustomControlManifest = {
+  id: 'communitytoolkit-maui',
+  package: 'CommunityToolkit.Maui',
+  version: '9.x',
+  description: 'Official .NET MAUI Community Toolkit views',
+  xmlns: {
+    prefix: 'toolkit',
+    uri: 'http://schemas.microsoft.com/dotnet/2022/maui/toolkit'
+  },
+  controls: [
+    {
+      tag: 'AvatarView',
+      displayName: 'AvatarView',
+      description: 'Circular avatar with initials or an image',
+      icon: 'account_circle',
+      defaultWidth: 48,
+      defaultHeight: 48,
+      preview: { kind: 'text', label: '{Text}', cornerRadius: '{CornerRadius}', backgroundColor: '#512bd4', textColor: '#ffffff' },
+      properties: [
+        { name: 'Text', type: 'string', defaultValue: 'AB' },
+        { name: 'CornerRadius', type: 'number', defaultValue: 24 },
+        { name: 'BorderColor', type: 'color', defaultValue: '#512bd4' },
+        { name: 'BorderWidth', type: 'number', defaultValue: 1 },
+        { name: 'ImageSource', type: 'string' }
+      ]
+    },
+    {
+      tag: 'Expander',
+      displayName: 'Expander',
+      description: 'Collapsible container',
+      icon: 'expand_more',
+      canHaveChildren: true,
+      defaultWidth: 240,
+      defaultHeight: 120,
+      preview: { kind: 'slot', label: 'Expander', icon: 'expand_more' },
+      properties: [
+        { name: 'IsExpanded', type: 'boolean', defaultValue: true },
+        { name: 'Direction', type: 'enum', options: ['Down', 'Up'], defaultValue: 'Down' }
+      ]
+    },
+    {
+      tag: 'DrawingView',
+      displayName: 'DrawingView',
+      description: 'Free hand drawing surface',
+      icon: 'draw',
+      defaultWidth: 240,
+      defaultHeight: 160,
+      preview: { kind: 'box', label: 'DrawingView', icon: 'draw' },
+      properties: [
+        { name: 'LineColor', type: 'color', defaultValue: '#000000' },
+        { name: 'LineWidth', type: 'number', defaultValue: 5 },
+        { name: 'IsMultiLineModeEnabled', type: 'boolean', defaultValue: false }
+      ]
+    },
+    {
+      tag: 'MediaElement',
+      displayName: 'MediaElement',
+      description: 'Audio and video playback',
+      icon: 'play_circle',
+      defaultWidth: 280,
+      defaultHeight: 160,
+      preview: { kind: 'image', label: 'MediaElement', icon: 'play_circle', backgroundColor: '#101828' },
+      properties: [
+        { name: 'Source', type: 'string' },
+        { name: 'ShouldAutoPlay', type: 'boolean', defaultValue: false },
+        { name: 'ShouldShowPlaybackControls', type: 'boolean', defaultValue: true },
+        { name: 'Aspect', type: 'enum', options: ['AspectFit', 'AspectFill', 'Fill'], defaultValue: 'AspectFit' }
+      ]
+    },
+    {
+      tag: 'Popup',
+      displayName: 'Popup',
+      description: 'Modal popup content host',
+      icon: 'picture_in_picture',
+      canHaveChildren: true,
+      defaultWidth: 260,
+      defaultHeight: 160,
+      preview: { kind: 'slot', label: 'Popup', icon: 'picture_in_picture' },
+      properties: [
+        { name: 'CanBeDismissedByTappingOutsideOfPopup', type: 'boolean', defaultValue: true },
+        { name: 'Color', type: 'color', defaultValue: '#ffffff' }
+      ]
+    },
+    {
+      tag: 'SemanticOrderView',
+      displayName: 'SemanticOrderView',
+      description: 'Controls the screen reader order of its children',
+      icon: 'format_list_numbered',
+      canHaveChildren: true,
+      defaultWidth: 240,
+      defaultHeight: 120,
+      preview: { kind: 'slot', label: 'SemanticOrderView', icon: 'format_list_numbered' },
+      properties: []
+    }
+  ]
+};
+
+/** Manifests shipped with the designer. */
+export const BUNDLED_MANIFESTS: CustomControlManifest[] = [COMMUNITY_TOOLKIT_MANIFEST];

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -30,7 +30,9 @@ export enum ElementType {
   Frame = 'Frame',
   Border = 'Border',
   ScrollView = 'ScrollView',
-  CollectionView = 'CollectionView'
+  CollectionView = 'CollectionView',
+  /** Any control that comes from a NuGet package manifest or imported XAML. */
+  Custom = 'Custom'
 }
 
 export const DEFAULT_ICON_PATH_DATA = 'M12 2L2 22h20L12 2Z';
@@ -89,6 +91,20 @@ export interface ElementProperties {
   // CollectionView preview
   itemCount?: number;
   itemTemplateText?: string;
+
+  // Custom (third party) control properties
+  /** Local XAML tag of a custom control, e.g. `AvatarView`. */
+  customTag?: string;
+  /** XML prefix the control is emitted with, e.g. `toolkit`. */
+  customPrefix?: string;
+  /** Namespace URI, kept on the element so XAML survives without the manifest. */
+  customNamespace?: string;
+  /** Values for the properties declared in the control's manifest. */
+  customValues?: Record<string, string>;
+  /** Attributes the designer does not model, preserved verbatim. */
+  rawAttributes?: Record<string, string>;
+  /** Property elements of a custom control (e.g. Expander.Header), kept as XML. */
+  rawContentXml?: string[];
 
   // Other properties
   isVisible?: boolean;

--- a/src/app/services/clipboard.ts
+++ b/src/app/services/clipboard.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { ElementService } from './element';
 import { XamlParserService } from './xaml-parser';
+import { CustomControlRegistryService } from './custom-control-registry';
 import { MauiElement, ElementType } from '../models/maui-element';
 
 export interface ComponentTemplate {
@@ -111,7 +112,8 @@ export class ClipboardService {
 
   constructor(
     private elementService: ElementService,
-    private xamlParser: XamlParserService
+    private xamlParser: XamlParserService,
+    private registry: CustomControlRegistryService
   ) {
     this.buffer = this.readClipboard();
   }
@@ -209,7 +211,7 @@ export class ClipboardService {
 
   private resolveTargetParent(): MauiElement {
     const selected = this.elementService.getSelectedElement();
-    if (selected && this.canHaveChildren(selected.type)) {
+    if (selected && this.canHaveChildren(selected.type, selected)) {
       return selected;
     }
     if (selected?.parent) {
@@ -218,7 +220,10 @@ export class ClipboardService {
     return this.elementService.getRootElement();
   }
 
-  private canHaveChildren(type: ElementType): boolean {
+  private canHaveChildren(type: ElementType, element?: MauiElement): boolean {
+    if (type === ElementType.Custom && element) {
+      return this.registry.findForElement(element)?.definition.canHaveChildren ?? false;
+    }
     return [
       ElementType.StackLayout,
       ElementType.VerticalStackLayout,

--- a/src/app/services/custom-control-registry.service.spec.ts
+++ b/src/app/services/custom-control-registry.service.spec.ts
@@ -1,0 +1,169 @@
+import { TestBed } from '@angular/core/testing';
+import { CustomControlRegistryService } from './custom-control-registry';
+import { COMMUNITY_TOOLKIT_MANIFEST, CustomControlManifest } from '../models/custom-control';
+import { ElementService } from './element';
+import { ElementType } from '../models/maui-element';
+
+const SYNCFUSION_MANIFEST: CustomControlManifest = {
+  id: 'syncfusion-sample',
+  package: 'Syncfusion.Maui.Inputs',
+  xmlns: { prefix: 'sf', uri: 'clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs' },
+  controls: [
+    {
+      tag: 'SfComboBox',
+      displayName: 'Combo box',
+      defaultWidth: 200,
+      defaultHeight: 40,
+      preview: { kind: 'box', label: '{Placeholder}' },
+      properties: [
+        { name: 'Placeholder', type: 'string', defaultValue: 'Select an item' },
+        { name: 'IsEditable', type: 'boolean', defaultValue: false }
+      ]
+    }
+  ]
+};
+
+describe('CustomControlRegistryService', () => {
+  let service: CustomControlRegistryService;
+
+  beforeEach(() => {
+    localStorage.removeItem('maui-designer.custom-controls');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CustomControlRegistryService);
+  });
+
+  afterEach(() => localStorage.removeItem('maui-designer.custom-controls'));
+
+  it('ships the CommunityToolkit manifest out of the box', () => {
+    const lookup = service.find('toolkit', 'AvatarView');
+
+    expect(lookup).toBeTruthy();
+    expect(lookup!.manifest.package).toBe(COMMUNITY_TOOLKIT_MANIFEST.package);
+    expect(lookup!.definition.properties!.some(property => property.name === 'CornerRadius')).toBeTrue();
+  });
+
+  it('imports a manifest and exposes its controls', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+
+    const lookup = service.find('sf', 'SfComboBox');
+    expect(lookup).toBeTruthy();
+    expect(lookup!.definition.displayName).toBe('Combo box');
+    expect(service.controls.length).toBeGreaterThan(COMMUNITY_TOOLKIT_MANIFEST.controls.length);
+  });
+
+  it('imports an array of manifests', () => {
+    service.import(JSON.stringify([SYNCFUSION_MANIFEST]));
+    expect(service.find('sf', 'SfComboBox')).toBeTruthy();
+  });
+
+  it('rejects a manifest without a namespace', () => {
+    expect(() => service.import(JSON.stringify({ package: 'Broken', controls: [] }))).toThrow();
+  });
+
+  it('finds controls case insensitively and without a prefix', () => {
+    expect(service.find('toolkit', 'avatarview')).toBeTruthy();
+    expect(service.find(undefined, 'AvatarView')).toBeTruthy();
+  });
+
+  it('removes a manifest', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    service.remove('syncfusion-sample');
+
+    expect(service.find('sf', 'SfComboBox')).toBeNull();
+  });
+
+  it('persists manifests across instances', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const restored = TestBed.inject(CustomControlRegistryService);
+
+    expect(restored.find('sf', 'SfComboBox')).toBeTruthy();
+    expect(restored.find('toolkit', 'AvatarView')).toBeTruthy();
+  });
+
+  it('exports the registry as JSON', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    const exported = JSON.parse(service.export()) as CustomControlManifest[];
+
+    expect(exported.some(manifest => manifest.id === 'syncfusion-sample')).toBeTrue();
+  });
+
+  it('learns an unknown control from imported XAML', () => {
+    const lookup = service.learn('telerik', 'clr-namespace:Telerik.Maui', 'RadCalendar', {
+      SelectionMode: 'Single',
+      DayCellHeight: '32',
+      IsVisible: 'True'
+    });
+
+    expect(lookup.definition.tag).toBe('RadCalendar');
+    expect(lookup.manifest.learned).toBeTrue();
+    expect(lookup.definition.properties!.find(p => p.name === 'DayCellHeight')!.type).toBe('number');
+    expect(lookup.definition.properties!.find(p => p.name === 'IsVisible')!.type).toBe('boolean');
+    expect(lookup.definition.properties!.find(p => p.name === 'SelectionMode')!.type).toBe('string');
+  });
+
+  it('never downgrades a supplied manifest to a learned one', () => {
+    service.learn('toolkit', 'http://schemas.microsoft.com/dotnet/2022/maui/toolkit', 'AvatarView', { Text: 'ZZ' });
+
+    const lookup = service.find('toolkit', 'AvatarView')!;
+    expect(lookup.manifest.learned).toBeFalsy();
+    expect(lookup.definition.displayName).toBe('AvatarView');
+  });
+
+  it('adds newly learned properties to an existing learned control', () => {
+    service.learn('acme', 'clr-namespace:Acme', 'Gauge', { Value: '10' });
+    const lookup = service.learn('acme', 'clr-namespace:Acme', 'Gauge', { Maximum: '100' });
+
+    const names = lookup.definition.properties!.map(property => property.name);
+    expect(names).toContain('Value');
+    expect(names).toContain('Maximum');
+  });
+
+  it('builds default properties from a manifest', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    const lookup = service.find('sf', 'SfComboBox')!;
+
+    const properties = service.defaultProperties(lookup);
+
+    expect(properties.customTag).toBe('SfComboBox');
+    expect(properties.customPrefix).toBe('sf');
+    expect(properties.customNamespace).toContain('Syncfusion');
+    expect(properties.width).toBe(200);
+    expect(properties.customValues!['Placeholder']).toBe('Select an item');
+  });
+
+  it('interpolates preview placeholders from the element values', () => {
+    const elements = TestBed.inject(ElementService);
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    const lookup = service.find('sf', 'SfComboBox')!;
+    const element = elements.createElement(ElementType.Custom, service.defaultProperties(lookup));
+
+    expect(service.interpolate('{Placeholder}', element)).toBe('Select an item');
+    expect(service.interpolate('{Missing}', element)).toBe('');
+  });
+
+  it('lists bindable properties including preserved attributes', () => {
+    const elements = TestBed.inject(ElementService);
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    const lookup = service.find('sf', 'SfComboBox')!;
+    const element = elements.createElement(ElementType.Custom, {
+      ...service.defaultProperties(lookup),
+      rawAttributes: { ItemsSource: 'Items' }
+    });
+
+    const bindable = service.bindableProperties(element);
+    expect(bindable).toContain('Placeholder');
+    expect(bindable).toContain('ItemsSource');
+  });
+
+  it('restores the bundled manifests on reset', () => {
+    service.import(JSON.stringify(SYNCFUSION_MANIFEST));
+    service.resetToBundled();
+
+    expect(service.find('sf', 'SfComboBox')).toBeNull();
+    expect(service.find('toolkit', 'AvatarView')).toBeTruthy();
+  });
+});

--- a/src/app/services/custom-control-registry.ts
+++ b/src/app/services/custom-control-registry.ts
@@ -1,0 +1,290 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import {
+  BUNDLED_MANIFESTS,
+  CustomControlDefinition,
+  CustomControlLookup,
+  CustomControlManifest,
+  CustomPropertyDefinition,
+  customControlKey
+} from '../models/custom-control';
+import { ElementProperties, MauiElement } from '../models/maui-element';
+
+/**
+ * Holds the manifests that describe third party controls. Manifests can be
+ * bundled with the app, imported as JSON (for example generated from a NuGet
+ * package), or learned automatically from imported XAML.
+ */
+@Injectable({ providedIn: 'root' })
+export class CustomControlRegistryService {
+  private static readonly STORAGE_KEY = 'maui-designer.custom-controls';
+
+  private manifestsSubject = new BehaviorSubject<CustomControlManifest[]>(this.restore());
+  manifests$ = this.manifestsSubject.asObservable();
+
+  get manifests(): CustomControlManifest[] {
+    return this.manifestsSubject.value;
+  }
+
+  /** Every registered control, flattened, for toolbox rendering. */
+  get controls(): CustomControlLookup[] {
+    return this.manifests.flatMap(manifest =>
+      manifest.controls.map(definition => ({ manifest, definition }))
+    );
+  }
+
+  /** Finds a control by `prefix:Tag`, falling back to a prefix-less match. */
+  find(prefix: string | undefined, tag: string): CustomControlLookup | null {
+    const byPrefix = this.manifests
+      .filter(manifest => !prefix || manifest.xmlns.prefix === prefix)
+      .flatMap(manifest => manifest.controls.map(definition => ({ manifest, definition })))
+      .find(entry => entry.definition.tag.toLowerCase() === tag.toLowerCase());
+
+    if (byPrefix) {
+      return byPrefix;
+    }
+
+    return (
+      this.controls.find(entry => entry.definition.tag.toLowerCase() === tag.toLowerCase()) || null
+    );
+  }
+
+  findForElement(element: MauiElement): CustomControlLookup | null {
+    const { customTag, customPrefix } = element.properties;
+    return customTag ? this.find(customPrefix, customTag) : null;
+  }
+
+  /** The properties a custom element can be bound to. */
+  bindableProperties(element: MauiElement): string[] {
+    const lookup = this.findForElement(element);
+    const declared = (lookup?.definition.properties || [])
+      .filter(property => property.bindable !== false)
+      .map(property => property.name);
+    const raw = Object.keys(element.properties.rawAttributes || {});
+    return [...new Set([...declared, ...raw])];
+  }
+
+  // --- Manifest management ----------------------------------------------------
+
+  /** Adds or replaces a manifest (matched on id, or on namespace prefix). */
+  register(manifest: CustomControlManifest): CustomControlManifest {
+    const normalized = this.normalize(manifest);
+    const existing = this.manifests.find(
+      candidate => candidate.id === normalized.id || candidate.xmlns.prefix === normalized.xmlns.prefix
+    );
+
+    const next = existing
+      ? this.manifests.map(candidate => (candidate === existing ? this.merge(existing, normalized) : candidate))
+      : [...this.manifests, normalized];
+
+    this.write(next);
+    return this.manifests.find(candidate => candidate.id === normalized.id) || normalized;
+  }
+
+  remove(id: string): void {
+    this.write(this.manifests.filter(manifest => manifest.id !== id));
+  }
+
+  /** Restores the bundled manifests and drops everything else. */
+  resetToBundled(): void {
+    this.write(BUNDLED_MANIFESTS.map(manifest => this.normalize(manifest)));
+  }
+
+  /** Parses a manifest JSON document; accepts a single manifest or an array. */
+  import(json: string): CustomControlManifest[] {
+    const parsed = JSON.parse(json);
+    const candidates: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+    const imported: CustomControlManifest[] = [];
+
+    for (const candidate of candidates) {
+      const manifest = candidate as CustomControlManifest;
+      if (!manifest || !manifest.xmlns?.prefix || !manifest.xmlns?.uri || !Array.isArray(manifest.controls)) {
+        throw new Error('Invalid manifest: expected { package, xmlns: { prefix, uri }, controls: [] }');
+      }
+      imported.push(this.register(manifest));
+    }
+
+    return imported;
+  }
+
+  export(): string {
+    return JSON.stringify(this.manifests, null, 2);
+  }
+
+  /**
+   * Registers a control seen in imported XAML so it becomes editable even
+   * though no manifest was supplied. Existing manifests are never downgraded.
+   */
+  learn(prefix: string, uri: string, tag: string, attributes: Record<string, string>): CustomControlLookup {
+    const existing = this.find(prefix, tag);
+    if (existing && !existing.manifest.learned) {
+      return existing;
+    }
+
+    const properties: CustomPropertyDefinition[] = Object.keys(attributes).map(name => ({
+      name,
+      type: this.inferType(attributes[name])
+    }));
+
+    const manifest = this.manifests.find(candidate => candidate.xmlns.prefix === prefix);
+    const definition: CustomControlDefinition = {
+      tag,
+      displayName: tag,
+      description: `Learned from imported XAML (${prefix ? `${prefix}:` : ''}${tag})`,
+      icon: 'extension',
+      canHaveChildren: true,
+      preview: { kind: 'box', label: tag, icon: 'extension' },
+      properties
+    };
+
+    if (manifest) {
+      const merged: CustomControlManifest = {
+        ...manifest,
+        controls: manifest.controls.some(control => control.tag === tag)
+          ? manifest.controls.map(control =>
+              control.tag === tag ? this.mergeDefinition(control, definition) : control
+            )
+          : [...manifest.controls, definition]
+      };
+      this.write(this.manifests.map(candidate => (candidate === manifest ? merged : candidate)));
+    } else {
+      this.write([
+        ...this.manifests,
+        this.normalize({
+          id: `learned-${prefix || 'default'}`,
+          package: prefix ? `Imported (${prefix})` : 'Imported controls',
+          description: 'Controls discovered in imported XAML',
+          xmlns: { prefix, uri },
+          controls: [definition],
+          learned: true
+        })
+      ]);
+    }
+
+    return this.find(prefix, tag)!;
+  }
+
+  // --- Element helpers --------------------------------------------------------
+
+  /** Default designer properties for a control described by a manifest. */
+  defaultProperties(lookup: CustomControlLookup): Partial<ElementProperties> {
+    const { manifest, definition } = lookup;
+    const customValues: Record<string, string> = {};
+
+    for (const property of definition.properties || []) {
+      if (property.defaultValue !== undefined) {
+        customValues[property.name] = String(property.defaultValue);
+      }
+    }
+
+    return {
+      x: 0,
+      y: 0,
+      width: definition.defaultWidth ?? 120,
+      height: definition.defaultHeight ?? 48,
+      isVisible: true,
+      isEnabled: true,
+      customTag: definition.tag,
+      customPrefix: manifest.xmlns.prefix,
+      customNamespace: manifest.xmlns.uri,
+      customValues,
+      rawAttributes: {}
+    };
+  }
+
+  /** Resolves `{Property}` placeholders in a preview string. */
+  interpolate(template: string | undefined, element: MauiElement): string {
+    if (!template) {
+      return '';
+    }
+    const values = element.properties.customValues || {};
+    const raw = element.properties.rawAttributes || {};
+    return template.replace(/\{([^}]+)\}/g, (_, name: string) => values[name] ?? raw[name] ?? '');
+  }
+
+  // --- Internals --------------------------------------------------------------
+
+  private inferType(value: string): CustomPropertyDefinition['type'] {
+    if (/^(true|false)$/i.test(value)) {
+      return 'boolean';
+    }
+    if (/^-?\d+(\.\d+)?$/.test(value)) {
+      return 'number';
+    }
+    if (/^#[0-9a-f]{3,8}$/i.test(value)) {
+      return 'color';
+    }
+    return 'string';
+  }
+
+  private normalize(manifest: CustomControlManifest): CustomControlManifest {
+    return {
+      ...manifest,
+      id: manifest.id || `manifest-${manifest.xmlns.prefix}-${Date.now()}`,
+      package: manifest.package || manifest.xmlns.prefix,
+      controls: manifest.controls.map(control => ({
+        ...control,
+        displayName: control.displayName || control.tag,
+        icon: control.icon || 'extension',
+        properties: control.properties || []
+      }))
+    };
+  }
+
+  /** A supplied manifest always wins over a learned one. */
+  private merge(existing: CustomControlManifest, incoming: CustomControlManifest): CustomControlManifest {
+    const controls = [...incoming.controls];
+    for (const control of existing.controls) {
+      if (!controls.some(candidate => candidate.tag === control.tag)) {
+        controls.push(control);
+      }
+    }
+    return { ...existing, ...incoming, controls, learned: incoming.learned && existing.learned };
+  }
+
+  private mergeDefinition(
+    existing: CustomControlDefinition,
+    incoming: CustomControlDefinition
+  ): CustomControlDefinition {
+    const properties = [...(existing.properties || [])];
+    for (const property of incoming.properties || []) {
+      if (!properties.some(candidate => candidate.name === property.name)) {
+        properties.push(property);
+      }
+    }
+    return { ...existing, properties };
+  }
+
+  private write(manifests: CustomControlManifest[]): void {
+    this.manifestsSubject.next(manifests);
+    try {
+      localStorage.setItem(CustomControlRegistryService.STORAGE_KEY, JSON.stringify(manifests));
+    } catch {
+      // storage is optional
+    }
+  }
+
+  private restore(): CustomControlManifest[] {
+    const bundled = BUNDLED_MANIFESTS.map(manifest => this.normalize(manifest));
+    try {
+      const stored = localStorage.getItem(CustomControlRegistryService.STORAGE_KEY);
+      if (!stored) {
+        return bundled;
+      }
+      const parsed = JSON.parse(stored) as CustomControlManifest[];
+      if (!Array.isArray(parsed)) {
+        return bundled;
+      }
+      // Bundled manifests are always available, user manifests win on conflict
+      const merged = [...parsed.map(manifest => this.normalize(manifest))];
+      for (const manifest of bundled) {
+        if (!merged.some(candidate => candidate.xmlns.prefix === manifest.xmlns.prefix)) {
+          merged.push(manifest);
+        }
+      }
+      return merged;
+    } catch {
+      return bundled;
+    }
+  }
+}

--- a/src/app/services/custom-control-xaml.spec.ts
+++ b/src/app/services/custom-control-xaml.spec.ts
@@ -1,0 +1,163 @@
+import { TestBed } from '@angular/core/testing';
+import { XamlParserService } from './xaml-parser';
+import { XamlGeneratorService } from './xaml-generator';
+import { CustomControlRegistryService } from './custom-control-registry';
+import { ElementType } from '../models/maui-element';
+
+const THIRD_PARTY_XAML = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:sf="clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"
+             x:Class="YourApp.MainPage">
+    <AbsoluteLayout x:Name="RootLayout" WidthRequest="800" HeightRequest="600">
+        <toolkit:AvatarView x:Name="Avatar" Text="AB" CornerRadius="24"
+                            AbsoluteLayout.LayoutBounds="10,10,48,48" WidthRequest="48" HeightRequest="48" />
+        <sf:SfComboBox x:Name="Picker" Placeholder="Pick one" ItemsSource="{Binding Items}"
+                       AbsoluteLayout.LayoutBounds="10,80,200,40" WidthRequest="200" HeightRequest="40" />
+    </AbsoluteLayout>
+</ContentPage>`;
+
+describe('Custom controls in XAML', () => {
+  let parser: XamlParserService;
+  let generator: XamlGeneratorService;
+  let registry: CustomControlRegistryService;
+
+  beforeEach(() => {
+    localStorage.removeItem('maui-designer.custom-controls');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    parser = TestBed.inject(XamlParserService);
+    generator = TestBed.inject(XamlGeneratorService);
+    registry = TestBed.inject(CustomControlRegistryService);
+  });
+
+  afterEach(() => localStorage.removeItem('maui-designer.custom-controls'));
+
+  it('keeps unknown controls instead of dropping them', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+
+    expect(root.children.length).toBe(2);
+    expect(root.children[0].type).toBe(ElementType.Custom);
+    expect(root.children[0].properties.customTag).toBe('AvatarView');
+    expect(root.children[0].properties.customPrefix).toBe('toolkit');
+    expect(root.children[1].properties.customTag).toBe('SfComboBox');
+  });
+
+  it('maps manifest properties and preserves the rest', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+    const avatar = root.children[0];
+    const combo = root.children[1];
+
+    expect(avatar.properties.customValues!['Text']).toBe('AB');
+    expect(avatar.properties.customValues!['CornerRadius']).toBe('24');
+    // SfComboBox is unknown, so its attributes are learned into a manifest
+    expect(combo.properties.customValues!['Placeholder']).toBe('Pick one');
+  });
+
+  it('captures bindings on custom controls', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+
+    expect(root.children[1].properties.bindings!['ItemsSource']).toBe('Items');
+  });
+
+  it('keeps the designer layout properties of custom controls', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+    const avatar = root.children[0];
+
+    expect(avatar.properties.x).toBe(10);
+    expect(avatar.properties.y).toBe(10);
+    expect(avatar.properties.width).toBe(48);
+    expect(avatar.name).toBe('Avatar');
+  });
+
+  it('regenerates the third party tags with their namespaces', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+    const xaml = generator.generateXaml(root);
+
+    expect(xaml).toContain('xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"');
+    expect(xaml).toContain('xmlns:sf="clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs"');
+    expect(xaml).toContain('<toolkit:AvatarView');
+    expect(xaml).toContain('<sf:SfComboBox');
+    expect(xaml).toContain('Text="AB"');
+    expect(xaml).toContain('CornerRadius="24"');
+    expect(xaml).toContain('ItemsSource="{Binding Items}"');
+  });
+
+  it('only declares namespaces that are used', () => {
+    const root = parser.parseXaml(THIRD_PARTY_XAML);
+    root.children = [];
+
+    expect(generator.generateXaml(root)).not.toContain('xmlns:toolkit');
+  });
+
+  it('round trips a custom control through parse and generate', () => {
+    const first = generator.generateXaml(parser.parseXaml(THIRD_PARTY_XAML));
+    const second = generator.generateXaml(parser.parseXaml(first));
+
+    expect(second).toContain('<toolkit:AvatarView');
+    expect(second).toContain('Text="AB"');
+    expect(second).toContain('Placeholder="Pick one"');
+    expect(second).toContain('ItemsSource="{Binding Items}"');
+  });
+
+  it('preserves attributes the designer does not model', () => {
+    const xaml = THIRD_PARTY_XAML.replace('Text="AB"', 'Text="AB" ImageSource="avatar.png" Rotation="15"');
+    const root = parser.parseXaml(xaml);
+    const avatar = root.children[0];
+
+    expect(avatar.properties.customValues!['ImageSource']).toBe('avatar.png');
+    expect(avatar.properties.rawAttributes!['Rotation']).toBe('15');
+    expect(generator.generateXaml(root)).toContain('Rotation="15"');
+  });
+
+  it('keeps property elements of custom controls verbatim', () => {
+    const xaml = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit">
+    <AbsoluteLayout x:Name="RootLayout" WidthRequest="800" HeightRequest="600">
+        <toolkit:Expander x:Name="Details" AbsoluteLayout.LayoutBounds="0,0,240,120" WidthRequest="240" HeightRequest="120">
+            <toolkit:Expander.Header>
+                <Label Text="More" />
+            </toolkit:Expander.Header>
+        </toolkit:Expander>
+    </AbsoluteLayout>
+</ContentPage>`;
+
+    const root = parser.parseXaml(xaml);
+    const generated = generator.generateXaml(root);
+
+    expect(root.children[0].properties.rawContentXml!.length).toBe(1);
+    expect(generated).toContain('<toolkit:Expander.Header>');
+    expect(generated).toContain('Text="More"');
+  });
+
+  it('nests children of a custom container', () => {
+    const xaml = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit">
+    <AbsoluteLayout x:Name="RootLayout" WidthRequest="800" HeightRequest="600">
+        <toolkit:Expander x:Name="Details" AbsoluteLayout.LayoutBounds="0,0,240,120" WidthRequest="240" HeightRequest="120">
+            <Label x:Name="Inner" Text="Body" />
+        </toolkit:Expander>
+    </AbsoluteLayout>
+</ContentPage>`;
+
+    const root = parser.parseXaml(xaml);
+    const expander = root.children[0];
+
+    expect(expander.children.length).toBe(1);
+    expect(expander.children[0].type).toBe(ElementType.Label);
+    expect(generator.generateXaml(root)).toContain('<Label x:Name="Inner"');
+  });
+
+  it('registers unknown controls so they appear in the toolbox', () => {
+    parser.parseXaml(THIRD_PARTY_XAML);
+
+    const lookup = registry.find('sf', 'SfComboBox');
+    expect(lookup).toBeTruthy();
+    expect(lookup!.manifest.xmlns.uri).toContain('Syncfusion');
+  });
+});

--- a/src/app/services/drag-drop.ts
+++ b/src/app/services/drag-drop.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { CdkDragDrop, CdkDragEnd, CdkDragStart, transferArrayItem } from '@angular/cdk/drag-drop';
 import { ElementService } from './element';
+import { CustomControlRegistryService } from './custom-control-registry';
 import { LayoutDesignerService } from './layout-designer';
-import { MauiElement, ElementType } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties } from '../models/maui-element';
 import { BehaviorSubject, min } from 'rxjs';
 
 export interface DragData {
@@ -25,7 +26,8 @@ export class DragDropService {
 
   constructor(
     private elementService: ElementService,
-    private layoutDesigner: LayoutDesignerService
+    private layoutDesigner: LayoutDesignerService,
+    private registry: CustomControlRegistryService
   ) { }
 
   startDrag(data: DragData): void {
@@ -56,10 +58,16 @@ export class DragDropService {
    * Creates a new element of the given type inside the layout under the drop point.
    * Used by the native drag from the toolbox onto the canvas.
    */
-  createElementAtPosition(elementType: ElementType, dropX: number, dropY: number, canvasElement: HTMLElement): MauiElement {
+  createElementAtPosition(
+    elementType: ElementType,
+    dropX: number,
+    dropY: number,
+    canvasElement: HTMLElement,
+    properties?: Partial<ElementProperties>
+  ): MauiElement {
     const targetLayout = this.findLayoutAtPosition(dropX, dropY, canvasElement) || this.elementService.getRootElement();
 
-    const newElement = this.elementService.createElement(elementType);
+    const newElement = this.elementService.createElement(elementType, properties);
     this.elementService.addElement(newElement, targetLayout);
 
     const position = this.layoutDesigner.getChildLayoutProperties(
@@ -148,7 +156,7 @@ export class DragDropService {
     }
     
     // Check if target can accept children
-    return this.canHaveChildren(target.type);
+    return this.canElementHaveChildren(target);
   }
 
   /**
@@ -234,6 +242,14 @@ export class DragDropService {
       current = current.parent;
     }
     return false;
+  }
+
+  /** Custom controls declare in their manifest whether they accept children. */
+  canElementHaveChildren(element: MauiElement): boolean {
+    if (element.type === ElementType.Custom) {
+      return this.registry.findForElement(element)?.definition.canHaveChildren ?? false;
+    }
+    return this.canHaveChildren(element.type);
   }
 
   canHaveChildren(elementType: ElementType): boolean {

--- a/src/app/services/drag-drop.ts
+++ b/src/app/services/drag-drop.ts
@@ -80,7 +80,18 @@ export class DragDropService {
     return newElement;
   }
 
-  private resolveLocalPosition(targetLayout: MauiElement, dropX: number, dropY: number, canvasElement: HTMLElement): { x: number, y: number } {
+  /**
+   * The canvas is rendered inside a CSS scale transform, so client rectangles are zoomed while the
+   * model works in unscaled design pixels. This derives the current scale without a viewport dependency.
+   */
+  private canvasScale(canvasElement: HTMLElement): number {
+    const rect = canvasElement.getBoundingClientRect();
+    const layoutWidth = canvasElement.offsetWidth;
+    return layoutWidth > 0 && rect.width > 0 ? rect.width / layoutWidth : 1;
+  }
+
+  /** Converts a canvas-space point into coordinates local to the given layout. */
+  resolveLocalPosition(targetLayout: MauiElement, dropX: number, dropY: number, canvasElement: HTMLElement): { x: number, y: number } {
     const layoutInfo = this.layoutDesigner.getLayoutInfo(targetLayout.type);
     const dom = targetLayout.domElement;
 
@@ -88,10 +99,11 @@ export class DragDropService {
       return { x: dropX, y: dropY };
     }
 
+    const scale = this.canvasScale(canvasElement);
     const rect = dom.getBoundingClientRect();
     const canvasRect = canvasElement.getBoundingClientRect();
-    const localX = dropX - (rect.left - canvasRect.left);
-    const localY = dropY - (rect.top - canvasRect.top);
+    const localX = dropX - (rect.left - canvasRect.left) / scale;
+    const localY = dropY - (rect.top - canvasRect.top) / scale;
 
     if (layoutInfo.supportsGridPositioning) {
       const cell = this.layoutDesigner.getGridCellAtPosition(targetLayout, localX, localY, dom);
@@ -101,19 +113,21 @@ export class DragDropService {
     return { x: localX, y: localY };
   }
 
-  handleElementMove(element: MauiElement, x: number, y: number, targetParent: MauiElement): void {
+  handleElementMove(element: MauiElement, x: number, y: number, targetParent: MauiElement, canvasElement?: HTMLElement): void {
     // A move is a single undo step even though it touches several properties
-    this.elementService.runAsSingleChange(() => this.applyElementMove(element, x, y, targetParent));
+    this.elementService.runAsSingleChange(() => this.applyElementMove(element, x, y, targetParent, canvasElement));
   }
 
-  private applyElementMove(element: MauiElement, x: number, y: number, targetParent: MauiElement): void {
-    // Get layout info for the target parent
-    const layoutInfo = this.layoutDesigner.getLayoutInfo(targetParent.type);
-    
-    // Calculate appropriate position based on layout type
-    let domElement = targetParent.id === 'root' ? null! : targetParent.domElement!;
-    const position = this.layoutDesigner.calculateDropPosition(targetParent, { clientX: x, clientY: y } as MouseEvent, domElement!);
-    
+  private applyElementMove(element: MauiElement, x: number, y: number, targetParent: MauiElement, canvasElement?: HTMLElement): void {
+    // x/y arrive in canvas space; translate them into the target layout's own coordinates
+    const position = canvasElement
+      ? this.resolveLocalPosition(targetParent, x, y, canvasElement)
+      : this.layoutDesigner.calculateDropPosition(
+          targetParent,
+          { clientX: x, clientY: y } as MouseEvent,
+          targetParent.id === 'root' ? null : targetParent.domElement ?? null
+        );
+
     // Get layout-specific properties for the child element
     const layoutProperties = this.layoutDesigner.getChildLayoutProperties(targetParent, element, position);
     
@@ -162,34 +176,47 @@ export class DragDropService {
   /**
    * Handles dropping an element at a specific position on the canvas
    */
-  handleCanvasDrop(draggedElement: MauiElement, dropX: number, dropY: number, canvasElement: HTMLElement): void {
-    // Find the layout element at the drop position
-    const targetLayout = this.findLayoutAtPosition(dropX, dropY, canvasElement);
-    
+  handleCanvasDrop(
+    draggedElement: MauiElement,
+    dropX: number,
+    dropY: number,
+    canvasElement: HTMLElement,
+    hitPoint?: { x: number, y: number }
+  ): void {
+    // The pointer decides which layout receives the element, the element's own corner decides where
+    const hit = hitPoint ?? { x: dropX, y: dropY };
+    const targetLayout = this.findLayoutAtPosition(hit.x, hit.y, canvasElement, draggedElement);
+
     if (targetLayout && this.canDropOn(targetLayout, draggedElement)) {
-      this.handleElementMove(draggedElement, dropX, dropY, targetLayout);
+      this.handleElementMove(draggedElement, dropX, dropY, targetLayout, canvasElement);
     }
   }
 
   /**
    * Finds the layout element at a specific position on the canvas
    */
-  findLayoutAtPosition(x: number, y: number, canvasElement: HTMLElement): MauiElement | null {
+  findLayoutAtPosition(x: number, y: number, canvasElement: HTMLElement, draggedElement?: MauiElement): MauiElement | null {
     // Get all layout elements from the DOM
     const layoutElements = canvasElement.querySelectorAll('.layout-element');
-    let layoutElementsAtPosition = [];
+    const layoutElementsAtPosition: Element[] = [];
     let deepestLayout: MauiElement | null = null;
+    const scale = this.canvasScale(canvasElement);
+    const canvasRect = canvasElement.getBoundingClientRect();
+    const draggedDom = draggedElement?.domElement;
 
     for (const element of Array.from(layoutElements)) {
+      // A layout can never be dropped into itself or into one of its own descendants
+      if (draggedDom && (element === draggedDom || draggedDom.contains(element))) {
+        continue;
+      }
+
       const rect = element.getBoundingClientRect();
-      const canvasRect = canvasElement.getBoundingClientRect();
-      
-      // Convert absolute coordinates to relative coordinates
-      const relativeX = x - (rect.left - canvasRect.left);
-      const relativeY = y - (rect.top - canvasRect.top);
-      
-      // Check if point is within this element
-      if (relativeX >= 0 && relativeX <= rect.width && relativeY >= 0 && relativeY <= rect.height) {
+
+      // Client rectangles are zoomed, canvas coordinates are not
+      const relativeX = x - (rect.left - canvasRect.left) / scale;
+      const relativeY = y - (rect.top - canvasRect.top) / scale;
+
+      if (relativeX >= 0 && relativeX <= rect.width / scale && relativeY >= 0 && relativeY <= rect.height / scale) {
         layoutElementsAtPosition.push(element);
       }
     }
@@ -198,18 +225,21 @@ export class DragDropService {
       return this.elementService.getRootElement();
     }
 
-    // Find the deepest layout element that can contain children
-    let minNesting = 1000;
-    let finalElement;
+    // Prefer the most deeply nested layout under the point, not the one with the fewest children
+    let finalElement = layoutElementsAtPosition[0];
+    let maxDepth = -1;
     for (const elem of layoutElementsAtPosition) {
-      const numberOfNestings = elem.querySelectorAll('.layout-element').length;
-      if(numberOfNestings < minNesting) {
-        minNesting = numberOfNestings;
+      let depth = 0;
+      for (let node = elem.parentElement; node && node !== canvasElement; node = node.parentElement) {
+        depth++;
+      }
+      if (depth > maxDepth) {
+        maxDepth = depth;
         finalElement = elem;
       }
     }
 
-    deepestLayout = this.getMauiElementFromDOMElement(finalElement!);
+    deepestLayout = this.getMauiElementFromDOMElement(finalElement);
 
     // If no specific layout found, return root element
     return deepestLayout || this.elementService.getRootElement();

--- a/src/app/services/element.ts
+++ b/src/app/services/element.ts
@@ -54,12 +54,15 @@ export class ElementService {
   createElement(type: ElementType, properties?: Partial<ElementProperties>): MauiElement {
     this.elementCounter++;
     const defaultProperties = this.getDefaultProperties(type);
-    
+    const merged = { ...defaultProperties, ...properties };
+    // Custom controls are named after their XAML tag, not after "Custom"
+    const baseName = type === ElementType.Custom && merged.customTag ? merged.customTag : type;
+
     return {
       id: `element_${this.elementCounter}`,
       type: type,
-      name: `${type}${this.elementCounter}`,
-      properties: { ...defaultProperties, ...properties },
+      name: `${baseName}${this.elementCounter}`,
+      properties: merged,
       children: []
     };
   }
@@ -248,6 +251,14 @@ export class ElementService {
           ...common,
           width: 200,
           height: 200
+        };
+      case ElementType.Custom:
+        return {
+          ...common,
+          width: 120,
+          height: 48,
+          customValues: {},
+          rawAttributes: {}
         };
       default:
         return common;

--- a/src/app/services/host-bridge.spec.ts
+++ b/src/app/services/host-bridge.spec.ts
@@ -1,0 +1,171 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HostBridgeService, HostInboundMessage } from './host-bridge';
+
+describe('HostBridgeService', () => {
+  const originalChrome = (window as any).chrome;
+  const originalAcquire = (window as any).acquireVsCodeApi;
+
+  afterEach(() => {
+    (window as any).chrome = originalChrome;
+    (window as any).acquireVsCodeApi = originalAcquire;
+  });
+
+  function create(): HostBridgeService {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    return TestBed.inject(HostBridgeService);
+  }
+
+  function post(message: unknown) {
+    window.dispatchEvent(new MessageEvent('message', { data: message }));
+  }
+
+  it('reports a plain browser when no host is present', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(service.host).toBe('browser');
+    expect(service.isHosted).toBeFalse();
+  });
+
+  it('sending a message in a browser is a no-op', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(() => service.save('<ContentPage />')).not.toThrow();
+  });
+
+  it('detects Visual Studio through the WebView2 bridge', () => {
+    const posted: unknown[] = [];
+    (window as any).chrome = { webview: { postMessage: (m: unknown) => posted.push(m) } };
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(service.host).toBe('visual-studio');
+    expect(service.isHosted).toBeTrue();
+    // The designer announces itself as soon as it is hosted
+    expect(posted).toEqual([JSON.stringify({ type: 'designer.ready' })]);
+  });
+
+  it('serialises messages to Visual Studio as JSON strings', () => {
+    const posted: string[] = [];
+    (window as any).chrome = { webview: { postMessage: (m: string) => posted.push(m) } };
+
+    const service = create();
+    service.save('<ContentPage />');
+
+    expect(JSON.parse(posted[1])).toEqual({ type: 'document.save', xaml: '<ContentPage />' });
+  });
+
+  it('detects VS Code and posts structured messages', () => {
+    (window as any).chrome = undefined;
+    const posted: unknown[] = [];
+    (window as any).acquireVsCodeApi = () => ({ postMessage: (m: unknown) => posted.push(m) });
+
+    const service = create();
+    service.notifyChanged('<ContentPage />');
+
+    expect(service.host).toBe('vscode');
+    expect(posted).toEqual([
+      { type: 'designer.ready' },
+      { type: 'document.changed', xaml: '<ContentPage />' }
+    ]);
+  });
+
+  it('acquires the VS Code API only once', () => {
+    (window as any).chrome = undefined;
+    let calls = 0;
+    (window as any).acquireVsCodeApi = () => {
+      calls++;
+      return { postMessage: () => undefined };
+    };
+
+    const service = create();
+    service.notifyChanged('a');
+    service.notifyChanged('b');
+
+    expect(calls).toBe(1);
+    expect(service.host).toBe('vscode');
+  });
+
+  it('forwards messages received from the host', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post({ type: 'document.load', xaml: '<ContentPage />', fileName: 'MainPage.xaml' });
+
+    expect(received).toEqual([
+      { type: 'document.load', xaml: '<ContentPage />', fileName: 'MainPage.xaml' } as HostInboundMessage
+    ]);
+  });
+
+  it('accepts JSON encoded messages, as WebView2 delivers them', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post(JSON.stringify({ type: 'document.load', xaml: '<Grid />' }));
+
+    expect(received.length).toBe(1);
+    expect((received[0] as { xaml: string }).xaml).toBe('<Grid />');
+  });
+
+  it('ignores malformed or unrelated window messages', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post('not json at all');
+    post({ nope: true });
+    post(null);
+    post(42);
+
+    expect(received).toEqual([]);
+  });
+
+  it('tracks the file name the host opened', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    expect(service.fileName).toBeNull();
+
+    post({ type: 'host.ready', host: 'visual-studio', fileName: 'Views/LoginPage.xaml' });
+
+    expect(service.fileName).toBe('Views/LoginPage.xaml');
+  });
+
+  it('lets the host correct the detected kind', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    post({ type: 'host.ready', host: 'vscode' });
+
+    expect(service.host).toBe('vscode');
+  });
+
+  it('does not listen for host messages in a plain browser', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post({ type: 'document.load', xaml: '<ContentPage />' });
+
+    expect(received).toEqual([]);
+  });
+});

--- a/src/app/services/host-bridge.ts
+++ b/src/app/services/host-bridge.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+
+import { CustomControlManifest } from '../models/custom-control';
+
+/** Messages the host (Visual Studio / VS Code) sends into the designer. */
+export type HostInboundMessage =
+  | { type: 'host.ready'; host: HostKind; fileName?: string }
+  | { type: 'document.load'; xaml: string; fileName?: string }
+  | { type: 'manifests.push'; manifests: CustomControlManifest[] }
+  | { type: 'document.saved' };
+
+/** Messages the designer sends back to the host. */
+export type HostOutboundMessage =
+  | { type: 'designer.ready' }
+  | { type: 'document.changed'; xaml: string }
+  | { type: 'document.save'; xaml: string }
+  | { type: 'manifests.request' }
+  | { type: 'designer.error'; message: string };
+
+export type HostKind = 'visual-studio' | 'vscode' | 'browser';
+
+interface VsCodeApi {
+  postMessage(message: unknown): void;
+}
+
+declare global {
+  interface Window {
+    chrome?: { webview?: { postMessage(message: unknown): void } };
+    acquireVsCodeApi?: () => VsCodeApi;
+  }
+}
+
+/**
+ * Normalises the differences between the hosts the designer can run in.
+ *
+ * - Visual Studio hosts the built app in a WebView2 control and exchanges JSON through
+ *   `window.chrome.webview`.
+ * - VS Code hosts it in a webview and exchanges JSON through `acquireVsCodeApi()`.
+ * - In a plain browser the designer is standalone and every send is a no-op.
+ *
+ * Everything above this service is host agnostic.
+ */
+@Injectable({ providedIn: 'root' })
+export class HostBridgeService {
+  private readonly hostSubject: BehaviorSubject<HostKind>;
+  private readonly messageSubject = new Subject<HostInboundMessage>();
+  private readonly fileNameSubject = new BehaviorSubject<string | null>(null);
+  private vsCodeApi: VsCodeApi | null = null;
+
+  /** The host the designer is currently running in. */
+  readonly host$: Observable<HostKind>;
+  /** Messages pushed by the host. */
+  readonly messages$ = this.messageSubject.asObservable();
+  /** The document the host has opened, when there is one. */
+  readonly fileName$ = this.fileNameSubject.asObservable();
+
+  constructor() {
+    this.hostSubject = new BehaviorSubject<HostKind>(this.detectHost());
+    this.host$ = this.hostSubject.asObservable();
+
+    if (this.isHosted) {
+      window.addEventListener('message', this.onWindowMessage);
+      this.send({ type: 'designer.ready' });
+    }
+  }
+
+  get host(): HostKind {
+    return this.hostSubject.value;
+  }
+
+  /** True when the designer is embedded in an IDE rather than running standalone. */
+  get isHosted(): boolean {
+    return this.host !== 'browser';
+  }
+
+  get fileName(): string | null {
+    return this.fileNameSubject.value;
+  }
+
+  /** Sends a message to the host. Does nothing in a plain browser. */
+  send(message: HostOutboundMessage): void {
+    switch (this.host) {
+      case 'visual-studio':
+        window.chrome!.webview!.postMessage(JSON.stringify(message));
+        return;
+      case 'vscode':
+        this.vsCodeApi?.postMessage(message);
+        return;
+      default:
+        return;
+    }
+  }
+
+  /** Asks the host to persist the given XAML into the open document. */
+  save(xaml: string): void {
+    this.send({ type: 'document.save', xaml });
+  }
+
+  /** Tells the host the design changed so it can mark the document dirty. */
+  notifyChanged(xaml: string): void {
+    this.send({ type: 'document.changed', xaml });
+  }
+
+  /** Asks the host for control manifests generated from the project's NuGet packages. */
+  requestManifests(): void {
+    this.send({ type: 'manifests.request' });
+  }
+
+  reportError(message: string): void {
+    this.send({ type: 'designer.error', message });
+  }
+
+  /** Entry point used by the hosts: both post a message event onto the window. */
+  private readonly onWindowMessage = (event: MessageEvent) => {
+    const message = this.parse(event.data);
+    if (!message) {
+      return;
+    }
+
+    if (message.type === 'host.ready') {
+      this.hostSubject.next(message.host);
+    }
+    if ((message.type === 'host.ready' || message.type === 'document.load') && message.fileName) {
+      this.fileNameSubject.next(message.fileName);
+    }
+
+    this.messageSubject.next(message);
+  };
+
+  private parse(data: unknown): HostInboundMessage | null {
+    let payload: unknown = data;
+    if (typeof payload === 'string') {
+      try {
+        payload = JSON.parse(payload);
+      } catch {
+        return null;
+      }
+    }
+
+    if (!payload || typeof payload !== 'object' || typeof (payload as { type?: unknown }).type !== 'string') {
+      return null;
+    }
+    return payload as HostInboundMessage;
+  }
+
+  private detectHost(): HostKind {
+    if (typeof window === 'undefined') {
+      return 'browser';
+    }
+    if (window.chrome?.webview) {
+      return 'visual-studio';
+    }
+    if (typeof window.acquireVsCodeApi === 'function') {
+      this.vsCodeApi = window.acquireVsCodeApi();
+      return 'vscode';
+    }
+    return 'browser';
+  }
+}

--- a/src/app/services/layout-designer.ts
+++ b/src/app/services/layout-designer.ts
@@ -94,12 +94,15 @@ export class LayoutDesignerService {
       columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
     };
     
+    // offsetWidth/Height are unscaled, so grid maths stay correct while the canvas is zoomed
     const rect = containerElement.getBoundingClientRect();
+    const width = containerElement.offsetWidth || rect.width;
+    const height = containerElement.offsetHeight || rect.height;
     const rows = gridDefinition.rows.length;
     const columns = gridDefinition.columns.length;
-    
-    const cellWidth = rect.width / columns;
-    const cellHeight = rect.height / rows;
+
+    const cellWidth = width / columns;
+    const cellHeight = height / rows;
     
     const column = Math.min(Math.floor(x / cellWidth), columns - 1);
     const row = Math.min(Math.floor(y / cellHeight), rows - 1);

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -10,13 +10,35 @@ export class XamlGeneratorService {
 
   generateXaml(rootElement: MauiElement): string {
     const xamlContent = this.generateElementXaml(rootElement, 0);
-    
+    const namespaces = this.collectNamespaceDeclarations(rootElement);
+
     return `<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"${namespaces}
              x:Class="YourApp.MainPage">
 ${xamlContent}
 </ContentPage>`;
+  }
+
+  /**
+   * Only the namespaces actually used by custom controls in the tree are
+   * declared, so the generated page stays clean.
+   */
+  private collectNamespaceDeclarations(rootElement: MauiElement): string {
+    const used = new Map<string, string>();
+
+    const walk = (element: MauiElement) => {
+      const { customPrefix, customNamespace } = element.properties;
+      if (element.type === ElementType.Custom && customPrefix && customNamespace) {
+        used.set(customPrefix, customNamespace);
+      }
+      element.children.forEach(walk);
+    };
+    walk(rootElement);
+
+    return [...used.entries()]
+      .map(([prefix, uri]) => `\n             xmlns:${prefix}="${uri}"`)
+      .join('');
   }
 
   private generateElementXaml(element: MauiElement, indentLevel: number): string {
@@ -26,8 +48,9 @@ ${xamlContent}
     const attributes = this.generateAttributes(element);
     const hasChildren = element.children && element.children.length > 0;
     const isGrid = element.type === ElementType.Grid;
+    const rawContent = element.properties.rawContentXml || [];
 
-    if (!hasChildren && !isGrid) {
+    if (!hasChildren && !isGrid && rawContent.length === 0) {
       return `${indent}<${elementName}${attributes} />`;
     }
 
@@ -36,6 +59,11 @@ ${xamlContent}
     // Add special content for certain layouts
     if (isGrid) {
       xaml += this.generateGridDefinitions(element, indentLevel + 1);
+    }
+
+    // Property elements of custom controls are re-emitted verbatim
+    for (const raw of rawContent) {
+      xaml += `\n${'    '.repeat(indentLevel + 2)}${raw}`;
     }
 
     // Add children (a CollectionView wraps them in a DataTemplate)
@@ -66,6 +94,11 @@ ${xamlContent}
   }
 
   private getXamlElementName(element: MauiElement): string {
+    if (element.type === ElementType.Custom) {
+      const tag = element.properties.customTag || 'ContentView';
+      return element.properties.customPrefix ? `${element.properties.customPrefix}:${tag}` : tag;
+    }
+
     switch (element.type) {
       case ElementType.StackLayout:
         return element.properties.orientation === Orientation.Horizontal
@@ -116,6 +149,16 @@ ${xamlContent}
     // Add name attribute
     if (element.name) {
       attributes.push(`x:Name="${element.name}"`);
+    }
+
+    // Manifest driven and preserved attributes win over the generic mapping
+    if (element.type === ElementType.Custom) {
+      for (const [name, value] of Object.entries(props.customValues || {})) {
+        push(name, this.escapeXml(String(value)));
+      }
+      for (const [name, value] of Object.entries(props.rawAttributes || {})) {
+        push(name, this.escapeXml(value));
+      }
     }
     
     // For children of AbsoluteLayout
@@ -271,7 +314,18 @@ ${xamlContent}
       }
     }
 
-    return attributes.length > 0 ? ' ' + attributes.join(' ') : '';
+    // An attribute may only appear once: the first writer wins
+    const seen = new Set<string>();
+    const unique = attributes.filter(attribute => {
+      const name = attribute.slice(0, attribute.indexOf('='));
+      if (seen.has(name)) {
+        return false;
+      }
+      seen.add(name);
+      return true;
+    });
+
+    return unique.length > 0 ? ' ' + unique.join(' ') : '';
   }
 
   private generateGridDefinitions(element: MauiElement, indentLevel: number): string {

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -1,12 +1,35 @@
 import { Injectable } from '@angular/core';
 import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA } from '../models/maui-element';
+import { CustomControlRegistryService } from './custom-control-registry';
+
+/** Attributes the designer models itself, so they never end up in rawAttributes. */
+const RESERVED_ATTRIBUTES = new Set([
+  'x:name',
+  'x:class',
+  'absolutelayout.layoutbounds',
+  'absolutelayout.layoutflags',
+  'grid.row',
+  'grid.column',
+  'grid.rowspan',
+  'grid.columnspan',
+  'widthrequest',
+  'heightrequest',
+  'backgroundcolor',
+  'margin',
+  'padding',
+  'isvisible',
+  'isenabled'
+]);
 
 @Injectable({
   providedIn: 'root'
 })
 export class XamlParserService {
 
-  constructor() { }
+  /** xmlns prefixes declared on the document being parsed. */
+  private namespaces: Record<string, string> = {};
+
+  constructor(private registry: CustomControlRegistryService) { }
 
   parseXaml(xamlContent: string): MauiElement {
     try {
@@ -25,6 +48,8 @@ export class XamlParserService {
       if (!contentPage) {
         throw new Error('No root element found');
       }
+
+      this.namespaces = this.collectNamespaces(contentPage);
 
       if (contentPage.tagName.toLowerCase() === 'svg') {
         return this.parseSvgIcon(contentPage);
@@ -73,27 +98,33 @@ export class XamlParserService {
   }
 
   private parseElement(xmlElement: Element, parent: MauiElement | null): MauiElement {
-    const elementType = this.getElementTypeFromTag(xmlElement.tagName);
-    if (!elementType) {
-      throw new Error(`Unsupported element type: ${xmlElement.tagName}`);
-    }
+    const elementType = this.getElementTypeFromTag(xmlElement.tagName) ?? ElementType.Custom;
+    const properties = this.parseProperties(xmlElement, elementType, parent);
+    const fallbackName = elementType === ElementType.Custom
+      ? `${properties.customTag}${this.idCounter}`
+      : `${elementType}${this.idCounter}`;
 
     const element: MauiElement = {
       id: this.generateId(),
       type: elementType,
-      name: xmlElement.getAttribute('x:Name') || `${elementType}${this.idCounter}`,
-      properties: this.parseProperties(xmlElement, elementType, parent),
+      name: xmlElement.getAttribute('x:Name') || fallbackName,
+      properties,
       children: [],
       parent: parent || undefined
     };
 
-    // Parse child elements
-    for (const childXmlElement of this.getChildElements(xmlElement)) {
-      const childElementType = this.getElementTypeFromTag(childXmlElement.tagName);
-      if (childElementType) {
-        const childElement = this.parseElement(childXmlElement, element);
-        element.children.push(childElement);
+    // Property elements of a custom control cannot be modelled, so keep the XML
+    if (elementType === ElementType.Custom) {
+      const rawContent = this.collectRawPropertyElements(xmlElement);
+      if (rawContent.length) {
+        element.properties.rawContentXml = rawContent;
       }
+    }
+
+    // Parse child elements: unknown tags become custom elements, never dropped
+    for (const childXmlElement of this.getChildElements(xmlElement)) {
+      const childElement = this.parseElement(childXmlElement, element);
+      element.children.push(childElement);
     }
 
     if (elementType === ElementType.Grid) {
@@ -347,11 +378,91 @@ export class XamlParserService {
     return Number.isNaN(parsed) ? fallback : parsed;
   }
 
+  /** Serialises property elements such as `<toolkit:Expander.Header>` verbatim. */
+  private collectRawPropertyElements(xmlElement: Element): string[] {
+    const serializer = new XMLSerializer();
+    const raw: string[] = [];
+
+    for (let i = 0; i < xmlElement.children.length; i++) {
+      const child = xmlElement.children[i];
+      if (child.tagName.includes('.')) {
+        // The serializer repeats every namespace: they are declared on the page
+        raw.push(serializer.serializeToString(child).replace(/\s+xmlns(:[\w.-]+)?="[^"]*"/g, ''));
+      }
+    }
+
+    return raw;
+  }
+
+  /** Reads `xmlns:prefix="uri"` declarations from the document root. */
+  private collectNamespaces(root: Element): Record<string, string> {
+    const namespaces: Record<string, string> = {};
+    for (let i = 0; i < root.attributes.length; i++) {
+      const attribute = root.attributes[i];
+      if (attribute.name.startsWith('xmlns:')) {
+        namespaces[attribute.name.slice('xmlns:'.length)] = attribute.value;
+      }
+    }
+    return namespaces;
+  }
+
+  /**
+   * Keeps an unrecognised control usable: its tag, prefix, namespace and every
+   * attribute are preserved, and the control is registered so it can be edited.
+   */
+  private parseCustomControl(xmlElement: Element, properties: ElementProperties): void {
+    const [rawPrefix, rawTag] = xmlElement.tagName.includes(':')
+      ? xmlElement.tagName.split(':')
+      : ['', xmlElement.tagName];
+
+    const prefix = rawPrefix;
+    const tag = rawTag;
+    const uri = this.namespaces[prefix] || '';
+
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < xmlElement.attributes.length; i++) {
+      const attribute = xmlElement.attributes[i];
+      const name = attribute.name;
+      if (
+        name.startsWith('xmlns') ||
+        RESERVED_ATTRIBUTES.has(name.toLowerCase()) ||
+        this.isBindingExpression(attribute.value)
+      ) {
+        continue;
+      }
+      attributes[name] = attribute.value;
+    }
+
+    properties.customTag = tag;
+    properties.customPrefix = prefix || undefined;
+    properties.customNamespace = uri || undefined;
+
+    const lookup = this.registry.learn(prefix, uri, tag, attributes);
+    const declared = new Set((lookup.definition.properties || []).map(property => property.name));
+
+    const customValues: Record<string, string> = {};
+    const rawAttributes: Record<string, string> = {};
+    for (const [name, value] of Object.entries(attributes)) {
+      if (declared.has(name)) {
+        customValues[name] = value;
+      } else {
+        rawAttributes[name] = value;
+      }
+    }
+
+    properties.customValues = customValues;
+    properties.rawAttributes = rawAttributes;
+  }
+
   private parseProperties(xmlElement: Element, elementType: ElementType, parent: MauiElement | null): ElementProperties {
     const properties: ElementProperties = {
       isVisible: true,
       isEnabled: true
     };
+
+    if (elementType === ElementType.Custom) {
+      this.parseCustomControl(xmlElement, properties);
+    }
 
     // Bindings are captured separately so they survive a round trip
     const bindings = this.parseBindings(xmlElement);


### PR DESCRIPTION
## Why

People build MAUI UIs with controls that don't ship in the box — Syncfusion, Telerik, DevExpress, CommunityToolkit.Maui, or an internal shared library. Until now the designer threw those tags away: unknown elements were dropped on parse and could never be placed from the toolbox.

## What

Third-party controls are now **data, not code**. A small JSON manifest describes a package, and that single file drives the toolbox entry, the properties panel editors, the canvas preview and the generated XAML — no designer code changes, no NuGet resolution, no build step.

- **Manifest registry** (`custom-control-registry.ts`) — import from disk, export the whole registry, remove a pack, persisted in `localStorage`
- **Bundled CommunityToolkit.Maui pack** — `AvatarView`, `Expander`, `DrawingView`, `MediaElement`, `Popup`, `SemanticOrderView` work out of the box
- **Lossless round-trip of unknown tags** — namespaces, attributes, property elements (`<toolkit:Expander.Header>`) and nested children survive a parse/generate cycle verbatim. The namespace URI is stored on the element, so XAML keeps working even if the manifest is later removed
- **Learning parser** — a tag nobody declared is inferred from the XAML (including property types) and added to the toolbox automatically
- **Raw attribute editor** — anything the manifest doesn't declare is still editable
- **First-class citizens** — custom containers accept children and take part in drag-drop, clipboard, multi-select, alignment and undo

```json
{
  "id": "syncfusion-inputs",
  "package": "Syncfusion.Maui.Inputs",
  "xmlns": { "prefix": "sf", "uri": "clr-namespace:Syncfusion.Maui.Inputs;assembly=Syncfusion.Maui.Inputs" },
  "controls": [{
    "tag": "SfComboBox",
    "preview": { "kind": "box", "label": "{Placeholder}" },
    "properties": [{ "name": "Placeholder", "type": "string", "defaultValue": "Select an item" }]
  }]
}
```

## Bugs found and fixed along the way

- The generic property mapper also wrote `Text` for custom elements, producing `Attribute Text redefined`. Custom values are now emitted first and `generateAttributes` de-duplicates (first writer wins).
- `XMLSerializer` re-declares every namespace on serialized property elements; those injected `xmlns` attributes are now stripped.

## Testing

- 26 new unit tests (registry behaviour + XAML parse/generate contract) — **112/112 green**
- 16 new e2e tests in `e2e/custom-controls.spec.ts` — **136/136 green**
- Clean production build

## Also included

`docs/visual-studio-extension.md` — a feasibility assessment of turning the designer into a Visual Studio extension (VS 2022 VSIX with WebView2 and a custom `.xaml` editor, versus a VS Code webview extension), including how a VS host could generate these manifests automatically from the project's `PackageReference`s.