### PR TITLE
Host the designer inside a Visual Studio extension

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,7 @@ Always reference these instructions first and fallback to search or bash command
 - **Build Tests**: `ng build` -- verifies TypeScript compilation and bundling
 - **E2E Tests**: `npm run e2e` -- headless Playwright suite in `e2e/`; it boots `ng serve` on port 4300 automatically. Run `npx playwright install chromium` once first. Use `E2E_BASE_URL` to target an existing server.
 - **Test hooks**: components expose `data-testid` attributes consumed by `e2e/helpers/designer-page.ts`. Preserve them when editing templates.
+- **Extension tests**: `dotnet test extension/MauiDesigner.Core.sln` -- xUnit suite for the Visual Studio extension's cross-platform core. It runs on any OS; the VSIX itself needs Windows and the VS SDK.
 - **Polling helpers**: the XAML pane and the properties panel re-render from RxJS streams, so assert with `expectXamlToContain`, `xamlWhen`, `expectProperty` or `expectPropertyNumber` instead of one-shot reads, otherwise the tests flake on CI.
 - **Canvas coordinates**: the canvas sits inside a zoomable wrapper - convert client coordinates with `toCanvasPoint` (divide by `viewport.zoom`) in components, and avoid canvas x > ~400 in tests because the right panel overlaps it.
 - **Linting**: Use `ng lint` if ESLint is configured, or standard TypeScript compiler checks
@@ -138,7 +139,8 @@ typescript (5.5.4)
 - **Hot reloading**: Development server auto-reloads on file changes
 - **Keyboard shortcuts**: `Ctrl+Z`/`Ctrl+Y` undo-redo, `Ctrl+C`/`Ctrl+X`/`Ctrl+V` clipboard, `Ctrl+A` select all, `Ctrl+D` duplicate, `Delete` remove, arrow keys nudge, `Space`+drag or middle-drag to pan, `Ctrl`+wheel to zoom
 - **Bulk operations**: wrap multi-element changes in `elementService.runAsSingleChange()` with `{ recordHistory: false }` updates so they undo as one step
-- **CI/CD**: `.github/workflows/ci.yml` builds and runs unit + e2e tests; `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages on pushes to `main`
+- **IDE hosting**: `src/app/services/host-bridge.ts` detects Visual Studio (`window.chrome.webview`) or VS Code (`acquireVsCodeApi`). When hosted, the open document replaces browser storage as the source of truth -- `App.connectToHost()` applies `document.load`, streams `document.changed` and routes save to the host. Changing a message name means changing `extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs` too.
+- **CI/CD**: `.github/workflows/ci.yml` builds and runs unit + e2e tests plus the extension's `dotnet test`; `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages on pushes to `main`
 
 ## Troubleshooting
 - **Build fails with module not found**: Run `npm install` to ensure all dependencies are installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,18 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  extension-core:
+    name: Visual Studio extension (core library)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # Only the cross-platform half is built here; the VSIX itself needs
+      # Windows and the Visual Studio SDK. See extension/README.md.
+      - name: Test
+        run: dotnet test extension/MauiDesigner.Core.sln --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ Thumbs.db
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# .NET (extension/)
+[Bb]in/
+[Oo]bj/
+*.user
+*.vsix
+.vs/

--- a/README.md
+++ b/README.md
@@ -385,10 +385,19 @@ We welcome contributions! Please follow these steps:
 
 ## 🧩 IDE Integration
 
-Curious whether this designer can live inside Visual Studio? See
-[docs/visual-studio-extension.md](docs/visual-studio-extension.md) for a feasibility assessment of a
-VS 2022 VSIX (WebView2 + custom `.xaml` editor + NuGet-derived control manifests) and a VS Code
-webview extension.
+The designer also runs **inside Visual Studio 2022**. [`extension/`](extension/README.md) contains a
+VSIX that registers the designer as an alternative editor for `.xaml` files: it edits the same text
+buffer as the built-in XAML editor (so undo, the dirty marker and Ctrl+S all behave normally), and it
+generates toolbox entries from the controls in the project's own NuGet packages by inspecting
+`obj/project.assets.json` and the package assemblies.
+
+- [`extension/README.md`](extension/README.md) — how to build, test and debug the VSIX
+- [`docs/visual-studio-extension.md`](docs/visual-studio-extension.md) — the design rationale, and
+  why the classic in-process VSSDK model is required
+
+The web app detects its host at runtime (`src/app/services/host-bridge.ts`). In a plain browser
+nothing changes; inside an IDE the open document becomes the source of truth instead of browser
+storage.
 
 ## 📚 Resources
 

--- a/docs/visual-studio-extension.md
+++ b/docs/visual-studio-extension.md
@@ -1,6 +1,10 @@
 # Converting MAUI Designer into a Visual Studio extension
 
-*Feasibility assessment — verified against Microsoft Learn, WebView2 and VS Code extension docs.*
+*Design rationale — verified against Microsoft Learn, WebView2 and VS Code extension docs.*
+
+> **Status: Route A is implemented.** The VSIX and its cross-platform core library live in
+> [`extension/`](../extension/README.md); this document explains why it is built the way it is, and
+> what the alternatives were. Route B (VS Code) is still open.
 
 ## Short answer
 

--- a/e2e/ide-host.spec.ts
+++ b/e2e/ide-host.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { DesignerPage } from './helpers/designer-page';
+
+/**
+ * The designer is also shipped inside Visual Studio and VS Code, where the open
+ * document — not browser storage — is the source of truth. These tests stub the
+ * WebView2 bridge so the hosted path is exercised in a plain browser.
+ */
+
+/** Installs a fake `window.chrome.webview` before the app boots. */
+async function hostAsVisualStudio(page: Page) {
+  await page.addInitScript(() => {
+    const outbound: unknown[] = [];
+    (window as any).__hostMessages = outbound;
+    (window as any).chrome = {
+      webview: {
+        postMessage: (message: string) => outbound.push(JSON.parse(message))
+      }
+    };
+    (window as any).__sendToDesigner = (message: unknown) => {
+      window.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(message) }));
+    };
+  });
+}
+
+/** Messages the designer has posted back to the host. */
+function outbound(page: Page) {
+  return page.evaluate(() => (window as any).__hostMessages as { type: string; xaml?: string }[]);
+}
+
+async function sendToDesigner(page: Page, message: unknown) {
+  await page.evaluate(msg => (window as any).__sendToDesigner(msg), message);
+}
+
+test.describe('IDE host integration', () => {
+  test('announces itself and asks the host for control manifests', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await expect
+      .poll(async () => (await outbound(page)).map(m => m.type))
+      .toContain('designer.ready');
+
+    await sendToDesigner(page, { type: 'host.ready', host: 'visual-studio', fileName: 'MainPage.xaml' });
+
+    await expect
+      .poll(async () => (await outbound(page)).map(m => m.type))
+      .toContain('manifests.request');
+  });
+
+  test('opens the document the host pushes', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await sendToDesigner(page, {
+      type: 'document.load',
+      fileName: 'LoginPage.xaml',
+      xaml: `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Label Text="Hosted label" />
+  </AbsoluteLayout>
+</ContentPage>`
+    });
+
+    await designer.expectXamlToContain('Hosted label');
+    await expect(designer.canvas.locator('[data-element-type="Label"]')).toHaveCount(1);
+  });
+
+  test('streams every edit back to the host', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Button');
+
+    await expect
+      .poll(async () => {
+        const changes = (await outbound(page)).filter(m => m.type === 'document.changed');
+        return changes.length > 0 && changes[changes.length - 1].xaml!.includes('<Button');
+      })
+      .toBe(true);
+  });
+
+  test('save writes to the host document instead of browser storage', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Label');
+    await designer.saveButton.click();
+
+    await expect
+      .poll(async () => (await outbound(page)).filter(m => m.type === 'document.save').length)
+      .toBe(1);
+
+    // The browser-only toast must not appear when a host owns the document
+    await expect(designer.toast).toHaveCount(0);
+  });
+
+  test('registers custom controls the host discovered in NuGet packages', async ({ page }) => {
+    await hostAsVisualStudio(page);
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await sendToDesigner(page, {
+      type: 'manifests.push',
+      manifests: [
+        {
+          id: 'host.pack',
+          package: 'Contoso.Maui.Controls',
+          xmlns: {
+            prefix: 'contoso',
+            uri: 'clr-namespace:Contoso.Maui.Controls;assembly=Contoso.Maui.Controls'
+          },
+          controls: [
+            {
+              tag: 'RatingBar',
+              displayName: 'Rating Bar',
+              defaultWidth: 160,
+              defaultHeight: 40,
+              properties: []
+            }
+          ]
+        }
+      ]
+    });
+
+    await designer.openToolbox();
+    await expect(page.getByTestId('custom-item-contoso-RatingBar')).toBeVisible();
+  });
+
+  test('a plain browser is unaffected and still saves locally', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+
+    await designer.addControl('Label');
+    await designer.saveButton.click();
+
+    await expect(designer.toast).toContainText('Design saved to this browser');
+  });
+});

--- a/extension/MauiDesigner.Core.sln
+++ b/extension/MauiDesigner.Core.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core", "src\MauiDesigner.Core\MauiDesigner.Core.csproj", "{84A01464-33A0-41AC-B13D-1E2AB557F945}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C899E7CF-34A4-48FA-90C8-60E31F08536F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core.Tests", "tests\MauiDesigner.Core.Tests\MauiDesigner.Core.Tests.csproj", "{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Fakes", "Fakes", "{68503E8F-DC47-456D-902D-67F5DDF7C473}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Maui", "tests\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj", "{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Package", "tests\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj", "{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{68503E8F-DC47-456D-902D-67F5DDF7C473} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+	EndGlobalSection
+EndGlobal

--- a/extension/MauiDesigner.sln
+++ b/extension/MauiDesigner.sln
@@ -1,0 +1,60 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core", "src\MauiDesigner.Core\MauiDesigner.Core.csproj", "{84A01464-33A0-41AC-B13D-1E2AB557F945}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C899E7CF-34A4-48FA-90C8-60E31F08536F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Core.Tests", "tests\MauiDesigner.Core.Tests\MauiDesigner.Core.Tests.csproj", "{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Fakes", "Fakes", "{68503E8F-DC47-456D-902D-67F5DDF7C473}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Maui", "tests\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj", "{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Fakes.Package", "tests\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj", "{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiDesigner.Vsix", "src\MauiDesigner.Vsix\MauiDesigner.Vsix.csproj", "{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A01464-33A0-41AC-B13D-1E2AB557F945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{84A01464-33A0-41AC-B13D-1E2AB557F945} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11} = {A0C171F4-DBCD-4DE2-B17C-80F56FBF8FB7}
+		{627FC9A3-0D39-4B1A-8389-25C1F13B5B66} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{68503E8F-DC47-456D-902D-67F5DDF7C473} = {C899E7CF-34A4-48FA-90C8-60E31F08536F}
+		{B65ABC78-AA1F-4A57-8CE3-71218FAB1CC3} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+		{77A797C9-9D0D-4B2F-B3D2-9E2AADBB1542} = {68503E8F-DC47-456D-902D-67F5DDF7C473}
+	EndGlobalSection
+EndGlobal

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,106 @@
+# MAUI Designer for Visual Studio
+
+Visual Studio 2022 has no drag-and-drop designer for .NET MAUI XAML. This folder
+packages the Angular designer from this repository as a VSIX so it can edit the
+`.xaml` file that is open in the IDE, with the project's own NuGet controls in
+the toolbox.
+
+See [`../docs/visual-studio-extension.md`](../docs/visual-studio-extension.md)
+for the design rationale and the alternatives that were considered.
+
+## Layout
+
+| Project | Framework | Builds on |
+| --- | --- | --- |
+| `src/MauiDesigner.Core` | `netstandard2.0` | any OS |
+| `tests/MauiDesigner.Core.Tests` | `net8.0` | any OS |
+| `tests/Fakes/*` | `netstandard2.0` | any OS |
+| `src/MauiDesigner.Vsix` | `net472` | **Windows only** |
+
+`MauiDesigner.Core.sln` contains everything that is cross-platform and is what CI
+builds and tests. `MauiDesigner.sln` additionally contains the VSIX and requires
+Visual Studio 2022 with the *Visual Studio extension development* workload.
+
+## What the core library does
+
+* **`Projects/ProjectAssetsReader`** — reads `obj/project.assets.json` (written by
+  every NuGet restore) to find which packages a project references and where
+  their assemblies live in the global packages folder.
+* **`Manifests/ControlManifestGenerator`** — inspects those assemblies with
+  `MetadataLoadContext` (metadata only, no code is executed), finds public
+  concrete types deriving from `Microsoft.Maui.Controls.View`, reads their
+  `public static readonly BindableProperty XxxProperty` fields and emits the same
+  manifest JSON the designer already consumes for custom controls.
+* **`Protocol/DesignerSession`** — the host half of the message contract in
+  `src/app/services/host-bridge.ts`, free of any Visual Studio types so it can be
+  unit tested anywhere.
+
+### Message contract
+
+| Direction | Message | Meaning |
+| --- | --- | --- |
+| host → designer | `host.ready` | which IDE is hosting, and the open file |
+| host → designer | `document.load` | XAML to edit |
+| host → designer | `manifests.push` | controls found in the project's packages |
+| host → designer | `document.saved` | the document reached disk |
+| designer → host | `designer.ready` | the WebView finished booting |
+| designer → host | `document.changed` | the user edited the design |
+| designer → host | `document.save` | Ctrl+S inside the designer |
+| designer → host | `manifests.request` | asks for the project's controls |
+| designer → host | `designer.error` | something went wrong, for the output window |
+
+Both sides ignore malformed payloads, so a protocol mismatch degrades to "the
+designer does nothing" rather than taking down the IDE.
+
+## Building and running the tests
+
+Cross-platform (this is what CI runs):
+
+```bash
+cd extension
+dotnet test MauiDesigner.Core.sln
+```
+
+The tests build two fake assemblies — a stand-in `Microsoft.Maui.Controls` and a
+`Contoso.Maui.Controls` control package — so the reflection scanner is exercised
+for real without installing the MAUI workload.
+
+The VSIX, on Windows:
+
+```powershell
+npm ci
+npm run build            # produces dist/maui-designer/browser, embedded in the VSIX
+cd extension
+msbuild MauiDesigner.sln /p:Configuration=Release /restore
+```
+
+`bin\Release\MauiDesigner.Vsix.vsix` can then be installed, or press F5 to debug
+in the experimental instance.
+
+## How it works inside Visual Studio
+
+`MauiDesignerPackage` registers `DesignerEditorFactory` for `.xaml` at a *lower*
+priority than the built-in XAML editor, so double-clicking a file keeps the
+familiar behaviour and the designer is offered through **Open With…**.
+
+The factory reuses the document's existing `IVsTextLines` buffer when one is
+already open, which means the text editor and the designer edit the same buffer:
+changes made on the canvas appear in the XAML view immediately, undo/redo and the
+dirty indicator keep working, and Ctrl+S saves through the normal solution
+pipeline.
+
+`DesignerControl` hosts WebView2. The compiled Angular application is copied into
+`webview\` inside the VSIX and served through
+`SetVirtualHostNameToFolderMapping`, because a `file://` origin cannot use the
+storage and module loading the designer relies on. The WebView2 environment is
+created explicitly with a user data folder under `%LOCALAPPDATA%` — the Visual
+Studio install directory is read-only.
+
+## Limitations
+
+* Only Visual Studio 2022 (17.x). The out-of-process `VisualStudio.Extensibility`
+  model cannot host WebView2, so the classic in-process VSSDK model is required.
+* The designer understands the subset of XAML the web app supports; unknown tags
+  are preserved verbatim but are not editable beyond their attributes.
+* Manifest generation reads compile-time metadata, so a control's runtime
+  defaults are not known — the designer falls back to its own defaults.

--- a/extension/src/MauiDesigner.Core/Manifests/ControlManifestGenerator.cs
+++ b/extension/src/MauiDesigner.Core/Manifests/ControlManifestGenerator.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Manifests
+{
+    /// <summary>
+    /// Scans NuGet assemblies for MAUI controls and produces designer manifests.
+    /// Uses <see cref="MetadataLoadContext"/> so assemblies are inspected, never executed.
+    /// </summary>
+    public sealed class ControlManifestGenerator
+    {
+        private const string ViewTypeName = "Microsoft.Maui.Controls.View";
+        private const string LayoutTypeName = "Microsoft.Maui.Controls.Layout";
+        private const string BindablePropertyTypeName = "Microsoft.Maui.Controls.BindableProperty";
+
+        /// <summary>
+        /// Builds one manifest per CLR namespace found in <paramref name="assemblyPaths"/>.
+        /// </summary>
+        /// <param name="assemblyPaths">Assemblies to scan.</param>
+        /// <param name="referencePaths">Additional assemblies needed to resolve base types (MAUI, BCL).</param>
+        /// <param name="packageId">NuGet package the assemblies came from.</param>
+        /// <param name="packageVersion">NuGet package version.</param>
+        public IReadOnlyList<CustomControlManifest> Generate(
+            IEnumerable<string> assemblyPaths,
+            IEnumerable<string> referencePaths,
+            string packageId,
+            string? packageVersion = null)
+        {
+            var targets = assemblyPaths.Where(File.Exists).Distinct().ToList();
+            if (targets.Count == 0)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var all = targets
+                .Concat(referencePaths.Where(File.Exists))
+                .Distinct()
+                .ToList();
+
+            var resolver = new PathAssemblyResolver(all);
+            using var context = new MetadataLoadContext(resolver);
+
+            var manifests = new Dictionary<string, CustomControlManifest>(StringComparer.Ordinal);
+
+            foreach (var path in targets)
+            {
+                Assembly assembly;
+                try
+                {
+                    assembly = context.LoadFromAssemblyPath(path);
+                }
+                catch (BadImageFormatException)
+                {
+                    // Native or resource-only assembly: nothing to scan.
+                    continue;
+                }
+
+                var assemblyName = assembly.GetName().Name ?? Path.GetFileNameWithoutExtension(path);
+
+                foreach (var type in SafeGetTypes(assembly))
+                {
+                    if (!IsDesignableControl(type))
+                    {
+                        continue;
+                    }
+
+                    var clrNamespace = type.Namespace ?? string.Empty;
+                    var key = clrNamespace + "|" + assemblyName;
+
+                    if (!manifests.TryGetValue(key, out var manifest))
+                    {
+                        manifest = new CustomControlManifest
+                        {
+                            Id = $"{packageId}.{clrNamespace}".ToLowerInvariant(),
+                            Package = packageId,
+                            Version = packageVersion,
+                            Description = $"Discovered in {packageId}",
+                            Xmlns = new CustomNamespace
+                            {
+                                Prefix = SuggestPrefix(clrNamespace, packageId),
+                                Uri = $"clr-namespace:{clrNamespace};assembly={assemblyName}"
+                            }
+                        };
+                        manifests[key] = manifest;
+                    }
+
+                    manifest.Controls.Add(Describe(type));
+                }
+            }
+
+            foreach (var manifest in manifests.Values)
+            {
+                manifest.Controls.Sort((left, right) => string.CompareOrdinal(left.Tag, right.Tag));
+            }
+
+            return manifests.Values
+                .Where(manifest => manifest.Controls.Count > 0)
+                .OrderBy(manifest => manifest.Xmlns.Uri, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>A type is designable when it is a public, concrete MAUI <c>View</c>.</summary>
+        public static bool IsDesignableControl(Type type)
+        {
+            if (!type.IsPublic || type.IsAbstract || type.IsGenericTypeDefinition || type.IsInterface)
+            {
+                return false;
+            }
+
+            return InheritsFrom(type, ViewTypeName);
+        }
+
+        private static CustomControlDefinition Describe(Type type)
+        {
+            var isLayout = InheritsFrom(type, LayoutTypeName);
+
+            return new CustomControlDefinition
+            {
+                Tag = type.Name,
+                DisplayName = Humanize(type.Name),
+                Description = $"{type.FullName}",
+                Icon = isLayout ? "dashboard" : "widgets",
+                CanHaveChildren = isLayout ? true : (bool?)null,
+                DefaultWidth = isLayout ? 240 : 160,
+                DefaultHeight = isLayout ? 160 : 40,
+                Preview = new CustomPreview
+                {
+                    Kind = isLayout ? "slot" : "box",
+                    Label = Humanize(type.Name)
+                },
+                Properties = BindableProperties(type)
+            };
+        }
+
+        /// <summary>
+        /// MAUI controls expose their editable surface as
+        /// <c>public static readonly BindableProperty XxxProperty</c> fields.
+        /// </summary>
+        public static List<CustomPropertyDefinition> BindableProperties(Type type)
+        {
+            var properties = new List<CustomPropertyDefinition>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+            foreach (var field in fields)
+            {
+                if (!field.IsInitOnly ||
+                    field.FieldType.FullName != BindablePropertyTypeName ||
+                    !field.Name.EndsWith("Property", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var name = field.Name.Substring(0, field.Name.Length - "Property".Length);
+                if (name.Length == 0 || !seen.Add(name))
+                {
+                    continue;
+                }
+
+                var clrProperty = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+                properties.Add(new CustomPropertyDefinition
+                {
+                    Name = name,
+                    Type = MapType(clrProperty?.PropertyType),
+                    Options = EnumOptions(clrProperty?.PropertyType)
+                });
+            }
+
+            properties.Sort((left, right) => string.CompareOrdinal(left.Name, right.Name));
+            return properties;
+        }
+
+        /// <summary>Maps a CLR type onto the designer's property editor kinds.</summary>
+        public static string MapType(Type? type)
+        {
+            if (type is null)
+            {
+                return "string";
+            }
+
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (underlying.IsEnum)
+            {
+                return "enum";
+            }
+
+            switch (underlying.FullName)
+            {
+                case "System.Boolean":
+                    return "boolean";
+                case "System.Double":
+                case "System.Single":
+                case "System.Int32":
+                case "System.Int64":
+                case "System.Decimal":
+                    return "number";
+                case "Microsoft.Maui.Graphics.Color":
+                    return "color";
+                default:
+                    return "string";
+            }
+        }
+
+        private static List<string>? EnumOptions(Type? type)
+        {
+            var underlying = type is null ? null : Nullable.GetUnderlyingType(type) ?? type;
+            if (underlying is null || !underlying.IsEnum)
+            {
+                return null;
+            }
+
+            try
+            {
+                return underlying.GetFields(BindingFlags.Public | BindingFlags.Static)
+                    .Select(field => field.Name)
+                    .ToList();
+            }
+            catch (NotSupportedException)
+            {
+                // Enum values cannot be read in a metadata-only context for some shapes.
+                return null;
+            }
+        }
+
+        /// <summary>Derives a short, readable XML prefix, e.g. `Syncfusion.Maui.Inputs` -&gt; `inputs`.</summary>
+        public static string SuggestPrefix(string clrNamespace, string packageId)
+        {
+            var source = string.IsNullOrWhiteSpace(clrNamespace) ? packageId : clrNamespace;
+            var segments = source.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(segment => !segment.Equals("Maui", StringComparison.OrdinalIgnoreCase) &&
+                                  !segment.Equals("Controls", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var candidate = segments.Count > 0 ? segments[segments.Count - 1] : source;
+            var cleaned = new string(candidate.Where(char.IsLetterOrDigit).ToArray());
+
+            return cleaned.Length == 0 ? "custom" : cleaned.ToLowerInvariant();
+        }
+
+        /// <summary>`SfComboBox` -&gt; `Sf Combo Box`.</summary>
+        public static string Humanize(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            var builder = new System.Text.StringBuilder();
+            for (var index = 0; index < name.Length; index++)
+            {
+                var current = name[index];
+                if (index > 0 && char.IsUpper(current) && !char.IsUpper(name[index - 1]))
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(current);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool InheritsFrom(Type type, string baseTypeFullName)
+        {
+            try
+            {
+                for (var current = type.BaseType; current is not null; current = current.BaseType)
+                {
+                    if (current.FullName == baseTypeFullName)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // A base type lives in an assembly that was not supplied; treat as unrelated.
+            }
+            catch (TypeLoadException)
+            {
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException error)
+            {
+                return error.Types.Where(type => type is not null)!;
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Manifests/CustomControlManifest.cs
+++ b/extension/src/MauiDesigner.Core/Manifests/CustomControlManifest.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MauiDesigner.Core.Manifests
+{
+    /// <summary>
+    /// C# mirror of <c>src/app/models/custom-control.ts</c>. The designer running
+    /// inside the WebView consumes exactly this JSON shape.
+    /// </summary>
+    public sealed class CustomControlManifest
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>NuGet package id; shown as the toolbox group title.</summary>
+        [JsonPropertyName("package")]
+        public string Package { get; set; } = string.Empty;
+
+        [JsonPropertyName("version")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("xmlns")]
+        public CustomNamespace Xmlns { get; set; } = new CustomNamespace();
+
+        [JsonPropertyName("controls")]
+        public List<CustomControlDefinition> Controls { get; set; } = new List<CustomControlDefinition>();
+    }
+
+    public sealed class CustomNamespace
+    {
+        /// <summary>XML prefix used in the document, e.g. <c>toolkit</c>.</summary>
+        [JsonPropertyName("prefix")]
+        public string Prefix { get; set; } = string.Empty;
+
+        /// <summary>A <c>clr-namespace:</c> declaration.</summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+    }
+
+    public sealed class CustomControlDefinition
+    {
+        /// <summary>Local XAML tag without the prefix, e.g. <c>AvatarView</c>.</summary>
+        [JsonPropertyName("tag")]
+        public string Tag { get; set; } = string.Empty;
+
+        [JsonPropertyName("displayName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("icon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Icon { get; set; }
+
+        [JsonPropertyName("canHaveChildren")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? CanHaveChildren { get; set; }
+
+        [JsonPropertyName("defaultWidth")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? DefaultWidth { get; set; }
+
+        [JsonPropertyName("defaultHeight")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? DefaultHeight { get; set; }
+
+        [JsonPropertyName("preview")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public CustomPreview? Preview { get; set; }
+
+        [JsonPropertyName("properties")]
+        public List<CustomPropertyDefinition> Properties { get; set; } = new List<CustomPropertyDefinition>();
+    }
+
+    public sealed class CustomPreview
+    {
+        /// <summary>One of <c>box</c>, <c>text</c>, <c>image</c>, <c>list</c>, <c>slot</c>.</summary>
+        [JsonPropertyName("kind")]
+        public string Kind { get; set; } = "box";
+
+        /// <summary>Supports <c>{PropertyName}</c> placeholders.</summary>
+        [JsonPropertyName("label")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("icon")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Icon { get; set; }
+    }
+
+    public sealed class CustomPropertyDefinition
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>One of <c>string</c>, <c>number</c>, <c>boolean</c>, <c>color</c>, <c>enum</c>.</summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "string";
+
+        [JsonPropertyName("options")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Options { get; set; }
+
+        [JsonPropertyName("bindable")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Bindable { get; set; }
+    }
+
+    /// <summary>Shared serializer options so the host and the designer agree on casing.</summary>
+    public static class ManifestJson
+    {
+        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static string Serialize(object value) => JsonSerializer.Serialize(value, Options);
+    }
+}

--- a/extension/src/MauiDesigner.Core/MauiDesigner.Core.csproj
+++ b/extension/src/MauiDesigner.Core/MauiDesigner.Core.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- netstandard2.0 so the same assembly can be consumed by the .NET Framework VSIX -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <RootNamespace>MauiDesigner.Core</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/extension/src/MauiDesigner.Core/Projects/ProjectAssetsReader.cs
+++ b/extension/src/MauiDesigner.Core/Projects/ProjectAssetsReader.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace MauiDesigner.Core.Projects
+{
+    /// <summary>A NuGet package restored for a project, with the assemblies it contributes.</summary>
+    public sealed class PackageReferenceInfo
+    {
+        public PackageReferenceInfo(string id, string version, IReadOnlyList<string> assemblyPaths)
+        {
+            Id = id;
+            Version = version;
+            AssemblyPaths = assemblyPaths;
+        }
+
+        public string Id { get; }
+
+        public string Version { get; }
+
+        /// <summary>Absolute paths to the package's reference/lib assemblies that exist on disk.</summary>
+        public IReadOnlyList<string> AssemblyPaths { get; }
+    }
+
+    /// <summary>
+    /// Reads <c>obj/project.assets.json</c> — produced by every NuGet restore — to
+    /// discover which packages a MAUI project references and where their
+    /// assemblies live in the global packages folder.
+    /// </summary>
+    public static class ProjectAssetsReader
+    {
+        /// <summary>Locates <c>obj/project.assets.json</c> next to a project file.</summary>
+        public static string? FindAssetsFile(string projectFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(projectFilePath))
+            {
+                return null;
+            }
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+            if (string.IsNullOrEmpty(directory))
+            {
+                return null;
+            }
+
+            var assets = Path.Combine(directory, "obj", "project.assets.json");
+            return File.Exists(assets) ? assets : null;
+        }
+
+        /// <summary>Reads the packages of the first (or requested) target framework.</summary>
+        public static IReadOnlyList<PackageReferenceInfo> Read(string assetsFilePath, string? targetFramework = null)
+        {
+            if (!File.Exists(assetsFilePath))
+            {
+                throw new FileNotFoundException("project.assets.json was not found.", assetsFilePath);
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(assetsFilePath));
+            return Read(document.RootElement, targetFramework);
+        }
+
+        /// <summary>Overload used by the tests to avoid touching the file system.</summary>
+        public static IReadOnlyList<PackageReferenceInfo> ReadJson(string json, string? targetFramework = null)
+        {
+            using var document = JsonDocument.Parse(json);
+            return Read(document.RootElement, targetFramework);
+        }
+
+        private static IReadOnlyList<PackageReferenceInfo> Read(JsonElement root, string? targetFramework)
+        {
+            var packages = new List<PackageReferenceInfo>();
+
+            if (!root.TryGetProperty("targets", out var targets) || targets.ValueKind != JsonValueKind.Object)
+            {
+                return packages;
+            }
+
+            var target = SelectTarget(targets, targetFramework);
+            if (target is null)
+            {
+                return packages;
+            }
+
+            var roots = PackageFolders(root);
+
+            foreach (var entry in target.Value.EnumerateObject())
+            {
+                // Keys look like "CommunityToolkit.Maui/9.0.3"
+                var separator = entry.Name.LastIndexOf('/');
+                if (separator <= 0)
+                {
+                    continue;
+                }
+
+                if (entry.Value.TryGetProperty("type", out var type) &&
+                    !string.Equals(type.GetString(), "package", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var id = entry.Name.Substring(0, separator);
+                var version = entry.Name.Substring(separator + 1);
+                var relative = RelativeAssemblyPaths(entry.Value);
+                var resolved = Resolve(roots, id, version, relative);
+
+                packages.Add(new PackageReferenceInfo(id, version, resolved));
+            }
+
+            return packages;
+        }
+
+        private static JsonElement? SelectTarget(JsonElement targets, string? targetFramework)
+        {
+            foreach (var candidate in targets.EnumerateObject())
+            {
+                if (targetFramework is null ||
+                    candidate.Name.IndexOf(targetFramework, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return candidate.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static IReadOnlyList<string> PackageFolders(JsonElement root)
+        {
+            var folders = new List<string>();
+
+            if (root.TryGetProperty("packageFolders", out var packageFolders) &&
+                packageFolders.ValueKind == JsonValueKind.Object)
+            {
+                folders.AddRange(packageFolders.EnumerateObject().Select(folder => folder.Name));
+            }
+
+            if (folders.Count == 0)
+            {
+                folders.Add(Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".nuget",
+                    "packages"));
+            }
+
+            return folders;
+        }
+
+        private static IReadOnlyList<string> RelativeAssemblyPaths(JsonElement package)
+        {
+            var paths = new List<string>();
+
+            // "compile" is the reference assembly set; fall back to "runtime".
+            foreach (var section in new[] { "compile", "runtime" })
+            {
+                if (!package.TryGetProperty(section, out var items) || items.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                foreach (var item in items.EnumerateObject())
+                {
+                    // NuGet uses "_._" as a placeholder for "no assets".
+                    if (item.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        paths.Add(item.Name.Replace('/', Path.DirectorySeparatorChar));
+                    }
+                }
+
+                if (paths.Count > 0)
+                {
+                    break;
+                }
+            }
+
+            return paths;
+        }
+
+        private static IReadOnlyList<string> Resolve(
+            IReadOnlyList<string> roots,
+            string id,
+            string version,
+            IReadOnlyList<string> relativePaths)
+        {
+            var resolved = new List<string>();
+
+            foreach (var relative in relativePaths)
+            {
+                foreach (var root in roots)
+                {
+                    var full = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant(), relative);
+                    if (File.Exists(full))
+                    {
+                        resolved.Add(full);
+                        break;
+                    }
+
+                    // Some feeds keep the original casing on disk.
+                    var cased = Path.Combine(root, id, version, relative);
+                    if (File.Exists(cased))
+                    {
+                        resolved.Add(cased);
+                        break;
+                    }
+                }
+            }
+
+            return resolved;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
+++ b/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Protocol
+{
+    /// <summary>
+    /// The message contract between the IDE host and the Angular designer.
+    /// Mirrors <c>src/app/services/host-bridge.ts</c>; changing one side requires
+    /// changing the other.
+    /// </summary>
+    public static class MessageTypes
+    {
+        // Host -> designer
+        public const string HostReady = "host.ready";
+        public const string DocumentLoad = "document.load";
+        public const string ManifestsPush = "manifests.push";
+        public const string DocumentSaved = "document.saved";
+
+        // Designer -> host
+        public const string DesignerReady = "designer.ready";
+        public const string DocumentChanged = "document.changed";
+        public const string DocumentSave = "document.save";
+        public const string ManifestsRequest = "manifests.request";
+        public const string DesignerError = "designer.error";
+    }
+
+    /// <summary>A single message in either direction.</summary>
+    public sealed class DesignerMessage
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("host")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Host { get; set; }
+
+        [JsonPropertyName("fileName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FileName { get; set; }
+
+        [JsonPropertyName("xaml")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Xaml { get; set; }
+
+        [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("manifests")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<CustomControlManifest>? Manifests { get; set; }
+    }
+
+    /// <summary>Builds and parses <see cref="DesignerMessage"/> payloads.</summary>
+    public static class DesignerProtocol
+    {
+        private static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static string HostReady(string host, string? fileName = null) =>
+            Serialize(new DesignerMessage { Type = MessageTypes.HostReady, Host = host, FileName = fileName });
+
+        public static string DocumentLoad(string xaml, string? fileName = null) =>
+            Serialize(new DesignerMessage { Type = MessageTypes.DocumentLoad, Xaml = xaml, FileName = fileName });
+
+        public static string ManifestsPush(IEnumerable<CustomControlManifest> manifests) =>
+            Serialize(new DesignerMessage
+            {
+                Type = MessageTypes.ManifestsPush,
+                Manifests = new List<CustomControlManifest>(manifests)
+            });
+
+        public static string DocumentSaved() => Serialize(new DesignerMessage { Type = MessageTypes.DocumentSaved });
+
+        public static string Serialize(DesignerMessage message) => JsonSerializer.Serialize(message, Options);
+
+        /// <summary>
+        /// Parses a message posted by the designer. Returns <c>null</c> instead of
+        /// throwing so a malformed payload can never take down the IDE.
+        /// </summary>
+        public static DesignerMessage? Parse(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            try
+            {
+                var message = JsonSerializer.Deserialize<DesignerMessage>(json!, Options);
+                return string.IsNullOrEmpty(message?.Type) ? null : message;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Core/Protocol/DesignerSession.cs
+++ b/extension/src/MauiDesigner.Core/Protocol/DesignerSession.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+
+using MauiDesigner.Core.Manifests;
+
+namespace MauiDesigner.Core.Protocol
+{
+    /// <summary>
+    /// The host-side half of the designer conversation, kept free of any Visual
+    /// Studio types so it can be unit tested on any platform. The VSIX supplies
+    /// the transport (WebView2) and the document services through the callbacks.
+    /// </summary>
+    public sealed class DesignerSession
+    {
+        private readonly Action<string> _post;
+        private readonly string _hostKind;
+        private bool _designerReady;
+        private string? _pendingXaml;
+
+        /// <param name="post">Sends a JSON payload into the WebView.</param>
+        /// <param name="hostKind"><c>visual-studio</c> or <c>vscode</c>.</param>
+        public DesignerSession(Action<string> post, string hostKind = "visual-studio")
+        {
+            _post = post ?? throw new ArgumentNullException(nameof(post));
+            _hostKind = hostKind;
+        }
+
+        /// <summary>Path of the document currently shown in the designer.</summary>
+        public string? FileName { get; private set; }
+
+        /// <summary>The latest XAML the designer produced.</summary>
+        public string? CurrentXaml { get; private set; }
+
+        /// <summary>True when the designer has edits the host has not persisted.</summary>
+        public bool IsDirty { get; private set; }
+
+        /// <summary>Raised when the designer asks the host to write the document.</summary>
+        public event EventHandler<DocumentSaveRequestedEventArgs>? SaveRequested;
+
+        /// <summary>Raised on every designer edit so the host can mark the buffer dirty.</summary>
+        public event EventHandler<DocumentChangedEventArgs>? DocumentChanged;
+
+        /// <summary>Raised when the designer reports a problem, for the output window.</summary>
+        public event EventHandler<string>? ErrorReported;
+
+        /// <summary>Raised when the designer asks for the project's control manifests.</summary>
+        public event EventHandler? ManifestsRequested;
+
+        /// <summary>
+        /// Queues (or sends, once the designer is ready) the document to edit.
+        /// </summary>
+        public void OpenDocument(string xaml, string fileName)
+        {
+            FileName = fileName;
+            CurrentXaml = xaml;
+            IsDirty = false;
+
+            if (_designerReady)
+            {
+                _post(DesignerProtocol.DocumentLoad(xaml, fileName));
+            }
+            else
+            {
+                // The WebView may still be starting; replay as soon as it announces itself.
+                _pendingXaml = xaml;
+            }
+        }
+
+        /// <summary>Pushes control manifests generated from the project's NuGet packages.</summary>
+        public void PushManifests(IEnumerable<CustomControlManifest> manifests)
+        {
+            _post(DesignerProtocol.ManifestsPush(manifests));
+        }
+
+        /// <summary>Tells the designer the document reached disk.</summary>
+        public void NotifySaved()
+        {
+            IsDirty = false;
+            _post(DesignerProtocol.DocumentSaved());
+        }
+
+        /// <summary>Handles a raw message posted by the designer. Unknown payloads are ignored.</summary>
+        public void HandleMessage(string? json)
+        {
+            var message = DesignerProtocol.Parse(json);
+            if (message is null)
+            {
+                return;
+            }
+
+            switch (message.Type)
+            {
+                case MessageTypes.DesignerReady:
+                    _designerReady = true;
+                    _post(DesignerProtocol.HostReady(_hostKind, FileName));
+                    if (_pendingXaml is not null)
+                    {
+                        _post(DesignerProtocol.DocumentLoad(_pendingXaml, FileName));
+                        _pendingXaml = null;
+                    }
+                    break;
+
+                case MessageTypes.ManifestsRequest:
+                    ManifestsRequested?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case MessageTypes.DocumentChanged:
+                    if (message.Xaml is null || message.Xaml == CurrentXaml)
+                    {
+                        break;
+                    }
+
+                    CurrentXaml = message.Xaml;
+                    IsDirty = true;
+                    DocumentChanged?.Invoke(this, new DocumentChangedEventArgs(message.Xaml));
+                    break;
+
+                case MessageTypes.DocumentSave:
+                    var xaml = message.Xaml ?? CurrentXaml;
+                    if (xaml is null)
+                    {
+                        break;
+                    }
+
+                    CurrentXaml = xaml;
+                    SaveRequested?.Invoke(this, new DocumentSaveRequestedEventArgs(xaml, FileName));
+                    break;
+
+                case MessageTypes.DesignerError:
+                    ErrorReported?.Invoke(this, message.Message ?? "Unknown designer error");
+                    break;
+            }
+        }
+    }
+
+    public sealed class DocumentChangedEventArgs : EventArgs
+    {
+        public DocumentChangedEventArgs(string xaml) => Xaml = xaml;
+
+        public string Xaml { get; }
+    }
+
+    public sealed class DocumentSaveRequestedEventArgs : EventArgs
+    {
+        public DocumentSaveRequestedEventArgs(string xaml, string? fileName)
+        {
+            Xaml = xaml;
+            FileName = fileName;
+        }
+
+        public string Xaml { get; }
+
+        public string? FileName { get; }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="MauiDesigner.Vsix.DesignerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf">
+    <Grid>
+        <!-- Source is never set in XAML: the WebView2 environment is created explicitly. -->
+        <wv2:WebView2 x:Name="WebView" />
+        <TextBlock x:Name="StatusText"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="Starting the MAUI designer..." />
+    </Grid>
+</UserControl>

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.xaml.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+using Microsoft.Web.WebView2.Core;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Hosts the Angular designer in WebView2. The compiled application is served
+    /// through a virtual host name because `file://` origins cannot use the
+    /// browser storage and module loading the designer relies on.
+    /// </summary>
+    public partial class DesignerControl : UserControl, IDisposable
+    {
+        private const string VirtualHost = "maui-designer.invalid";
+
+        private readonly TaskCompletionSource<bool> _ready =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private bool _disposed;
+
+        public DesignerControl()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>Raised for every JSON message the designer posts to the host.</summary>
+        public event EventHandler<string>? MessageReceived;
+
+        /// <summary>Boots WebView2 and navigates to the bundled designer.</summary>
+        public async Task InitializeAsync(string webRootDirectory)
+        {
+            try
+            {
+                if (!Directory.Exists(webRootDirectory))
+                {
+                    ShowStatus($"The designer web assets were not found at {webRootDirectory}.");
+                    return;
+                }
+
+                // Keep the user profile out of the VS install directory, which is read-only.
+                var userDataFolder = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "MauiDesigner",
+                    "WebView2");
+                Directory.CreateDirectory(userDataFolder);
+
+                var environment = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
+                await WebView.EnsureCoreWebView2Async(environment);
+
+                var core = WebView.CoreWebView2;
+                core.SetVirtualHostNameToFolderMapping(
+                    VirtualHost,
+                    webRootDirectory,
+                    CoreWebView2HostResourceAccessKind.Allow);
+
+                core.Settings.AreDefaultContextMenusEnabled = false;
+                core.Settings.IsStatusBarEnabled = false;
+                core.Settings.AreDevToolsEnabled = true;
+
+                core.WebMessageReceived += OnWebMessageReceived;
+
+                core.Navigate($"https://{VirtualHost}/index.html");
+
+                StatusText.Visibility = Visibility.Collapsed;
+                _ready.TrySetResult(true);
+            }
+            catch (Exception error)
+            {
+                ShowStatus($"The designer could not start: {error.Message}");
+                _ready.TrySetResult(false);
+            }
+        }
+
+        /// <summary>Posts a JSON payload to the designer. Safe to call before it is ready.</summary>
+        public void PostMessage(string json)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _ = Dispatcher.InvokeAsync(async () =>
+            {
+                if (!await _ready.Task || _disposed || WebView.CoreWebView2 is null)
+                {
+                    return;
+                }
+
+                // The designer listens for `window` message events, so the payload
+                // is delivered as a string and parsed there.
+                WebView.CoreWebView2.PostWebMessageAsString(json);
+            });
+        }
+
+        private void OnWebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs args)
+        {
+            string json;
+            try
+            {
+                json = args.TryGetWebMessageAsString();
+            }
+            catch (ArgumentException)
+            {
+                json = args.WebMessageAsJson;
+            }
+
+            MessageReceived?.Invoke(this, json);
+        }
+
+        private void ShowStatus(string message)
+        {
+            StatusText.Text = message;
+            StatusText.Visibility = Visibility.Visible;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _ready.TrySetResult(false);
+
+            if (WebView.CoreWebView2 is not null)
+            {
+                WebView.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
+            }
+
+            WebView.Dispose();
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerEditorFactory.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerEditorFactory.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Creates the designer editor for a `.xaml` document. The document data is a
+    /// standard text buffer, so the built-in XAML editor and the designer can be
+    /// open on the same file at the same time and stay in sync.
+    /// </summary>
+    [Guid(FactoryGuidString)]
+    public sealed class DesignerEditorFactory : IVsEditorFactory, IDisposable
+    {
+        /// <summary>Editor factory GUID, referenced by the registration attributes.</summary>
+        public const string FactoryGuidString = "c1e5aa5a-2f4f-4c92-9b1c-8f5a55da0e77";
+
+        private readonly AsyncPackage _package;
+        private ServiceProvider? _serviceProvider;
+
+        public DesignerEditorFactory(AsyncPackage package)
+        {
+            _package = package ?? throw new ArgumentNullException(nameof(package));
+        }
+
+        public int SetSite(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = new ServiceProvider(serviceProvider);
+            return VSConstants.S_OK;
+        }
+
+        public int Close() => VSConstants.S_OK;
+
+        public int MapLogicalView(ref Guid logicalView, out string? physicalView)
+        {
+            physicalView = null;
+
+            // Both the primary and the designer view show the drag and drop surface.
+            if (logicalView == VSConstants.LOGVIEWID_Primary || logicalView == VSConstants.LOGVIEWID_Designer)
+            {
+                return VSConstants.S_OK;
+            }
+
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int CreateEditorInstance(
+            uint createFlags,
+            string documentMoniker,
+            string? physicalView,
+            IVsHierarchy hierarchy,
+            uint itemId,
+            IntPtr existingDocData,
+            out IntPtr documentView,
+            out IntPtr documentData,
+            out string editorCaption,
+            out Guid commandUiGuid,
+            out int createDocumentWindowFlags)
+        {
+            documentView = IntPtr.Zero;
+            documentData = IntPtr.Zero;
+            editorCaption = " [Designer]";
+            commandUiGuid = Guid.Empty;
+            createDocumentWindowFlags = 0;
+
+            if ((createFlags & (uint)(__VSCREATEEDITORFLAGS.CEF_OPENFILE | __VSCREATEEDITORFLAGS.CEF_SILENT)) == 0)
+            {
+                return VSConstants.E_INVALIDARG;
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Reuse the buffer the built-in editor already opened, otherwise create one.
+            var textLines = existingDocData != IntPtr.Zero
+                ? Marshal.GetObjectForIUnknown(existingDocData) as IVsTextLines
+                : CreateTextBuffer();
+
+            if (textLines is null)
+            {
+                // Another editor owns this document with an incompatible buffer type.
+                return VSConstants.VS_E_INCOMPATIBLEDOCDATA;
+            }
+
+            if (existingDocData == IntPtr.Zero)
+            {
+                documentData = Marshal.GetIUnknownForObject(textLines);
+            }
+            else
+            {
+                documentData = existingDocData;
+                Marshal.AddRef(documentData);
+            }
+
+            var pane = new DesignerPane(_package, textLines, documentMoniker, hierarchy);
+            documentView = Marshal.GetIUnknownForObject(pane);
+
+            return VSConstants.S_OK;
+        }
+
+        private IVsTextLines? CreateTextBuffer()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var localRegistry = _serviceProvider?.GetService(typeof(SLocalRegistry)) as ILocalRegistry;
+            if (localRegistry is null)
+            {
+                return null;
+            }
+
+            var bufferGuid = typeof(IVsTextLines).GUID;
+            var hresult = localRegistry.CreateInstance(
+                typeof(VsTextBufferClass).GUID,
+                null,
+                ref bufferGuid,
+                (uint)CLSCTX.CLSCTX_INPROC_SERVER,
+                out var buffer);
+
+            if (ErrorHandler.Failed(hresult) || buffer == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                return (IVsTextLines)Marshal.GetObjectForIUnknown(buffer);
+            }
+            finally
+            {
+                Marshal.Release(buffer);
+            }
+        }
+
+        public void Dispose()
+        {
+            _serviceProvider?.Dispose();
+            _serviceProvider = null;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Protocol;
+using MauiDesigner.Vsix.Projects;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// The document window: hosts the WebView, and keeps the Visual Studio text
+    /// buffer and the designer in sync in both directions.
+    /// </summary>
+    public sealed class DesignerPane : WindowPane
+    {
+        private readonly IVsTextLines _textLines;
+        private readonly string _documentMoniker;
+        private readonly IVsHierarchy _hierarchy;
+        private readonly DesignerControl _control;
+        private readonly DesignerSession _session;
+        private bool _applyingDesignerEdit;
+
+        public DesignerPane(
+            IServiceProvider serviceProvider,
+            IVsTextLines textLines,
+            string documentMoniker,
+            IVsHierarchy hierarchy)
+            : base(serviceProvider)
+        {
+            _textLines = textLines ?? throw new ArgumentNullException(nameof(textLines));
+            _documentMoniker = documentMoniker;
+            _hierarchy = hierarchy;
+
+            _control = new DesignerControl();
+            _session = new DesignerSession(_control.PostMessage);
+
+            _control.MessageReceived += (_, json) => _session.HandleMessage(json);
+            _session.DocumentChanged += OnDesignerEdited;
+            _session.SaveRequested += OnSaveRequested;
+            _session.ManifestsRequested += OnManifestsRequested;
+            _session.ErrorReported += (_, message) => WriteToOutput(message);
+        }
+
+        /// <inheritdoc />
+        public override object Content => _control;
+
+        /// <inheritdoc />
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            _ = _control.InitializeAsync(WebAssetLocator.WebRootDirectory);
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _session.OpenDocument(ReadBuffer(), _documentMoniker);
+        }
+
+        private void OnDesignerEdited(object sender, DocumentChangedEventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                WriteBuffer(args.Xaml);
+            });
+        }
+
+        private void OnSaveRequested(object sender, DocumentSaveRequestedEventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                WriteBuffer(args.Xaml);
+
+                if (GetService(typeof(SVsRunningDocumentTable)) is IVsRunningDocumentTable4 table &&
+                    GetService(typeof(SVsSolution)) is IVsSolution solution)
+                {
+                    var cookie = table.GetDocumentCookie(_documentMoniker);
+                    solution.SaveSolutionElement(
+                        (uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_SaveIfDirty,
+                        _hierarchy,
+                        cookie);
+                }
+
+                _session.NotifySaved();
+            });
+        }
+
+        private void OnManifestsRequested(object sender, EventArgs args)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var projectFile = ProjectManifestProvider.FindProjectFile(_hierarchy, _documentMoniker);
+
+                await TaskScheduler.Default;
+                IReadOnlyList<CustomControlManifest> manifests;
+                try
+                {
+                    manifests = ProjectManifestProvider.ForProject(projectFile);
+                }
+                catch (Exception error)
+                {
+                    WriteToOutput($"Could not read the project's NuGet controls: {error.Message}");
+                    return;
+                }
+
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                _session.PushManifests(manifests);
+            });
+        }
+
+        private string ReadBuffer()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ErrorHandler.ThrowOnFailure(_textLines.GetLineCount(out var lineCount));
+            ErrorHandler.ThrowOnFailure(_textLines.GetLengthOfLine(lineCount - 1, out var lastLineLength));
+            ErrorHandler.ThrowOnFailure(
+                _textLines.GetLineText(0, 0, lineCount - 1, lastLineLength, out var text));
+
+            return text ?? string.Empty;
+        }
+
+        private void WriteBuffer(string xaml)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_applyingDesignerEdit || ReadBuffer() == xaml)
+            {
+                return;
+            }
+
+            _applyingDesignerEdit = true;
+            try
+            {
+                ErrorHandler.ThrowOnFailure(_textLines.GetLineCount(out var lineCount));
+                ErrorHandler.ThrowOnFailure(_textLines.GetLengthOfLine(lineCount - 1, out var lastLineLength));
+
+                var bytes = System.Text.Encoding.Unicode.GetBytes(xaml);
+                var buffer = System.Runtime.InteropServices.Marshal.AllocCoTaskMem(bytes.Length + 2);
+                try
+                {
+                    System.Runtime.InteropServices.Marshal.Copy(bytes, 0, buffer, bytes.Length);
+                    System.Runtime.InteropServices.Marshal.WriteInt16(buffer, bytes.Length, 0);
+
+                    ErrorHandler.ThrowOnFailure(_textLines.ReplaceLines(
+                        0, 0, lineCount - 1, lastLineLength, buffer, xaml.Length, null));
+                }
+                finally
+                {
+                    System.Runtime.InteropServices.Marshal.FreeCoTaskMem(buffer);
+                }
+            }
+            finally
+            {
+                _applyingDesignerEdit = false;
+            }
+        }
+
+        private void WriteToOutput(string message)
+        {
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (GetService(typeof(SVsGeneralOutputWindowPane)) is IVsOutputWindowPane pane)
+                {
+                    pane.OutputStringThreadSafe($"MAUI Designer: {message}{Environment.NewLine}");
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _control.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Editor/WebAssetLocator.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/WebAssetLocator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>Finds the compiled Angular application shipped inside the VSIX.</summary>
+    public static class WebAssetLocator
+    {
+        /// <summary>The folder mapped into WebView2 as a virtual host.</summary>
+        public static string WebRootDirectory
+        {
+            get
+            {
+                var assembly = Assembly.GetExecutingAssembly().Location;
+                var directory = Path.GetDirectoryName(assembly) ?? AppDomain.CurrentDomain.BaseDirectory;
+                return Path.Combine(directory, "webview");
+            }
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
+++ b/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Windows only. Requires Visual Studio 2022 with the "Visual Studio extension
+    development" workload; it cannot be built with `dotnet build` on Linux/macOS.
+    See extension/README.md.
+  -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6E7B4B0D-8F5A-4A63-9F1E-4F2F7B0C6A11}</ProjectGuid>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MauiDesigner.Vsix</RootNamespace>
+    <AssemblyName>MauiDesigner.Vsix</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+    <DeployExtension Condition="'$(IsBuildingVsix)' == ''">true</DeployExtension>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.11.40262" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiDesigner.Core\MauiDesigner.Core.csproj">
+      <Name>MauiDesigner.Core</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Editor\DesignerControl.xaml.cs">
+      <DependentUpon>DesignerControl.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Editor\DesignerEditorFactory.cs" />
+    <Compile Include="Editor\DesignerPane.cs" />
+    <Compile Include="Editor\WebAssetLocator.cs" />
+    <Compile Include="MauiDesignerPackage.cs" />
+    <Compile Include="Projects\ProjectManifestProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="Editor\DesignerControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <!--
+    The VSIX ships the compiled Angular application. Run `npm run build` in the
+    repository root first; the output of dist/maui-designer/browser is embedded
+    under `webview\` and served through a virtual host name.
+  -->
+  <PropertyGroup>
+    <AngularDistDirectory Condition="'$(AngularDistDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\..\dist\maui-designer\browser</AngularDistDirectory>
+  </PropertyGroup>
+
+  <Target Name="IncludeAngularApp" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <AngularAsset Include="$(AngularDistDirectory)\**\*" />
+      <Content Include="@(AngularAsset)">
+        <Link>webview\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+    </ItemGroup>
+    <Warning Condition="!Exists('$(AngularDistDirectory)')"
+             Text="The Angular application was not found at $(AngularDistDirectory). Run 'npm ci &amp;&amp; npm run build' in the repository root before building the VSIX." />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+</Project>

--- a/extension/src/MauiDesigner.Vsix/MauiDesignerPackage.cs
+++ b/extension/src/MauiDesigner.Vsix/MauiDesignerPackage.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MauiDesigner.Vsix
+{
+    /// <summary>
+    /// Registers the MAUI designer as an alternative editor for `.xaml` files.
+    /// </summary>
+    /// <remarks>
+    /// The priority is deliberately lower than the built-in XAML editor so the
+    /// designer never steals the default double-click experience; it is offered
+    /// through <c>File &gt; Open With</c> and the context menu instead.
+    /// </remarks>
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [Guid(PackageGuidString)]
+    [ProvideEditorFactory(typeof(DesignerEditorFactory), 110, TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
+    [ProvideEditorExtension(typeof(DesignerEditorFactory), ".xaml", 0x10, NameResourceID = 110)]
+    [ProvideEditorLogicalView(typeof(DesignerEditorFactory), VSConstants.LOGVIEWID.Designer_string)]
+    public sealed class MauiDesignerPackage : AsyncPackage
+    {
+        /// <summary>Package GUID, referenced by the generated pkgdef.</summary>
+        public const string PackageGuidString = "3b9a7bd5-51b1-4f2a-9a1d-0f0a4a2f9c31";
+
+        /// <inheritdoc />
+        protected override async Task InitializeAsync(
+            CancellationToken cancellationToken,
+            IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress);
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            RegisterEditorFactory(new DesignerEditorFactory(this));
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Projects/ProjectManifestProvider.cs
+++ b/extension/src/MauiDesigner.Vsix/Projects/ProjectManifestProvider.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Projects;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace MauiDesigner.Vsix.Projects
+{
+    /// <summary>
+    /// Turns the NuGet packages a MAUI project restored into designer manifests,
+    /// so third party controls appear in the toolbox with their real properties.
+    /// </summary>
+    public static class ProjectManifestProvider
+    {
+        /// <summary>Finds the project file that owns an open document.</summary>
+        public static string? FindProjectFile(IVsHierarchy? hierarchy, string documentMoniker)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (hierarchy is IVsProject project &&
+                ErrorHandler.Succeeded(project.GetMkDocument(VSConstants.VSITEMID_ROOT, out var projectFile)) &&
+                File.Exists(projectFile))
+            {
+                return projectFile;
+            }
+
+            // Fall back to walking up from the document until a project file appears.
+            var directory = Path.GetDirectoryName(documentMoniker);
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Directory.EnumerateFiles(directory, "*.csproj").FirstOrDefault();
+                if (candidate is not null)
+                {
+                    return candidate;
+                }
+
+                directory = Path.GetDirectoryName(directory);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Scans every restored package of <paramref name="projectFile"/> and returns
+        /// manifests for the ones that contain MAUI controls. Never throws for a
+        /// package that cannot be inspected: it is simply skipped.
+        /// </summary>
+        public static IReadOnlyList<CustomControlManifest> ForProject(string? projectFile)
+        {
+            if (projectFile is null)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var assetsFile = ProjectAssetsReader.FindAssetsFile(projectFile);
+            if (assetsFile is null)
+            {
+                return Array.Empty<CustomControlManifest>();
+            }
+
+            var packages = ProjectAssetsReader.Read(assetsFile);
+
+            // Base types must resolve, so every package assembly is offered as a reference.
+            var references = packages.SelectMany(package => package.AssemblyPaths).Distinct().ToList();
+
+            var generator = new ControlManifestGenerator();
+            var manifests = new List<CustomControlManifest>();
+
+            foreach (var package in packages)
+            {
+                if (package.AssemblyPaths.Count == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    manifests.AddRange(
+                        generator.Generate(package.AssemblyPaths, references, package.Id, package.Version));
+                }
+                catch (Exception)
+                {
+                    // A package that cannot be inspected must not break the designer.
+                }
+            }
+
+            return manifests;
+        }
+    }
+}

--- a/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
+++ b/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("MAUI Designer for Visual Studio")]
+[assembly: AssemblyDescription("Visual drag and drop designer for .NET MAUI XAML pages.")]
+[assembly: AssemblyProduct("MAUI Designer")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: ComVisible(false)]

--- a/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
+++ b/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="0.1.0" Language="en-US" Publisher="GMPrakhar" />
+    <DisplayName>MAUI Designer</DisplayName>
+    <Description xml:space="preserve">A drag and drop visual designer for .NET MAUI XAML pages, including controls that come from NuGet packages.</Description>
+    <MoreInfo>https://github.com/GMPrakhar/MAUI-Designer</MoreInfo>
+    <License>LICENSE.txt</License>
+    <Tags>maui, xaml, designer, dotnet</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+</PackageManifest>

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiDesigner.Fakes.Maui.csproj
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiDesigner.Fakes.Maui.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Stand-in for Microsoft.Maui.Controls so the scanner can be tested without the MAUI workload -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Microsoft.Maui.Controls</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiStubs.cs
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Maui/MauiStubs.cs
@@ -1,0 +1,30 @@
+namespace Microsoft.Maui.Graphics
+{
+    public class Color
+    {
+    }
+}
+
+namespace Microsoft.Maui.Controls
+{
+    public sealed class BindableProperty
+    {
+        public static BindableProperty Create(string name) => new BindableProperty();
+    }
+
+    public abstract class Element
+    {
+    }
+
+    public abstract class VisualElement : Element
+    {
+    }
+
+    public abstract class View : VisualElement
+    {
+    }
+
+    public abstract class Layout : View
+    {
+    }
+}

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Package/Controls.cs
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Package/Controls.cs
@@ -1,0 +1,59 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Contoso.Maui.Controls
+{
+    public enum RatingShape
+    {
+        Star,
+        Heart
+    }
+
+    public class RatingBar : View
+    {
+        public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value");
+        public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create("IsReadOnly");
+        public static readonly BindableProperty CaptionProperty = BindableProperty.Create("Caption");
+        public static readonly BindableProperty ShapeProperty = BindableProperty.Create("Shape");
+        public static readonly BindableProperty FillColorProperty = BindableProperty.Create("FillColor");
+
+        // Not a BindableProperty field: must be ignored
+        public static readonly string Documentation = "https://contoso.example";
+
+        public double Value { get; set; }
+
+        public bool IsReadOnly { get; set; }
+
+        public string? Caption { get; set; }
+
+        public RatingShape Shape { get; set; }
+
+        public Color? FillColor { get; set; }
+    }
+
+    public class CardPanel : Layout
+    {
+        public static readonly BindableProperty TitleProperty = BindableProperty.Create("Title");
+
+        public string? Title { get; set; }
+    }
+
+    public abstract class AbstractControl : View
+    {
+    }
+
+    internal class InternalControl : View
+    {
+    }
+
+    public class NotAControl
+    {
+    }
+}
+
+namespace Contoso.Maui.Charts
+{
+    public class SparkLine : Microsoft.Maui.Controls.View
+    {
+    }
+}

--- a/extension/tests/Fakes/MauiDesigner.Fakes.Package/MauiDesigner.Fakes.Package.csproj
+++ b/extension/tests/Fakes/MauiDesigner.Fakes.Package/MauiDesigner.Fakes.Package.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Stand-in for a third party control package such as Syncfusion or Telerik -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Contoso.Maui.Controls</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extension/tests/MauiDesigner.Core.Tests/ControlManifestGeneratorTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/ControlManifestGeneratorTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    /// <summary>
+    /// Scans the fake `Contoso.Maui.Controls` package that is built alongside the
+    /// tests, so the reflection path is exercised for real without the MAUI workload.
+    /// </summary>
+    public class ControlManifestGeneratorTests
+    {
+        private static readonly string PackageAssembly = FakeAssembly("Contoso.Maui.Controls.dll");
+        private static readonly string MauiAssembly = FakeAssembly("Microsoft.Maui.Controls.dll");
+
+        private static string FakeAssembly(string fileName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, fileName);
+            Assert.True(File.Exists(path), $"Expected the test fake '{fileName}' next to the test assembly.");
+            return path;
+        }
+
+        private static IReadOnlyList<string> RuntimeReferences()
+        {
+            var trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+            return trusted.Split(Path.PathSeparator).Where(path => path.Length > 0).ToList();
+        }
+
+        private static IReadOnlyList<CustomControlManifest> Generate()
+        {
+            var references = RuntimeReferences().Concat(new[] { MauiAssembly }).ToList();
+            return new ControlManifestGenerator()
+                .Generate(new[] { PackageAssembly }, references, "Contoso.Maui.Controls", "1.2.3");
+        }
+
+        [Fact]
+        public void Produces_one_manifest_per_clr_namespace()
+        {
+            var manifests = Generate();
+
+            Assert.Equal(2, manifests.Count);
+            Assert.Contains(manifests, manifest => manifest.Xmlns.Uri ==
+                "clr-namespace:Contoso.Maui.Controls;assembly=Contoso.Maui.Controls");
+            Assert.Contains(manifests, manifest => manifest.Xmlns.Uri ==
+                "clr-namespace:Contoso.Maui.Charts;assembly=Contoso.Maui.Controls");
+        }
+
+        [Fact]
+        public void Carries_the_package_identity()
+        {
+            var manifest = Generate().First();
+
+            Assert.Equal("Contoso.Maui.Controls", manifest.Package);
+            Assert.Equal("1.2.3", manifest.Version);
+            Assert.NotEmpty(manifest.Id);
+        }
+
+        [Fact]
+        public void Only_public_concrete_views_become_controls()
+        {
+            var controls = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Select(control => control.Tag)
+                .ToList();
+
+            Assert.Contains("RatingBar", controls);
+            Assert.Contains("CardPanel", controls);
+            Assert.Contains("SparkLine", controls);
+            Assert.DoesNotContain("AbstractControl", controls);
+            Assert.DoesNotContain("InternalControl", controls);
+            Assert.DoesNotContain("NotAControl", controls);
+        }
+
+        [Fact]
+        public void Layouts_accept_children_and_render_as_slots()
+        {
+            var controls = Generate().SelectMany(manifest => manifest.Controls).ToList();
+
+            var panel = controls.Single(control => control.Tag == "CardPanel");
+            Assert.True(panel.CanHaveChildren);
+            Assert.Equal("slot", panel.Preview!.Kind);
+
+            var rating = controls.Single(control => control.Tag == "RatingBar");
+            Assert.Null(rating.CanHaveChildren);
+            Assert.Equal("box", rating.Preview!.Kind);
+        }
+
+        [Fact]
+        public void Bindable_properties_become_editable_properties_with_mapped_types()
+        {
+            var rating = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Single(control => control.Tag == "RatingBar");
+
+            var byName = rating.Properties.ToDictionary(property => property.Name, property => property.Type);
+
+            Assert.Equal("number", byName["Value"]);
+            Assert.Equal("boolean", byName["IsReadOnly"]);
+            Assert.Equal("string", byName["Caption"]);
+            Assert.Equal("enum", byName["Shape"]);
+            Assert.Equal("color", byName["FillColor"]);
+
+            // A public static readonly field that is not a BindableProperty is ignored
+            Assert.DoesNotContain(rating.Properties, property => property.Name == "Documentation");
+        }
+
+        [Fact]
+        public void Enum_properties_expose_their_values()
+        {
+            var shape = Generate()
+                .SelectMany(manifest => manifest.Controls)
+                .Single(control => control.Tag == "RatingBar")
+                .Properties
+                .Single(property => property.Name == "Shape");
+
+            Assert.Equal(new[] { "Star", "Heart" }, shape.Options);
+        }
+
+        [Fact]
+        public void Missing_assemblies_yield_no_manifests()
+        {
+            var manifests = new ControlManifestGenerator()
+                .Generate(new[] { "/does/not/exist.dll" }, Array.Empty<string>(), "Ghost");
+
+            Assert.Empty(manifests);
+        }
+
+        [Fact]
+        public void Generated_manifests_round_trip_through_the_designer_json_shape()
+        {
+            var json = ManifestJson.Serialize(Generate());
+
+            Assert.Contains("\"xmlns\"", json);
+            Assert.Contains("\"prefix\"", json);
+            Assert.Contains("\"controls\"", json);
+            Assert.Contains("\"RatingBar\"", json);
+        }
+
+        [Theory]
+        [InlineData("Syncfusion.Maui.Inputs", "Syncfusion.Maui.Inputs", "inputs")]
+        [InlineData("Telerik.Maui.Controls", "Telerik.UI.for.Maui", "telerik")]
+        [InlineData("", "CommunityToolkit.Maui", "communitytoolkit")]
+        public void Prefixes_are_short_and_readable(string clrNamespace, string packageId, string expected)
+        {
+            Assert.Equal(expected, ControlManifestGenerator.SuggestPrefix(clrNamespace, packageId));
+        }
+
+        [Theory]
+        [InlineData("SfComboBox", "Sf Combo Box")]
+        [InlineData("RatingBar", "Rating Bar")]
+        [InlineData("Label", "Label")]
+        [InlineData("", "")]
+        public void Display_names_are_humanized(string name, string expected)
+        {
+            Assert.Equal(expected, ControlManifestGenerator.Humanize(name));
+        }
+
+        [Fact]
+        public void Unknown_clr_types_fall_back_to_string_editors()
+        {
+            Assert.Equal("string", ControlManifestGenerator.MapType(null));
+            Assert.Equal("string", ControlManifestGenerator.MapType(typeof(Uri)));
+            Assert.Equal("number", ControlManifestGenerator.MapType(typeof(int?)));
+            Assert.Equal("boolean", ControlManifestGenerator.MapType(typeof(bool)));
+        }
+    }
+}

--- a/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MauiDesigner.Core.Manifests;
+using MauiDesigner.Core.Protocol;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    /// <summary>
+    /// The session is the host half of the contract in `src/app/services/host-bridge.ts`.
+    /// </summary>
+    public class DesignerSessionTests
+    {
+        private readonly List<string> _posted = new List<string>();
+
+        private DesignerSession CreateSession() => new DesignerSession(_posted.Add);
+
+        private IEnumerable<DesignerMessage> Posted() =>
+            _posted.Select(DesignerProtocol.Parse).Where(message => message is not null)!;
+
+        private static string FromDesigner(string type, string? xaml = null, string? message = null) =>
+            DesignerProtocol.Serialize(new DesignerMessage { Type = type, Xaml = xaml, Message = message });
+
+        [Fact]
+        public void Opening_a_document_before_the_designer_is_ready_replays_it()
+        {
+            var session = CreateSession();
+
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+            Assert.Empty(_posted);
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+
+            var types = Posted().Select(message => message.Type).ToList();
+            Assert.Equal(new[] { MessageTypes.HostReady, MessageTypes.DocumentLoad }, types);
+
+            var load = Posted().Last();
+            Assert.Equal("<ContentPage />", load.Xaml);
+            Assert.Equal("MainPage.xaml", load.FileName);
+        }
+
+        [Fact]
+        public void Opening_a_document_after_the_designer_is_ready_sends_it_immediately()
+        {
+            var session = CreateSession();
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+            _posted.Clear();
+
+            session.OpenDocument("<Grid />", "Other.xaml");
+
+            var load = Assert.Single(Posted());
+            Assert.Equal(MessageTypes.DocumentLoad, load.Type);
+            Assert.Equal("<Grid />", load.Xaml);
+        }
+
+        [Fact]
+        public void The_host_announces_which_ide_it_is()
+        {
+            var session = new DesignerSession(_posted.Add, "vscode");
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerReady));
+
+            Assert.Equal("vscode", Posted().First().Host);
+        }
+
+        [Fact]
+        public void Designer_edits_mark_the_document_dirty()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            var changes = new List<string>();
+            session.DocumentChanged += (_, args) => changes.Add(args.Xaml);
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<ContentPage><Label /></ContentPage>"));
+
+            Assert.True(session.IsDirty);
+            Assert.Equal("<ContentPage><Label /></ContentPage>", session.CurrentXaml);
+            Assert.Single(changes);
+        }
+
+        [Fact]
+        public void An_echo_of_the_current_xaml_is_not_a_change()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            var changes = 0;
+            session.DocumentChanged += (_, _) => changes++;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<ContentPage />"));
+
+            Assert.False(session.IsDirty);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void Save_requests_reach_the_host_and_clear_the_dirty_flag_once_written()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentChanged, "<Grid />"));
+
+            DocumentSaveRequestedEventArgs? request = null;
+            session.SaveRequested += (_, args) => request = args;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentSave, "<Grid />"));
+
+            Assert.NotNull(request);
+            Assert.Equal("<Grid />", request!.Xaml);
+            Assert.Equal("MainPage.xaml", request.FileName);
+            Assert.True(session.IsDirty);
+
+            session.NotifySaved();
+
+            Assert.False(session.IsDirty);
+            Assert.Contains(Posted(), message => message.Type == MessageTypes.DocumentSaved);
+        }
+
+        [Fact]
+        public void A_save_without_xaml_falls_back_to_the_last_known_document()
+        {
+            var session = CreateSession();
+            session.OpenDocument("<ContentPage />", "MainPage.xaml");
+
+            DocumentSaveRequestedEventArgs? request = null;
+            session.SaveRequested += (_, args) => request = args;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DocumentSave));
+
+            Assert.Equal("<ContentPage />", request!.Xaml);
+        }
+
+        [Fact]
+        public void Manifest_requests_are_surfaced_to_the_host()
+        {
+            var session = CreateSession();
+            var requested = 0;
+            session.ManifestsRequested += (_, _) => requested++;
+
+            session.HandleMessage(FromDesigner(MessageTypes.ManifestsRequest));
+
+            Assert.Equal(1, requested);
+        }
+
+        [Fact]
+        public void Manifests_are_pushed_in_the_shape_the_designer_expects()
+        {
+            var session = CreateSession();
+
+            session.PushManifests(new[]
+            {
+                new CustomControlManifest
+                {
+                    Id = "contoso",
+                    Package = "Contoso.Maui.Controls",
+                    Xmlns = new CustomNamespace { Prefix = "contoso", Uri = "clr-namespace:Contoso" },
+                    Controls = { new CustomControlDefinition { Tag = "RatingBar" } }
+                }
+            });
+
+            var message = Assert.Single(Posted());
+            Assert.Equal(MessageTypes.ManifestsPush, message.Type);
+            Assert.Equal("contoso", message.Manifests!.Single().Xmlns.Prefix);
+            Assert.Contains("\"tag\":\"RatingBar\"", _posted.Single());
+        }
+
+        [Fact]
+        public void Designer_errors_are_surfaced_to_the_host()
+        {
+            var session = CreateSession();
+            string? reported = null;
+            session.ErrorReported += (_, message) => reported = message;
+
+            session.HandleMessage(FromDesigner(MessageTypes.DesignerError, message: "Malformed XAML"));
+
+            Assert.Equal("Malformed XAML", reported);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not json")]
+        [InlineData("{}")]
+        [InlineData("{\"type\":\"something.unknown\"}")]
+        public void Malformed_or_unknown_messages_are_ignored(string? json)
+        {
+            var session = CreateSession();
+
+            var exception = Record.Exception(() => session.HandleMessage(json));
+
+            Assert.Null(exception);
+            Assert.Empty(_posted);
+            Assert.False(session.IsDirty);
+        }
+
+        [Fact]
+        public void A_session_needs_a_transport()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DesignerSession(null!));
+        }
+    }
+}

--- a/extension/tests/MauiDesigner.Core.Tests/MauiDesigner.Core.Tests.csproj
+++ b/extension/tests/MauiDesigner.Core.Tests/MauiDesigner.Core.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MauiDesigner.Core\MauiDesigner.Core.csproj" />
+    <!-- Stand-ins for Microsoft.Maui.Controls and a third party control package -->
+    <ProjectReference Include="..\Fakes\MauiDesigner.Fakes.Maui\MauiDesigner.Fakes.Maui.csproj" />
+    <ProjectReference Include="..\Fakes\MauiDesigner.Fakes.Package\MauiDesigner.Fakes.Package.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extension/tests/MauiDesigner.Core.Tests/ProjectAssetsReaderTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/ProjectAssetsReaderTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using MauiDesigner.Core.Projects;
+
+using Xunit;
+
+namespace MauiDesigner.Core.Tests
+{
+    public class ProjectAssetsReaderTests
+    {
+        private const string Assets = @"{
+  ""version"": 3,
+  ""targets"": {
+    ""net8.0-android34.0"": {
+      ""CommunityToolkit.Maui/9.0.3"": {
+        ""type"": ""package"",
+        ""compile"": {
+          ""lib/net8.0/CommunityToolkit.Maui.dll"": {},
+          ""lib/net8.0/CommunityToolkit.Maui.Core.dll"": {}
+        },
+        ""runtime"": {
+          ""lib/net8.0/CommunityToolkit.Maui.dll"": {}
+        }
+      },
+      ""Newtonsoft.Json/13.0.3"": {
+        ""type"": ""package"",
+        ""compile"": {
+          ""lib/netstandard2.0/_._"": {}
+        }
+      },
+      ""MyApp.Shared/1.0.0"": {
+        ""type"": ""project""
+      }
+    }
+  },
+  ""packageFolders"": {
+    ""PACKAGES_ROOT"": {}
+  }
+}";
+
+        private static string WithRoot(string root) => Assets.Replace("PACKAGES_ROOT", root.Replace(@"\", @"\\"));
+
+        [Fact]
+        public void Reads_packages_from_the_first_target()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets);
+
+            Assert.Equal(2, packages.Count);
+            Assert.Contains(packages, package => package.Id == "CommunityToolkit.Maui" && package.Version == "9.0.3");
+            Assert.Contains(packages, package => package.Id == "Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void Project_references_are_not_packages()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets);
+
+            Assert.DoesNotContain(packages, package => package.Id == "MyApp.Shared");
+        }
+
+        [Fact]
+        public void Resolves_assembly_paths_that_exist_on_disk()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "maui-designer-assets-" + Guid.NewGuid().ToString("N"));
+            var libraryDirectory = Path.Combine(root, "communitytoolkit.maui", "9.0.3", "lib", "net8.0");
+            Directory.CreateDirectory(libraryDirectory);
+            File.WriteAllText(Path.Combine(libraryDirectory, "CommunityToolkit.Maui.dll"), string.Empty);
+
+            try
+            {
+                var package = ProjectAssetsReader.ReadJson(WithRoot(root))
+                    .Single(candidate => candidate.Id == "CommunityToolkit.Maui");
+
+                // Only the assembly that is actually on disk is returned
+                Assert.Equal(
+                    new[] { Path.Combine(libraryDirectory, "CommunityToolkit.Maui.dll") },
+                    package.AssemblyPaths);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Placeholder_assets_contribute_no_assemblies()
+        {
+            var package = ProjectAssetsReader.ReadJson(Assets).Single(candidate => candidate.Id == "Newtonsoft.Json");
+
+            Assert.Empty(package.AssemblyPaths);
+        }
+
+        [Fact]
+        public void A_target_framework_can_be_selected()
+        {
+            var packages = ProjectAssetsReader.ReadJson(Assets, "net8.0-android");
+
+            Assert.NotEmpty(packages);
+            Assert.Empty(ProjectAssetsReader.ReadJson(Assets, "net472"));
+        }
+
+        [Fact]
+        public void An_assets_file_without_targets_is_empty_rather_than_fatal()
+        {
+            Assert.Empty(ProjectAssetsReader.ReadJson("{}"));
+        }
+
+        [Fact]
+        public void Finds_the_assets_file_next_to_a_project()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "maui-designer-project-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(root, "obj"));
+            var project = Path.Combine(root, "MyApp.csproj");
+            File.WriteAllText(project, "<Project />");
+
+            try
+            {
+                Assert.Null(ProjectAssetsReader.FindAssetsFile(project));
+
+                var assets = Path.Combine(root, "obj", "project.assets.json");
+                File.WriteAllText(assets, "{}");
+
+                Assert.Equal(assets, ProjectAssetsReader.FindAssetsFile(project));
+                Assert.Null(ProjectAssetsReader.FindAssetsFile(""));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void A_missing_assets_file_is_reported_clearly()
+        {
+            Assert.Throws<FileNotFoundException>(
+                () => ProjectAssetsReader.Read(Path.Combine(Path.GetTempPath(), "nope.assets.json")));
+        }
+    }
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,6 +4,10 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { Subscription } from 'rxjs';
 
 import { ElementService } from './services/element';
+import { HostBridgeService } from './services/host-bridge';
+import { XamlParserService } from './services/xaml-parser';
+import { XamlGeneratorService } from './services/xaml-generator';
+import { CustomControlRegistryService } from './services/custom-control-registry';
 import { ToolboxComponent } from './components/toolbox/toolbox';
 import { DesignerCanvasComponent } from './components/designer-canvas/designer-canvas';
 import { PropertiesPanelComponent } from './components/properties-panel/properties-panel';
@@ -40,6 +44,7 @@ export class App implements OnInit, OnDestroy {
   canUndo = false;
   canRedo = false;
   toastMessage = '';
+  hostFileName: string | null = null;
   private toastTimeout: any;
   private subscription = new Subscription();
 
@@ -55,7 +60,13 @@ export class App implements OnInit, OnDestroy {
   private readonly MIN_PANEL_SIZE = 50;
   private readonly MAX_PANEL_RATIO = 0.8;
 
-  constructor(private elementService: ElementService) {}
+  constructor(
+    private elementService: ElementService,
+    private hostBridge: HostBridgeService,
+    private xamlParser: XamlParserService,
+    private xamlGenerator: XamlGeneratorService,
+    private registry: CustomControlRegistryService
+  ) {}
 
   ngOnInit() {
     this.subscription.add(
@@ -64,6 +75,57 @@ export class App implements OnInit, OnDestroy {
         this.canRedo = state.canRedo;
       })
     );
+
+    if (this.hostBridge.isHosted) {
+      this.connectToHost();
+    }
+  }
+
+  /** In Visual Studio or VS Code the open .xaml document is the source of truth. */
+  private connectToHost() {
+    this.subscription.add(
+      this.hostBridge.messages$.subscribe(message => {
+        switch (message.type) {
+          case 'host.ready':
+            this.hostBridge.requestManifests();
+            break;
+          case 'document.load':
+            this.loadFromHost(message.xaml);
+            break;
+          case 'manifests.push':
+            for (const manifest of message.manifests) {
+              this.registry.register(manifest);
+            }
+            break;
+          case 'document.saved':
+            this.showToast('Saved');
+            break;
+        }
+      })
+    );
+
+    // Every change flows back so the host can keep the document in sync
+    this.subscription.add(
+      this.elementService.elements$.subscribe(root => {
+        this.hostBridge.notifyChanged(this.xamlGenerator.generateXaml(root));
+      })
+    );
+
+    this.subscription.add(this.hostBridge.fileName$.subscribe(name => (this.hostFileName = name)));
+  }
+
+  private loadFromHost(xaml: string) {
+    try {
+      this.elementService.setRootElement(this.xamlParser.parseXaml(xaml));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.hostBridge.reportError(message);
+      this.showToast(`Could not open the document: ${message}`);
+    }
+  }
+
+  get isHosted(): boolean {
+    return this.hostBridge.isHosted;
   }
 
   ngOnDestroy() {
@@ -82,6 +144,12 @@ export class App implements OnInit, OnDestroy {
   }
 
   saveDesign() {
+    if (this.hostBridge.isHosted) {
+      // Hosted in an IDE the design belongs to the open file, not to browser storage
+      this.hostBridge.save(this.xamlGenerator.generateXaml(this.elementService.getRootElement()));
+      return;
+    }
+
     this.showToast(
       this.elementService.saveToStorage()
         ? 'Design saved to this browser'

--- a/src/app/services/host-bridge.spec.ts
+++ b/src/app/services/host-bridge.spec.ts
@@ -1,0 +1,171 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HostBridgeService, HostInboundMessage } from './host-bridge';
+
+describe('HostBridgeService', () => {
+  const originalChrome = (window as any).chrome;
+  const originalAcquire = (window as any).acquireVsCodeApi;
+
+  afterEach(() => {
+    (window as any).chrome = originalChrome;
+    (window as any).acquireVsCodeApi = originalAcquire;
+  });
+
+  function create(): HostBridgeService {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    return TestBed.inject(HostBridgeService);
+  }
+
+  function post(message: unknown) {
+    window.dispatchEvent(new MessageEvent('message', { data: message }));
+  }
+
+  it('reports a plain browser when no host is present', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(service.host).toBe('browser');
+    expect(service.isHosted).toBeFalse();
+  });
+
+  it('sending a message in a browser is a no-op', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(() => service.save('<ContentPage />')).not.toThrow();
+  });
+
+  it('detects Visual Studio through the WebView2 bridge', () => {
+    const posted: unknown[] = [];
+    (window as any).chrome = { webview: { postMessage: (m: unknown) => posted.push(m) } };
+    (window as any).acquireVsCodeApi = undefined;
+
+    const service = create();
+
+    expect(service.host).toBe('visual-studio');
+    expect(service.isHosted).toBeTrue();
+    // The designer announces itself as soon as it is hosted
+    expect(posted).toEqual([JSON.stringify({ type: 'designer.ready' })]);
+  });
+
+  it('serialises messages to Visual Studio as JSON strings', () => {
+    const posted: string[] = [];
+    (window as any).chrome = { webview: { postMessage: (m: string) => posted.push(m) } };
+
+    const service = create();
+    service.save('<ContentPage />');
+
+    expect(JSON.parse(posted[1])).toEqual({ type: 'document.save', xaml: '<ContentPage />' });
+  });
+
+  it('detects VS Code and posts structured messages', () => {
+    (window as any).chrome = undefined;
+    const posted: unknown[] = [];
+    (window as any).acquireVsCodeApi = () => ({ postMessage: (m: unknown) => posted.push(m) });
+
+    const service = create();
+    service.notifyChanged('<ContentPage />');
+
+    expect(service.host).toBe('vscode');
+    expect(posted).toEqual([
+      { type: 'designer.ready' },
+      { type: 'document.changed', xaml: '<ContentPage />' }
+    ]);
+  });
+
+  it('acquires the VS Code API only once', () => {
+    (window as any).chrome = undefined;
+    let calls = 0;
+    (window as any).acquireVsCodeApi = () => {
+      calls++;
+      return { postMessage: () => undefined };
+    };
+
+    const service = create();
+    service.notifyChanged('a');
+    service.notifyChanged('b');
+
+    expect(calls).toBe(1);
+    expect(service.host).toBe('vscode');
+  });
+
+  it('forwards messages received from the host', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post({ type: 'document.load', xaml: '<ContentPage />', fileName: 'MainPage.xaml' });
+
+    expect(received).toEqual([
+      { type: 'document.load', xaml: '<ContentPage />', fileName: 'MainPage.xaml' } as HostInboundMessage
+    ]);
+  });
+
+  it('accepts JSON encoded messages, as WebView2 delivers them', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post(JSON.stringify({ type: 'document.load', xaml: '<Grid />' }));
+
+    expect(received.length).toBe(1);
+    expect((received[0] as { xaml: string }).xaml).toBe('<Grid />');
+  });
+
+  it('ignores malformed or unrelated window messages', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post('not json at all');
+    post({ nope: true });
+    post(null);
+    post(42);
+
+    expect(received).toEqual([]);
+  });
+
+  it('tracks the file name the host opened', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    expect(service.fileName).toBeNull();
+
+    post({ type: 'host.ready', host: 'visual-studio', fileName: 'Views/LoginPage.xaml' });
+
+    expect(service.fileName).toBe('Views/LoginPage.xaml');
+  });
+
+  it('lets the host correct the detected kind', () => {
+    (window as any).chrome = { webview: { postMessage: () => undefined } };
+    const service = create();
+
+    post({ type: 'host.ready', host: 'vscode' });
+
+    expect(service.host).toBe('vscode');
+  });
+
+  it('does not listen for host messages in a plain browser', () => {
+    (window as any).chrome = undefined;
+    (window as any).acquireVsCodeApi = undefined;
+    const service = create();
+
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    post({ type: 'document.load', xaml: '<ContentPage />' });
+
+    expect(received).toEqual([]);
+  });
+});

--- a/src/app/services/host-bridge.ts
+++ b/src/app/services/host-bridge.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+
+import { CustomControlManifest } from '../models/custom-control';
+
+/** Messages the host (Visual Studio / VS Code) sends into the designer. */
+export type HostInboundMessage =
+  | { type: 'host.ready'; host: HostKind; fileName?: string }
+  | { type: 'document.load'; xaml: string; fileName?: string }
+  | { type: 'manifests.push'; manifests: CustomControlManifest[] }
+  | { type: 'document.saved' };
+
+/** Messages the designer sends back to the host. */
+export type HostOutboundMessage =
+  | { type: 'designer.ready' }
+  | { type: 'document.changed'; xaml: string }
+  | { type: 'document.save'; xaml: string }
+  | { type: 'manifests.request' }
+  | { type: 'designer.error'; message: string };
+
+export type HostKind = 'visual-studio' | 'vscode' | 'browser';
+
+interface VsCodeApi {
+  postMessage(message: unknown): void;
+}
+
+declare global {
+  interface Window {
+    chrome?: { webview?: { postMessage(message: unknown): void } };
+    acquireVsCodeApi?: () => VsCodeApi;
+  }
+}
+
+/**
+ * Normalises the differences between the hosts the designer can run in.
+ *
+ * - Visual Studio hosts the built app in a WebView2 control and exchanges JSON through
+ *   `window.chrome.webview`.
+ * - VS Code hosts it in a webview and exchanges JSON through `acquireVsCodeApi()`.
+ * - In a plain browser the designer is standalone and every send is a no-op.
+ *
+ * Everything above this service is host agnostic.
+ */
+@Injectable({ providedIn: 'root' })
+export class HostBridgeService {
+  private readonly hostSubject: BehaviorSubject<HostKind>;
+  private readonly messageSubject = new Subject<HostInboundMessage>();
+  private readonly fileNameSubject = new BehaviorSubject<string | null>(null);
+  private vsCodeApi: VsCodeApi | null = null;
+
+  /** The host the designer is currently running in. */
+  readonly host$: Observable<HostKind>;
+  /** Messages pushed by the host. */
+  readonly messages$ = this.messageSubject.asObservable();
+  /** The document the host has opened, when there is one. */
+  readonly fileName$ = this.fileNameSubject.asObservable();
+
+  constructor() {
+    this.hostSubject = new BehaviorSubject<HostKind>(this.detectHost());
+    this.host$ = this.hostSubject.asObservable();
+
+    if (this.isHosted) {
+      window.addEventListener('message', this.onWindowMessage);
+      this.send({ type: 'designer.ready' });
+    }
+  }
+
+  get host(): HostKind {
+    return this.hostSubject.value;
+  }
+
+  /** True when the designer is embedded in an IDE rather than running standalone. */
+  get isHosted(): boolean {
+    return this.host !== 'browser';
+  }
+
+  get fileName(): string | null {
+    return this.fileNameSubject.value;
+  }
+
+  /** Sends a message to the host. Does nothing in a plain browser. */
+  send(message: HostOutboundMessage): void {
+    switch (this.host) {
+      case 'visual-studio':
+        window.chrome!.webview!.postMessage(JSON.stringify(message));
+        return;
+      case 'vscode':
+        this.vsCodeApi?.postMessage(message);
+        return;
+      default:
+        return;
+    }
+  }
+
+  /** Asks the host to persist the given XAML into the open document. */
+  save(xaml: string): void {
+    this.send({ type: 'document.save', xaml });
+  }
+
+  /** Tells the host the design changed so it can mark the document dirty. */
+  notifyChanged(xaml: string): void {
+    this.send({ type: 'document.changed', xaml });
+  }
+
+  /** Asks the host for control manifests generated from the project's NuGet packages. */
+  requestManifests(): void {
+    this.send({ type: 'manifests.request' });
+  }
+
+  reportError(message: string): void {
+    this.send({ type: 'designer.error', message });
+  }
+
+  /** Entry point used by the hosts: both post a message event onto the window. */
+  private readonly onWindowMessage = (event: MessageEvent) => {
+    const message = this.parse(event.data);
+    if (!message) {
+      return;
+    }
+
+    if (message.type === 'host.ready') {
+      this.hostSubject.next(message.host);
+    }
+    if ((message.type === 'host.ready' || message.type === 'document.load') && message.fileName) {
+      this.fileNameSubject.next(message.fileName);
+    }
+
+    this.messageSubject.next(message);
+  };
+
+  private parse(data: unknown): HostInboundMessage | null {
+    let payload: unknown = data;
+    if (typeof payload === 'string') {
+      try {
+        payload = JSON.parse(payload);
+      } catch {
+        return null;
+      }
+    }
+
+    if (!payload || typeof payload !== 'object' || typeof (payload as { type?: unknown }).type !== 'string') {
+      return null;
+    }
+    return payload as HostInboundMessage;
+  }
+
+  private detectHost(): HostKind {
+    if (typeof window === 'undefined') {
+      return 'browser';
+    }
+    if (window.chrome?.webview) {
+      return 'visual-studio';
+    }
+    if (typeof window.acquireVsCodeApi === 'function') {
+      this.vsCodeApi = window.acquireVsCodeApi();
+      return 'vscode';
+    }
+    return 'browser';
+  }
+}


### PR DESCRIPTION
Stacked on #88 — review that one first; this PR's diff is only the last commit.

## Why

Visual Studio 2022 has no drag-and-drop designer for .NET MAUI, and Microsoft has [said it will not build one](https://developercommunity.visualstudio.com/t/XAML-Designer-for-Net-MAUI/10224319). What ships instead is Hot Reload and Live Preview — read-only mirrors of a running app, not layout editing. This PR makes the designer in this repo usable as a real editor inside the IDE, with the project's own NuGet controls in the toolbox.

## Web app: host bridge

`src/app/services/host-bridge.ts` detects Visual Studio (`window.chrome.webview`) or VS Code (`acquireVsCodeApi`). **In a plain browser nothing changes.** When hosted:

- `document.load` from the host is parsed and becomes the design
- every model change streams back as `document.changed`
- the toolbar's save routes to the host instead of browser storage
- `manifests.push` registers controls the host found in NuGet packages

## `extension/`

| Project | Framework | Builds on |
| --- | --- | --- |
| `MauiDesigner.Core` | `netstandard2.0` | any OS |
| `MauiDesigner.Core.Tests` | `net8.0` | any OS |
| `MauiDesigner.Vsix` | `net472` | **Windows + VS SDK** |

**`MauiDesigner.Core`** — reads `obj/project.assets.json` to find restored packages, inspects their assemblies with `MetadataLoadContext` (metadata only, nothing is executed) for public concrete `Microsoft.Maui.Controls.View` subclasses and their `public static readonly BindableProperty` fields, and emits the manifest JSON the designer already consumes from #88. `DesignerSession` is the host half of the message protocol with no Visual Studio types in it, so it is testable anywhere.

**`MauiDesigner.Vsix`** — registers the designer as an alternative `.xaml` editor at a *lower* priority than the built-in one, so double-click keeps its familiar behaviour and the designer appears under **Open With…**. It reuses the document's existing `IVsTextLines` buffer, which means the text editor and the canvas edit the same buffer: changes appear in the XAML view immediately, and undo, the dirty marker and Ctrl+S all keep working. The compiled Angular app is embedded in the VSIX and served to WebView2 through `SetVirtualHostNameToFolderMapping` (a `file://` origin cannot use the storage and module loading the designer relies on).

## Testing

- **41 xUnit tests** (`dotnet test extension/MauiDesigner.Core.sln`) — the suite builds a fake `Microsoft.Maui.Controls` and a fake `Contoso.Maui.Controls` package so the reflection scanner runs for real without the MAUI workload. Covers namespace grouping, layout vs view, property type mapping, enum options, prefix/display-name derivation, `project.assets.json` parsing and path resolution, the full session handshake, dirty tracking, deferred document load, and malformed-payload handling.
- **12 new Angular unit tests** for the host bridge (host detection per IDE, JSON vs object messages, malformed payloads ignored, outbound payload shape). 124 unit tests total, all green.
- **6 new e2e tests** (`e2e/ide-host.spec.ts`) stub `window.chrome.webview` to drive the hosted path end to end, plus one asserting a plain browser is unaffected. **148/148 e2e pass in CI mode with `--retries=0`**; the previously flaky move spec passed 30/30 under `--repeat-each=5`.
- CI gains an `extension-core` job running `dotnet test` on Linux.

The VSIX itself cannot be compiled in this environment (needs Windows + the VS SDK) and has not been run in Visual Studio — that is the one piece needing a manual check before release.
