### PR TITLE
License the project for noncommercial use

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -66,7 +66,9 @@ jobs:
 
           # A VSIX that installs but shows an empty WebView is the failure mode
           # worth guarding against, so assert on the payload, not just the file.
-          foreach ($required in @('extension.vsixmanifest', 'MauiDesigner.Vsix.dll', 'MauiDesigner.Core.dll')) {
+          # LICENSE.txt is here because the manifest points at it: if it goes
+          # missing the package silently ships with no terms shown at install.
+          foreach ($required in @('extension.vsixmanifest', 'MauiDesigner.Vsix.dll', 'MauiDesigner.Core.dll', 'LICENSE.txt')) {
             if ($names -notcontains $required) { throw "The VSIX is missing $required." }
           }
           if (-not ($names -match '^webview/index\.html$')) {

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,133 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Required Notice: Copyright (c) 2025 Prakhar Londhe (https://github.com/GMPrakhar/MAUI-Designer)
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 
 **Live demo:** https://gmprakhar.github.io/MAUI-Designer/ (deployed to GitHub Pages from `main`)
 
-![MAUI Designer](https://img.shields.io/badge/Angular-18.2.0-red) ![TypeScript](https://img.shields.io/badge/TypeScript-5.5.4-blue) ![License](https://img.shields.io/badge/License-MIT-green)
+![MAUI Designer](https://img.shields.io/badge/Angular-18.2.0-red) ![TypeScript](https://img.shields.io/badge/TypeScript-5.5.4-blue) ![License](https://img.shields.io/badge/License-PolyForm%20Noncommercial-blue)
 
 ## 🚀 Features
 
@@ -426,7 +426,17 @@ storage.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+Licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE.md). Use it freely for
+any noncommercial purpose — personal projects, study, research, hobby work — and for charitable,
+educational, government and other noncommercial organisations. Commercial use needs a separate
+licence; open an issue to ask.
+
+This is a source-available licence, not an OSI-approved open source one, so GitHub will not
+label the repository "open source". Earlier revisions of this README stated MIT, and nothing here
+retroactively withdraws rights anyone already relied on under that statement.
+
+The dependencies keep their own licences (Angular and the rest are MIT); this applies only to the
+code in this repository.
 
 ## 👨‍💻 Author
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -136,3 +136,9 @@ Studio install directory is read-only.
   are preserved verbatim but are not editable beyond their attributes.
 * Manifest generation reads compile-time metadata, so a control's runtime
   defaults are not known — the designer falls back to its own defaults.
+
+## Licence
+
+[PolyForm Noncommercial 1.0.0](../LICENSE.md), the same as the rest of the
+repository. The manifest points Visual Studio at it, so the terms are shown
+before the extension installs rather than buried in a file nobody opens.

--- a/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
+++ b/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
@@ -82,16 +82,30 @@
   <!--
     Visual Studio shows this before the user accepts the install, which is the
     one moment the noncommercial terms are guaranteed to be seen. The manifest
-    names it LICENSE.txt, so the repository's LICENSE.md is linked under that
-    name rather than copied, keeping a single source of truth.
+    names it LICENSE.txt, so the repository's LICENSE.md is copied under that
+    name rather than duplicated in the tree, keeping one source of truth.
+    A statically declared item is not enough: the VSSDK builds its file list
+    from items it can map into the package, and rejects the manifest reference
+    with VSSDK1310 unless the file is contributed the same way the web assets
+    are.
   -->
-  <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\..\LICENSE.md">
-      <Link>LICENSE.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-  </ItemGroup>
+  <PropertyGroup>
+    <LicenseSourceFile Condition="'$(LicenseSourceFile)' == ''">$(MSBuildThisFileDirectory)..\..\..\LICENSE.md</LicenseSourceFile>
+    <LicenseVsixFile>$(IntermediateOutputPath)LICENSE.txt</LicenseVsixFile>
+  </PropertyGroup>
+
+  <Target Name="IncludeLicense" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('$(LicenseSourceFile)')"
+           Text="The manifest declares a licence but $(LicenseSourceFile) does not exist. Either restore the file or remove &lt;License&gt; from source.extension.vsixmanifest." />
+    <Copy SourceFiles="$(LicenseSourceFile)" DestinationFiles="$(LicenseVsixFile)" SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <Content Include="$(LicenseVsixFile)">
+        <Link>LICENSE.txt</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
+++ b/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
@@ -79,6 +79,20 @@
     </None>
   </ItemGroup>
 
+  <!--
+    Visual Studio shows this before the user accepts the install, which is the
+    one moment the noncommercial terms are guaranteed to be seen. The manifest
+    names it LICENSE.txt, so the repository's LICENSE.md is linked under that
+    name rather than copied, keeping a single source of truth.
+  -->
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\..\LICENSE.md">
+      <Link>LICENSE.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
+++ b/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
     <DisplayName>MAUI Designer</DisplayName>
     <Description xml:space="preserve">A drag and drop visual designer for .NET MAUI XAML pages, including controls that come from NuGet packages.</Description>
     <MoreInfo>https://github.com/GMPrakhar/MAUI-Designer</MoreInfo>
+    <License>LICENSE.txt</License>
     <Tags>maui, xaml, designer, dotnet</Tags>
   </Metadata>
   <Installation>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-designer",
   "version": "0.0.0",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
The repository had **no LICENSE file**, so it was legally all-rights-reserved — nobody could use it at all. Meanwhile the README claimed **MIT** in two places and linked to a `LICENSE` file that never existed. Both statements were wrong, in opposite directions.

### The licence

**[PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0)**, chosen over the Creative Commons NC licences because those are explicitly not recommended for software (no patent grant, no source/binary distinction). PolyForm is drafted for software, reads in plain language, has an SPDX identifier, and states outright that charities, schools, public research bodies and governments count as noncommercial regardless of funding.

The licence body is the **canonical SPDX text, byte for byte** (verified with `diff` against `spdx/license-list-data`); the only addition is the `Required Notice:` line the licence itself asks for.

### Also updated

- `package.json` gains `"license": "PolyForm-Noncommercial-1.0.0"` — a real SPDX id, so tooling reads it correctly.
- The README's MIT badge and licence section now describe the actual terms.
- The VSIX manifest references `LICENSE.txt` again. That element was removed earlier *precisely because no licence file existed*; now Visual Studio shows the terms in the install dialog, which is the one moment a user is guaranteed to see them. The repo's `LICENSE.md` is linked into the package rather than copied, so there's a single source of truth.
- CI asserts `LICENSE.txt` is in the VSIX — a missing licence would otherwise ship silently, which is exactly how the previous breakage went unnoticed.

### Two things worth being explicit about

**This is source-available, not open source.** PolyForm NC is not OSI-approved, so GitHub will stop labelling the repo as open source, and it will be ineligible for some OSS-only tooling and registries. That is the intended trade-off, not an oversight.

**It does not retroactively withdraw anything.** Anyone who took the code while the README said MIT has an arguable grant under it, and MIT is irrevocable for copies already received. The README states this rather than quietly rewriting history. Contributor check: `git log` shows only you and Copilot, so there are no third-party contributions needing consent to relicense.

If you'd rather allow commercial use with attribution after all, the change is a one-file swap — say the word.

### Verification

41/41 .NET tests pass, production build succeeds, manifest element order validated against the VSIX schema (`License` must sit between `MoreInfo` and `Tags`). The Windows packaging job on this PR is what proves the `LICENSE.txt` reference actually resolves.