### PR TITLE
Highlight the grid cell the pointer is actually over

### DIFF
--- a/e2e/grid-hover.spec.ts
+++ b/e2e/grid-hover.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test';
+
+import { DesignerPage } from './helpers/designer-page';
+
+/**
+ * The cell highlighted under the pointer is the only feedback showing where a
+ * drop will land, so if it points at the wrong cell the designer is actively
+ * misleading. These drive the real canvas rather than the maths behind it,
+ * because every bug this covers came from the wiring and not the arithmetic.
+ */
+test.describe('Grid cell hover', () => {
+  /** A grid whose columns are deliberately unequal: 40px, then the rest. */
+  const unevenGrid = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Grid ColumnDefinitions="40,*" RowDefinitions="*,*" WidthRequest="300" HeightRequest="200" />
+</ContentPage>`;
+
+  /** Reads the row/column of whichever overlay cell is highlighted. */
+  async function highlightedCell(designer: DesignerPage) {
+    return designer.canvas.evaluate(canvas => {
+      const overlay = canvas.querySelector('.grid-visualization');
+      if (!overlay) {
+        return null;
+      }
+
+      const cells = Array.from(overlay.children);
+      const index = cells.findIndex(cell => cell.classList.contains('highlight-cell'));
+      if (index < 0) {
+        return null;
+      }
+
+      const columns = getComputedStyle(overlay).gridTemplateColumns.split(' ').length;
+      return { row: Math.floor(index / columns), column: index % columns };
+    });
+  }
+
+  /** Moves the pointer to a point inside the grid, in grid-local pixels. */
+  async function hoverGrid(designer: DesignerPage, page: any, x: number, y: number) {
+    const grid = designer.canvas.locator('.element-grid').first();
+    const box = (await grid.boundingBox())!;
+    await page.mouse.move(box.x + x, box.y + y);
+    return box;
+  }
+
+  test('highlights the cell under the pointer', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(unevenGrid);
+
+    const grid = designer.canvas.locator('.element-grid').first();
+    await expect(grid).toBeVisible();
+    const box = (await grid.boundingBox())!;
+
+    await hoverGrid(designer, page, 10, 10);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 0, column: 0 });
+
+    // Bottom right quadrant, well inside the wide second column.
+    await hoverGrid(designer, page, box.width - 20, box.height - 20);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 1, column: 1 });
+  });
+
+  test('tracks the pointer as it moves within one cell', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(unevenGrid);
+
+    const grid = designer.canvas.locator('.element-grid').first();
+    await expect(grid).toBeVisible();
+    const box = (await grid.boundingBox())!;
+
+    // Entering the grid once and then moving used to leave the highlight
+    // wherever it first landed, because the handler was bound to mouseover.
+    await hoverGrid(designer, page, 10, 10);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 0, column: 0 });
+
+    await hoverGrid(designer, page, 10, box.height - 20);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 1, column: 0 });
+  });
+
+  test('respects an uneven column boundary', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(unevenGrid);
+
+    const grid = designer.canvas.locator('.element-grid').first();
+    await expect(grid).toBeVisible();
+
+    // The first column is 40px wide. Splitting the grid evenly would place x=70
+    // in column 0, so this is the assertion that fails on equal-cell maths.
+    await hoverGrid(designer, page, 70, 20);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 0, column: 1 });
+
+    await hoverGrid(designer, page, 20, 20);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 0, column: 0 });
+  });
+
+  test('stays correct while the canvas is zoomed', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(unevenGrid);
+
+    await page.getByTestId('zoom-in').click();
+    await page.getByTestId('zoom-in').click();
+
+    const grid = designer.canvas.locator('.element-grid').first();
+    await expect(grid).toBeVisible();
+    const box = (await grid.boundingBox())!;
+
+    // boundingBox is in screen pixels, so it already includes the zoom. The
+    // highlight is only right if the handler divides the pointer offset back
+    // out; without that it drifts further from the pointer the more you zoom.
+    await hoverGrid(designer, page, box.width - 15, box.height - 15);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 1, column: 1 });
+
+    await hoverGrid(designer, page, box.width - 15, 15);
+    await expect.poll(() => highlightedCell(designer)).toEqual({ row: 0, column: 1 });
+  });
+
+  test('clears the highlight when the pointer leaves', async ({ page }) => {
+    const designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(unevenGrid);
+
+    await hoverGrid(designer, page, 10, 10);
+    await expect.poll(() => highlightedCell(designer)).not.toBeNull();
+
+    await page.mouse.move(5, 5);
+    await expect.poll(() => highlightedCell(designer)).toBeNull();
+  });
+});

--- a/e2e/xaml-editor.spec.ts
+++ b/e2e/xaml-editor.spec.ts
@@ -93,8 +93,27 @@ test.describe('XAML editor', () => {
     expect(xaml).toContain('Grid.Column="2"');
   });
 
-  test('downloads the XAML file', async ({ page }) => {
-    await designer.addControl('Label');
+  test('reads the comma separated grid definition shorthand', async () => {
+    // MAUI accepts RowDefinitions="Auto,2*" as shorthand for the property
+    // element form. It used to be ignored, so a grid written this way - which
+    // is how most real XAML writes it - imported as a default 2x2.
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Grid x:Name="Layout" WidthRequest="400" HeightRequest="300"
+          RowDefinitions="Auto,2*" ColumnDefinitions="80,*,*">
+        <Label x:Name="Cell" Text="Cell" Grid.Row="1" Grid.Column="2" />
+    </Grid>
+</ContentPage>`);
+
+    const xaml = await designer.xamlWhen(value => value.includes('<RowDefinition '));
+    expect(xaml).toContain('<RowDefinition Height="Auto" />');
+    expect(xaml).toContain('<RowDefinition Height="2*" />');
+    expect(xaml).toContain('<ColumnDefinition Width="80" />');
+    expect((xaml.match(/<ColumnDefinition /g) || []).length).toBe(3);
+    expect((xaml.match(/<RowDefinition /g) || []).length).toBe(2);
+  });
+
+  test('downloads the XAML file', async ({ page }) => {    await designer.addControl('Label');
     const downloadPromise = page.waitForEvent('download');
     await page.getByTestId('xaml-download').click();
     const download = await downloadPromise;

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -103,7 +103,7 @@
     (cdkDragMoved)="onDragMoved(element, $event)"
     (cdkDragEnded)="onDragEnded(element, $event)"
     (click)="onElementClick(element, $event)"
-    (mouseover)="onLayoutHover($event, element)"
+    (mousemove)="onLayoutHover($event, element)"
     (mouseleave)="onLayoutHoverExit(element)"
     [cdkDragData]="element">
 
@@ -243,6 +243,8 @@
            [cdkDropListData]="element.children"
            (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
            (mouseenter)="setElementRef(element, layoutDiv)"
+           (mousemove)="onLayoutHover($event, element)"
+           (mouseleave)="onLayoutHoverExit(element)"
            [style.grid-template-columns]="getGridTemplateColumns(element)"
            [style.grid-template-rows]="getGridTemplateRows(element)">
         <!-- Grid visualization -->
@@ -254,9 +256,7 @@
                class="grid-cell"
                [class.highlight-cell]="isHighlightedCell(element, i)"
                [style.grid-row]="getGridRowPosition(i, element)"
-               [style.grid-column]="getGridColumnPosition(i, element)"
-               (mousemove)="onLayoutHover($event, element)"
-               (mouseleave)="onLayoutHoverExit(element)">
+               [style.grid-column]="getGridColumnPosition(i, element)">
           </div>
         </div>
         

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -282,7 +282,9 @@
       right: 0;
       bottom: 0;
       display: grid;
-      gap: 1px;
+      // No gap: this overlay has to line up exactly with .element-grid, which
+      // has none. A gap here shifts every track and the highlight then sits
+      // beside the cell a child would actually drop into.
       pointer-events: none;
       z-index: 1;
 
@@ -293,11 +295,6 @@
         min-width: 0;
         min-height: 0;
         
-        &:hover {
-          background: rgba(66, 153, 225, 0.1);
-          border-color: rgba(66, 153, 225, 0.4);
-        }
-
         &.highlight-cell {
           background: rgba(66, 153, 225, 0.2);
           border-color: rgba(66, 153, 225, 0.6);
@@ -561,8 +558,11 @@
     border: 1px dashed rgba(66, 153, 225, 0.3);
     transition: all 0.2s ease;
 
-    &:hover {
-      background-color: rgba(66, 153, 225, 0.1);
+    // The overlay takes no pointer events, so the hovered cell is decided in
+    // code from the pointer position and flagged with .highlight-cell. A CSS
+    // :hover here would never match.
+    &.highlight-cell {
+      background-color: rgba(66, 153, 225, 0.2);
       border-color: rgba(66, 153, 225, 0.6);
     }
   }

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -954,11 +954,20 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   onLayoutHover(event: MouseEvent, element: MauiElement) {
 
     if (element.type === ElementType.Grid) {
-      const rect = (event.target as HTMLElement).getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
-      
-      const gridCell = this.layoutDesigner.getGridCellAtPosition(element, x, y, event.target as HTMLElement);
+      // The event bubbles, so event.target is whatever sits under the pointer -
+      // often a child element, whose rect would put the pointer in the wrong
+      // cell. The grid's own element is the only correct frame of reference.
+      const container = element.domElement ?? (event.currentTarget as HTMLElement | null);
+      if (!container) {
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      const zoom = this.viewport.zoom || 1;
+      const x = (event.clientX - rect.left) / zoom;
+      const y = (event.clientY - rect.top) / zoom;
+
+      const gridCell = this.layoutDesigner.getGridCellAtPosition(element, x, y, container);
       if (gridCell) {
         this.highlightedGridCell = { element, row: gridCell.row, column: gridCell.column };
       }

--- a/src/app/services/layout-designer.service.spec.ts
+++ b/src/app/services/layout-designer.service.spec.ts
@@ -1,0 +1,159 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LayoutDesignerService } from './layout-designer';
+import { ElementType, GridDefinition, MauiElement } from '../models/maui-element';
+
+/**
+ * Grid hit-testing decides which cell a drop lands in, so an off-by-one here
+ * silently writes the wrong Grid.Row/Grid.Column into the generated XAML.
+ */
+describe('LayoutDesignerService grid hit-testing', () => {
+  let service: LayoutDesignerService;
+  const containers: HTMLElement[] = [];
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LayoutDesignerService);
+  });
+
+  afterEach(() => {
+    while (containers.length) {
+      containers.pop()!.remove();
+    }
+  });
+
+  function grid(definition?: GridDefinition): MauiElement {
+    return {
+      id: 'grid',
+      type: ElementType.Grid,
+      properties: definition ? { gridDefinition: definition } : {},
+      children: []
+    } as unknown as MauiElement;
+  }
+
+  /**
+   * Builds a real grid with a real cell overlay and attaches it to the
+   * document, because the service measures the rendered tracks and detached
+   * nodes report every size as zero.
+   */
+  function renderGrid(columns: string, rows: string, width: number, height: number): HTMLElement {
+    const host = document.createElement('div');
+    host.style.cssText = `display:grid;position:relative;width:${width}px;height:${height}px;` +
+      `grid-template-columns:${columns};grid-template-rows:${rows};`;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'grid-visualization';
+    overlay.style.cssText = 'position:absolute;inset:0;display:grid;' +
+      `grid-template-columns:${columns};grid-template-rows:${rows};`;
+
+    const columnCount = columns.trim().split(/\s+/).length;
+    const rowCount = rows.trim().split(/\s+/).length;
+    for (let i = 0; i < columnCount * rowCount; i++) {
+      const cell = document.createElement('div');
+      cell.className = 'grid-cell';
+      overlay.appendChild(cell);
+    }
+
+    host.appendChild(overlay);
+    document.body.appendChild(host);
+    containers.push(host);
+    return host;
+  }
+
+  it('picks the cell under the pointer in an even grid', () => {
+    const container = renderGrid('1fr 1fr', '1fr 1fr', 200, 100);
+    const element = grid();
+
+    expect(service.getGridCellAtPosition(element, 10, 10, container)).toEqual({ row: 0, column: 0 });
+    expect(service.getGridCellAtPosition(element, 150, 10, container)).toEqual({ row: 0, column: 1 });
+    expect(service.getGridCellAtPosition(element, 150, 80, container)).toEqual({ row: 1, column: 1 });
+  });
+
+  it('respects uneven tracks instead of assuming equal cells', () => {
+    // Columns are 20% / 80%. Dividing the width evenly would put x=150 in the
+    // second column too, so the assertion that matters is x=60: evenly split it
+    // reads as column 0, but the first column actually ends at 40px.
+    const container = renderGrid('1fr 4fr', '1fr 1fr', 200, 100);
+    const element = grid({
+      columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 4, type: 'Star' } }],
+      rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }]
+    } as GridDefinition);
+
+    expect(service.getGridCellAtPosition(element, 10, 10, container)!.column).toBe(0);
+    expect(service.getGridCellAtPosition(element, 60, 10, container)!.column).toBe(1);
+  });
+
+  it('handles absolute tracks', () => {
+    const container = renderGrid('50px 1fr', '1fr', 200, 100);
+    const element = grid({
+      columns: [{ width: { value: 50, type: 'Absolute' } }, { width: { value: 1, type: 'Star' } }],
+      rows: [{ height: { value: 1, type: 'Star' } }]
+    } as GridDefinition);
+
+    expect(service.getGridCellAtPosition(element, 49, 10, container)!.column).toBe(0);
+    expect(service.getGridCellAtPosition(element, 51, 10, container)!.column).toBe(1);
+  });
+
+  it('clamps a pointer outside the grid to a real cell', () => {
+    const container = renderGrid('1fr 1fr', '1fr 1fr', 200, 100);
+    const element = grid();
+
+    // Negative coordinates used to floor to -1, which becomes Grid.Column="-1".
+    expect(service.getGridCellAtPosition(element, -30, -30, container)).toEqual({ row: 0, column: 0 });
+    expect(service.getGridCellAtPosition(element, 9999, 9999, container)).toEqual({ row: 1, column: 1 });
+  });
+
+  it('returns nothing for layouts that have no cells', () => {
+    const container = renderGrid('1fr', '1fr', 100, 100);
+    const stack = { id: 's', type: ElementType.VerticalStackLayout, properties: {}, children: [] } as unknown as MauiElement;
+
+    expect(service.getGridCellAtPosition(stack, 10, 10, container)).toBeNull();
+  });
+
+  it('sizes a child from its own row and column, not the whole grid', () => {
+    const container = renderGrid('50px 1fr', '1fr 1fr', 200, 100);
+    const element = grid({
+      columns: [{ width: { value: 50, type: 'Absolute' } }, { width: { value: 1, type: 'Star' } }],
+      rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }]
+    } as GridDefinition);
+
+    const child = { id: 'c', type: ElementType.Label, properties: { row: 0, column: 1 }, children: [] } as unknown as MauiElement;
+    const size = service.getGridChildMaxDimensions(child, element, container)!;
+
+    expect(size.maxWidth).toBeCloseTo(150, 0);
+    expect(size.maxHeight).toBeCloseTo(50, 0);
+  });
+
+  it('lets a spanning child cover every track it spans', () => {
+    const container = renderGrid('1fr 1fr', '1fr 1fr', 200, 100);
+    const element = grid();
+    const child = {
+      id: 'c',
+      type: ElementType.Label,
+      properties: { row: 0, column: 0, columnSpan: 2, rowSpan: 2 },
+      children: []
+    } as unknown as MauiElement;
+
+    const size = service.getGridChildMaxDimensions(child, element, container)!;
+
+    expect(size.maxWidth).toBeCloseTo(200, 0);
+    expect(size.maxHeight).toBeCloseTo(100, 0);
+  });
+
+  it('rebases a drop onto the container it was dropped into', () => {
+    const container = renderGrid('1fr 1fr', '1fr 1fr', 200, 100);
+    // Offset the grid so a viewport coordinate and a container-relative one
+    // cannot be confused: the drop is in the container's second column even
+    // though its viewport x is small.
+    container.style.position = 'absolute';
+    container.style.left = '120px';
+    container.style.top = '40px';
+
+    const element = grid();
+    const rect = container.getBoundingClientRect();
+    const event = { clientX: rect.left + 150, clientY: rect.top + 80 } as MouseEvent;
+
+    expect(service.calculateDropPosition(element, event, container)).toEqual({ x: 1, y: 1 });
+  });
+});

--- a/src/app/services/layout-designer.ts
+++ b/src/app/services/layout-designer.ts
@@ -8,6 +8,16 @@ export interface LayoutInfo {
   supportsGridPositioning: boolean;
 }
 
+/**
+ * The implicit 2x2 grid used when an element has no explicit definition.
+ *
+ * Shared so hit-testing and sizing cannot disagree about the fallback.
+ */
+export const DEFAULT_GRID_DEFINITION = {
+  rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }],
+  columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
+};
+
 @Injectable({
   providedIn: 'root'
 })
@@ -68,9 +78,16 @@ export class LayoutDesignerService {
       return { x: event.clientX, y: event.clientY };
     }
     
+    // clientX/Y are viewport coordinates, so they have to be rebased onto the
+    // container. properties.x/y are the element's position within *its own*
+    // parent, which is a different space entirely and lands the drop in the
+    // wrong cell whenever the layout is not at the canvas origin.
     const rect = containerElement.getBoundingClientRect();
-    const x = event.clientX - parentElement.properties.x!;
-    const y = event.clientY - parentElement.properties.y!;
+    const scale = rect.width && containerElement.offsetWidth
+      ? containerElement.offsetWidth / rect.width
+      : 1;
+    const x = (event.clientX - rect.left) * scale;
+    const y = (event.clientY - rect.top) * scale;
     
     const layoutInfo = this.getLayoutInfo(parentElement.type);
     
@@ -88,26 +105,80 @@ export class LayoutDesignerService {
   }
 
   private calculateGridPosition(gridElement: MauiElement, x: number, y: number, containerElement: HTMLElement): { x: number, y: number } {
-    // Get grid dimensions from element properties or use defaults
-    const gridDefinition = gridElement.properties.gridDefinition || {
-      rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }],
-      columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
-    };
-    
+    const gridDefinition = gridElement.properties.gridDefinition || DEFAULT_GRID_DEFINITION;
+
     // offsetWidth/Height are unscaled, so grid maths stay correct while the canvas is zoomed
     const rect = containerElement.getBoundingClientRect();
     const width = containerElement.offsetWidth || rect.width;
     const height = containerElement.offsetHeight || rect.height;
-    const rows = gridDefinition.rows.length;
-    const columns = gridDefinition.columns.length;
 
-    const cellWidth = width / columns;
-    const cellHeight = height / rows;
-    
-    const column = Math.min(Math.floor(x / cellWidth), columns - 1);
-    const row = Math.min(Math.floor(y / cellHeight), rows - 1);
-    
-    return { x: column, y: row }; // These represent grid coordinates, not pixel coordinates
+    const columnSizes = this.measureTracks(containerElement, 'column')
+      ?? this.calculateGridSizes(gridDefinition.columns.map(c => c.width), width);
+    const rowSizes = this.measureTracks(containerElement, 'row')
+      ?? this.calculateGridSizes(gridDefinition.rows.map(r => r.height), height);
+
+    return {
+      x: this.trackAtOffset(columnSizes, x),
+      y: this.trackAtOffset(rowSizes, y)
+    };
+  }
+
+  /**
+   * Find the track containing an offset, given the size of each track.
+   *
+   * Tracks are rarely equal - a Grid can mix Star, Absolute and Auto - so the
+   * boundaries have to be accumulated rather than derived by division.
+   */
+  private trackAtOffset(sizes: number[], offset: number): number {
+    let edge = 0;
+    for (let index = 0; index < sizes.length; index++) {
+      edge += sizes[index];
+      if (offset < edge) {
+        // Clamp below: a pointer left of/above the grid belongs to the first
+        // track, and a negative index would generate invalid XAML.
+        return Math.max(0, index);
+      }
+    }
+
+    return Math.max(0, sizes.length - 1);
+  }
+
+  /**
+   * Measure the rendered grid tracks, or null when the overlay is not laid out.
+   *
+   * The cell overlay is a real CSS grid, so the browser has already resolved
+   * Auto tracks and any gap between them. Measuring is therefore exact, where
+   * recomputing the sizes here can only ever approximate Auto and would have to
+   * duplicate the gap. Sizes are read from offsetWidth/offsetHeight, which are
+   * unscaled, so the result does not change as the canvas is zoomed.
+   */
+  private measureTracks(containerElement: HTMLElement, axis: 'column' | 'row'): number[] | null {
+    const overlay = containerElement.querySelector<HTMLElement>(':scope > .grid-visualization');
+    const cells = overlay ? Array.from(overlay.children) as HTMLElement[] : [];
+    if (!cells.length) {
+      return null;
+    }
+
+    // One row of cells gives every column width, and one column gives every
+    // row height. Deduplicate by start offset to pick a single line out.
+    const starts = new Map<number, number>();
+    for (const cell of cells) {
+      const start = axis === 'column' ? cell.offsetLeft : cell.offsetTop;
+      const size = axis === 'column' ? cell.offsetWidth : cell.offsetHeight;
+      if (!starts.has(start)) {
+        starts.set(start, size);
+      }
+    }
+
+    const ordered = [...starts.entries()].sort((a, b) => a[0] - b[0]);
+    if (!ordered.length || ordered.every(([, size]) => size === 0)) {
+      return null;
+    }
+
+    // Stretch each track to the start of the next one so any gap belongs to a
+    // cell. Without this, hovering a gap highlights whichever cell was last.
+    return ordered.map(([start, size], index) =>
+      index < ordered.length - 1 ? ordered[index + 1][0] - start : size);
   }
 
   getChildLayoutProperties(parent: MauiElement, child: MauiElement, position: { x: number, y: number }): Partial<MauiElement['properties']> {
@@ -219,12 +290,12 @@ export class LayoutDesignerService {
       return null;
     }
 
-    const gridDefinition = gridElement.properties.gridDefinition || {
-      rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }],
-      columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
-    };
+    const gridDefinition = gridElement.properties.gridDefinition || DEFAULT_GRID_DEFINITION;
 
     const rect = gridContainerElement.getBoundingClientRect();
+    // Unscaled, so a zoomed canvas does not shrink the size cap it computes.
+    const width = gridContainerElement.offsetWidth || rect.width;
+    const height = gridContainerElement.offsetHeight || rect.height;
     const totalColumns = gridDefinition.columns.length;
     const totalRows = gridDefinition.rows.length;
 
@@ -234,9 +305,12 @@ export class LayoutDesignerService {
     const columnSpan = childElement.properties.columnSpan || 1;
     const rowSpan = childElement.properties.rowSpan || 1;
 
-    // Calculate column widths
-    const columnWidths = this.calculateGridSizes(gridDefinition.columns.map(c => c.width), rect.width);
-    const rowHeights = this.calculateGridSizes(gridDefinition.rows.map(r => r.height), rect.height);
+    // Prefer the rendered tracks for the same reason hit-testing does: they
+    // already account for Auto sizing and the gap between cells.
+    const columnWidths = this.measureTracks(gridContainerElement, 'column')
+      ?? this.calculateGridSizes(gridDefinition.columns.map(c => c.width), width);
+    const rowHeights = this.measureTracks(gridContainerElement, 'row')
+      ?? this.calculateGridSizes(gridDefinition.rows.map(r => r.height), height);
 
     // Calculate max width by summing up the widths of spanned columns
     let maxWidth = 0;
@@ -263,12 +337,17 @@ export class LayoutDesignerService {
 
     // First pass: calculate fixed sizes and count star units
     definitions.forEach(def => {
-      if (def.type === 'Star') {
-        starCount += def.value;
-      } else if (def.type === 'Absolute') {
+      if (def.type === 'Absolute') {
         fixedSize += def.value;
+      } else if (def.type === 'Star') {
+        starCount += def.value;
+      } else {
+        // Auto needs content measurement, which is only available from the DOM.
+        // Treat it as one star so the tracks still sum to the container: the
+        // second pass hands Auto a star's worth, so counting it here too is
+        // what keeps the total honest.
+        starCount += 1;
       }
-      // Auto sizing is complex and would need content measurement, treating as 1 star for now
     });
 
     // Calculate size per star unit

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -182,12 +182,37 @@ export class XamlParserService {
       }
     }
 
+    // MAUI also accepts a comma separated shorthand - RowDefinitions="Auto,*".
+    // It is the form most real XAML uses, and ignoring it silently produced a
+    // default 2x2 grid, so an imported layout came back with the wrong shape.
+    if (!rows.length) {
+      rows.push(...this.parseGridLengthList(gridXmlElement.getAttribute('RowDefinitions'))
+        .map(height => ({ height })));
+    }
+
+    if (!columns.length) {
+      columns.push(...this.parseGridLengthList(gridXmlElement.getAttribute('ColumnDefinitions'))
+        .map(width => ({ width })));
+    }
+
     const defaultLength = (): GridLength => ({ value: 1, type: GridLengthType.Star });
 
     return {
       rows: rows.length ? rows : [{ height: defaultLength() }, { height: defaultLength() }],
       columns: columns.length ? columns : [{ width: defaultLength() }, { width: defaultLength() }]
     };
+  }
+
+  private parseGridLengthList(value: string | null): GridLength[] {
+    if (!value) {
+      return [];
+    }
+
+    return value
+      .split(',')
+      .map(part => part.trim())
+      .filter(part => part.length > 0)
+      .map(part => this.parseGridLength(part));
   }
 
   private parseGridLength(value: string | null): GridLength {


### PR DESCRIPTION
Hovering a `Grid` outlined the wrong cell. There was no single cause — the feature was wrong in five independent ways, which is why it looked erratic rather than simply offset.

## The hover bugs

1. **The cell handlers never ran.** The overlay sets `pointer-events: none`, so the `mousemove`/`mouseleave` bound to each `.grid-cell` never fired, and neither did their CSS `:hover`. Every highlight actually came from the wrapper's binding.
2. **That binding used `mouseover`**, which fires on entry only — so the outline stuck wherever the pointer first crossed into the grid instead of following it.
3. **It measured `event.target`**, which bubbling makes whichever node is under the pointer — usually a *child* element. The pointer was located against the wrong rectangle entirely.
4. **It never divided by the zoom**, so the outline drifted further from the pointer the more the canvas was zoomed.
5. **The hit-test split the grid into equal cells**, while the rendered overlay sizes tracks from the definitions. Any grid mixing `Auto`, `Absolute` or unequal `Star` widths disagreed with what was on screen.

## The fix

Bind to the grid container so `currentTarget` is the right node, switch to `mousemove`, and divide by the zoom. For the tracks, **measure the rendered cells** rather than recomputing them — the browser has already resolved `Auto` and any gap, so measuring is exact where arithmetic can only approximate. Sizes come from `offsetWidth`/`offsetHeight`, which are unscaled and so hold up under zoom. The computed path stays as a fallback for when nothing is laid out yet.

Also dropped the overlay's `gap`, which offset it from the content grid by a pixel per track, and clamped the index: a pointer left of or above a grid used to floor to `-1` and would have written `Grid.Column="-1"` into the XAML.

## Two neighbouring bugs found while confirming the above

Both can corrupt a layout on their own:

- **`calculateDropPosition` mixed coordinate spaces.** It subtracted `properties.x/y` — the element's offset within its *own parent* — from viewport coordinates. Any layout not at the canvas origin dropped into the wrong cell.
- **The parser ignored the `ColumnDefinitions="40,*"` shorthand**, understanding only the `<Grid.ColumnDefinitions>` element form. The shorthand is what most real MAUI XAML uses, so importing such a file produced a default 2×2 grid and quietly discarded the real layout.

## Testing

`layout-designer.ts` had **no tests at all**, which is how five bugs accumulated in one feature.

Covered by e2e specs that drive the real canvas, because every one of these was in the *wiring* rather than the arithmetic — a unit test of the maths would have passed throughout. Each test was confirmed to fail before the fix and pass after (4/5 of the new grid specs fail on `main`). Full suite green at **157 passed**.