### PR TITLE
Ship the VS 2026 fix as 0.1.1 so it can install over 0.1.0

### DIFF
--- a/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
+++ b/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
@@ -4,6 +4,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("MAUI Designer for Visual Studio")]
 [assembly: AssemblyDescription("Visual drag and drop designer for .NET MAUI XAML pages.")]
 [assembly: AssemblyProduct("MAUI Designer")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 [assembly: ComVisible(false)]

--- a/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
+++ b/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="0.1.0" Language="en-US" Publisher="GMPrakhar" />
+    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="0.1.1" Language="en-US" Publisher="GMPrakhar" />
     <DisplayName>MAUI Designer</DisplayName>
     <Description xml:space="preserve">A drag and drop visual designer for .NET MAUI XAML pages, including controls that come from NuGet packages.</Description>
     <MoreInfo>https://github.com/GMPrakhar/MAUI-Designer</MoreInfo>

--- a/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 using Xunit;
@@ -282,6 +283,38 @@ namespace MauiDesigner.Core.Tests
             // the extension at all -- the exact bug this range already had once.
             Assert.True(Covers(ranges[0], new Version(17, 0)), $"{ranges[0]} excludes Visual Studio 2022.");
             Assert.True(Covers(ranges[0], new Version(18, 8)), $"{ranges[0]} excludes Visual Studio 2026.");
+        }
+
+        [Fact]
+        public void The_manifest_and_the_assembly_agree_on_the_version()
+        {
+            var manifestPath = Path.Combine(ExtensionDirectory(), "src", "MauiDesigner.Vsix", "source.extension.vsixmanifest");
+            var manifest = XDocument.Load(manifestPath);
+            XNamespace ns = "http://schemas.microsoft.com/developer/vsx-schema/2011";
+
+            var manifestVersion = Version.Parse(
+                manifest.Root!.Element(ns + "Metadata")!.Element(ns + "Identity")!.Attribute("Version")!.Value);
+
+            var assemblyInfo = File.ReadAllText(
+                Path.Combine(ExtensionDirectory(), "src", "MauiDesigner.Vsix", "Properties", "AssemblyInfo.cs"));
+
+            // Visual Studio decides whether a VSIX is an upgrade purely from the
+            // manifest version. Shipping a fix without bumping it leaves everyone
+            // who already installed the extension stuck on the broken build, and
+            // nothing fails loudly when that happens -- the install is simply
+            // refused as "already installed".
+            foreach (var attribute in new[] { "AssemblyVersion", "AssemblyFileVersion" })
+            {
+                var match = Regex.Match(assemblyInfo, $@"{attribute}\(""([^""]+)""\)");
+                Assert.True(match.Success, $"AssemblyInfo.cs is missing [assembly: {attribute}].");
+
+                var declared = Version.Parse(match.Groups[1].Value);
+                Assert.True(
+                    declared.Major == manifestVersion.Major
+                        && declared.Minor == manifestVersion.Minor
+                        && declared.Build == manifestVersion.Build,
+                    $"{attribute} is {declared} but the manifest ships {manifestVersion}.");
+            }
         }
 
         private static bool Covers(string range, Version version)


### PR DESCRIPTION
## The problem

The `vsix-latest` release the website links to was built from `d712b96`, which predates
both the `[17.0,19.0)` manifest widening (#94) and the licence (#95). Anyone following the
beta download link today gets a VSIX that **cannot install on Visual Studio 2026 at all**.

## Why re-publishing was not enough on its own

Visual Studio decides whether a VSIX is an upgrade purely from the manifest identity
version. Republishing a rebuilt `0.1.0` would be refused as "already installed" for
everyone who took the first beta, silently leaving them on the broken build. So the
version has to move: `0.1.0` -> `0.1.1`.

## The drift guard

The manifest version and `AssemblyInfo.cs` were free to disagree, and that disagreement
has no symptom until someone tries to upgrade in the field — the install is simply
declined. `The_manifest_and_the_assembly_agree_on_the_version` ties them together.

Verified by planting the bug: setting `AssemblyInfo` back to `0.1.0.0` while the manifest
says `0.1.1` fails the test; aligned, all 50 tests pass.

## After this merges

Run the **Package VSIX** workflow against `main` with tag `vsix-v0.1.1-beta.1`. Publishing
is gated on `install-check`, which now passes on both VS 2022 and VS 2026, so the release
cannot go out unless it has been shown to install into a real IDE.