### PR TITLE
Let users restack overlapping elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Snap to Grid**: Configurable grid size with snapping while dragging
 - **Smart Guides**: Live guides when a dragged element lines up with a sibling or the page edges/centre
 - **Rulers**: Optional horizontal and vertical rulers around the design surface
+- **Z-Order**: Bring to front, send to back and single-step restacking (`Ctrl+]` / `Ctrl+[`, add `Shift` to jump to either end)
 
 ### Clipboard, Templates & Starter Pages
 - **Copy/Cut/Paste**: `Ctrl+C`, `Ctrl+X`, `Ctrl+V` (containers keep their children, names stay unique)

--- a/e2e/z-order.spec.ts
+++ b/e2e/z-order.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+/**
+ * Stacking order is not stored as a z-index anywhere -- it comes straight from
+ * the order of `children`, which is also the order elements are written to
+ * XAML. So the XAML pane is the honest place to assert against: if the emitted
+ * document changed order, the canvas and the saved file agree by construction.
+ */
+async function tagOrder(designer: DesignerPage): Promise<string[]> {
+  const xaml = await designer.getXaml();
+  return [...xaml.matchAll(/<(Label|Button|Image)\b/g)].map(match => match[1]);
+}
+
+/** Adds a control and places it at an absolute position. */
+async function addAt(designer: DesignerPage, type: string, x: number, y: number) {
+  await designer.addControl(type);
+  await designer.setProperty('x', String(x));
+  await designer.setProperty('y', String(y));
+}
+
+test.describe('Z-order controls', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    // Spread them out so each one is directly clickable. Stacking order is
+    // independent of position, so this does not weaken what is under test.
+    await addAt(designer, 'Label', 20, 20);
+    await addAt(designer, 'Button', 20, 140);
+    await addAt(designer, 'Image', 20, 260);
+  });
+
+  test('bring to front moves the element past all of its siblings', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await page.getByTestId('bring-to-front').click();
+
+    await expect.poll(() => tagOrder(designer)).toEqual(['Button', 'Image', 'Label']);
+  });
+
+  test('send to back moves the element behind all of its siblings', async ({ page }) => {
+    await designer.selectFirst('Image');
+    await page.getByTestId('send-to-back').click();
+
+    await expect.poll(() => tagOrder(designer)).toEqual(['Image', 'Label', 'Button']);
+  });
+
+  test('bring forward moves exactly one step', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await page.getByTestId('bring-forward').click();
+
+    await expect.poll(() => tagOrder(designer)).toEqual(['Button', 'Label', 'Image']);
+  });
+
+  test('send backward moves exactly one step', async ({ page }) => {
+    await designer.selectFirst('Image');
+    await page.getByTestId('send-backward').click();
+
+    await expect.poll(() => tagOrder(designer)).toEqual(['Label', 'Image', 'Button']);
+  });
+
+  test('keyboard shortcuts restack the selection', async ({ page }) => {
+    await designer.selectFirst('Label');
+
+    await page.keyboard.press('Control+]');
+    await expect.poll(() => tagOrder(designer)).toEqual(['Button', 'Label', 'Image']);
+
+    await page.keyboard.press('Control+Shift+]');
+    await expect.poll(() => tagOrder(designer)).toEqual(['Button', 'Image', 'Label']);
+
+    await page.keyboard.press('Control+Shift+[');
+    await expect.poll(() => tagOrder(designer)).toEqual(['Label', 'Button', 'Image']);
+  });
+
+  test('restacking is a single undo step', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await page.getByTestId('bring-to-front').click();
+    await expect.poll(() => tagOrder(designer)).toEqual(['Button', 'Image', 'Label']);
+
+    await designer.undoButton.click();
+
+    await expect.poll(() => tagOrder(designer)).toEqual(['Label', 'Button', 'Image']);
+  });
+
+  test('the buttons are disabled when there is nothing to restack against', async ({ page }) => {
+    // A fresh canvas with a single child has no sibling to move past.
+    await designer.goto();
+    await expect(page.getByTestId('bring-to-front')).toBeDisabled();
+
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+    await expect(page.getByTestId('bring-to-front')).toBeDisabled();
+
+    await designer.addControl('Button');
+    await designer.selectFirst('Button');
+    await expect(page.getByTestId('bring-to-front')).toBeEnabled();
+  });
+
+  test('a selected element paints in its real stacking order', async ({ page }) => {
+    // Regression guard: the canvas used to lift whatever was selected to
+    // z-index 9999, so sending the selection to the back left it visibly on
+    // top and the feature looked broken until you clicked somewhere else.
+    await designer.selectFirst('Image');
+    await page.getByTestId('send-to-back').click();
+
+    const zIndex = await page
+      .locator('[data-element-type="Image"]')
+      .first()
+      .evaluate(node => getComputedStyle(node).zIndex);
+
+    expect(zIndex).toBe('auto');
+  });
+});

--- a/src/app/components/canvas-toolbar/canvas-toolbar.html
+++ b/src/app/components/canvas-toolbar/canvas-toolbar.html
@@ -103,6 +103,21 @@
   </div>
 
   <div class="toolbar-group">
+    <button class="toolbar-button" data-testid="bring-to-front" title="Bring to front (Ctrl+Shift+])" [disabled]="!canReorder" (click)="reorder('front')">
+      <span class="material-icons">flip_to_front</span>
+    </button>
+    <button class="toolbar-button" data-testid="bring-forward" title="Bring forward (Ctrl+])" [disabled]="!canReorder" (click)="reorder('forward')">
+      <span class="material-icons">arrow_upward</span>
+    </button>
+    <button class="toolbar-button" data-testid="send-backward" title="Send backward (Ctrl+[)" [disabled]="!canReorder" (click)="reorder('backward')">
+      <span class="material-icons">arrow_downward</span>
+    </button>
+    <button class="toolbar-button" data-testid="send-to-back" title="Send to back (Ctrl+Shift+[)" [disabled]="!canReorder" (click)="reorder('back')">
+      <span class="material-icons">flip_to_back</span>
+    </button>
+  </div>
+
+  <div class="toolbar-group">
     <button class="toolbar-button" data-testid="toolbar-copy" title="Copy (Ctrl+C)" [disabled]="!hasSelection" (click)="copy()">
       <span class="material-icons">content_copy</span>
     </button>

--- a/src/app/components/canvas-toolbar/canvas-toolbar.ts
+++ b/src/app/components/canvas-toolbar/canvas-toolbar.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
-import { ElementService } from '../../services/element';
+import { ElementService, ReorderMode } from '../../services/element';
 import { AlignmentService, AlignMode, DistributeMode } from '../../services/alignment';
 import { ClipboardService } from '../../services/clipboard';
 import { ViewportService, ViewportState, DEVICE_PRESETS } from '../../services/viewport';
@@ -123,6 +123,16 @@ export class CanvasToolbarComponent implements OnInit, OnDestroy {
 
   distribute(mode: DistributeMode) {
     this.alignmentService.distribute(this.selection, mode);
+  }
+
+  // --- Z-order ----------------------------------------------------------------
+
+  get canReorder(): boolean {
+    return this.elementService.canReorderSelection();
+  }
+
+  reorder(mode: ReorderMode) {
+    this.elementService.reorderSelection(mode);
   }
 
   // --- Clipboard --------------------------------------------------------------

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -518,6 +518,13 @@
   }
 }
 
+/* Keep the element being dragged above its siblings for the duration of the
+   drag. Outside an interaction, elements paint in their real stacking order so
+   the z-order controls have a visible effect. */
+.cdk-drag-dragging {
+  z-index: 9999 !important;
+}
+
 .cdk-drag-preview {
   .selection-handles {
     display: none;

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -418,6 +418,15 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (ctrl && (event.key === ']' || event.key === '[')) {
+      event.preventDefault();
+      const toFront = event.key === ']';
+      this.elementService.reorderSelection(
+        event.shiftKey ? (toFront ? 'front' : 'back') : (toFront ? 'forward' : 'backward')
+      );
+      return;
+    }
+
     const selected = this.elementService.getSelectedElement();
     if (!selected) {
       return;
@@ -521,7 +530,11 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     const styles: any = {
       width: props.width + 'px',
       height: props.height + 'px',
-      zIndex: this.isSelected(element) ? 9999 : 'auto',
+      // Only lift the element while it is actively being resized. Lifting it for
+      // the whole time it is selected would hide the effect of send-to-back:
+      // the user restacks an element, sees nothing move, and assumes it failed.
+      // Dragging is covered by `.cdk-drag-dragging` in the stylesheet.
+      zIndex: this.isSelected(element) && this.isResizing ? 9999 : 'auto',
       transform: `translate3d(${props.x}px, ${props.y}px, 0px)`
     };
 

--- a/src/app/services/element.service.spec.ts
+++ b/src/app/services/element.service.spec.ts
@@ -60,4 +60,129 @@ describe('ElementService', () => {
     expect(button.properties.backgroundColor).toBe('#ff0000');
     expect(button.properties.width).toBe(200);
   });
+
+  describe('z-order', () => {
+    /** Adds `count` labels to the root and returns them in document order. */
+    function addLabels(count: number) {
+      const root = service.getRootElement();
+      return Array.from({ length: count }, () => {
+        const label = service.createElement(ElementType.Label);
+        service.addElement(label, root);
+        return label;
+      });
+    }
+
+    /** The current stacking order of the root's children, back to front. */
+    function order(labels: ReturnType<typeof addLabels>) {
+      return service.getRootElement().children.map(child => labels.indexOf(child));
+    }
+
+    it('brings the selection to the front', () => {
+      const labels = addLabels(3);
+      service.selectElement(labels[0]);
+
+      expect(service.reorderSelection('front')).toBe(true);
+      expect(order(labels)).toEqual([1, 2, 0]);
+    });
+
+    it('sends the selection to the back', () => {
+      const labels = addLabels(3);
+      service.selectElement(labels[2]);
+
+      expect(service.reorderSelection('back')).toBe(true);
+      expect(order(labels)).toEqual([2, 0, 1]);
+    });
+
+    it('moves one step at a time', () => {
+      const labels = addLabels(3);
+      service.selectElement(labels[0]);
+
+      service.reorderSelection('forward');
+      expect(order(labels)).toEqual([1, 0, 2]);
+
+      service.reorderSelection('forward');
+      expect(order(labels)).toEqual([1, 2, 0]);
+    });
+
+    it('keeps a multi-selection together instead of collapsing it', () => {
+      const labels = addLabels(4);
+      service.setSelection([labels[0], labels[1]]);
+
+      service.reorderSelection('forward');
+
+      // Both move up one slot and stay in their original relative order. Moving
+      // them independently would let the lower one hop over the upper one.
+      expect(order(labels)).toEqual([2, 0, 1, 3]);
+    });
+
+    it('reports no change when the selection is already at the edge', () => {
+      const labels = addLabels(3);
+      service.selectElement(labels[2]);
+
+      expect(service.reorderSelection('front')).toBe(false);
+      expect(service.reorderSelection('forward')).toBe(false);
+      expect(order(labels)).toEqual([0, 1, 2]);
+    });
+
+    it('does not spend an undo step on a move that changes nothing', () => {
+      const labels = addLabels(2);
+      service.selectElement(labels[1]);
+
+      // A fresh service has nothing to undo; a no-op must not create one.
+      const undoBefore = service.canUndo();
+      service.reorderSelection('front');
+
+      expect(service.canUndo()).toBe(undoBefore);
+    });
+
+    it('undoes a restack as a single step', () => {
+      const labels = addLabels(3);
+      service.selectElement(labels[0]);
+      service.reorderSelection('front');
+
+      service.undo();
+
+      const ids = service.getRootElement().children.map(child => child.id);
+      expect(ids).toEqual([labels[0].id, labels[1].id, labels[2].id]);
+    });
+
+    it('restacks each parent independently when the selection spans containers', () => {
+      const root = service.getRootElement();
+      const stack = service.createElement(ElementType.VerticalStackLayout);
+      service.addElement(stack, root);
+
+      const rootLabel = service.createElement(ElementType.Label);
+      service.addElement(rootLabel, root);
+      const nested = [0, 1].map(() => {
+        const label = service.createElement(ElementType.Label);
+        service.addElement(label, stack);
+        return label;
+      });
+
+      // `stack` is first in root, `nested[0]` is first in stack. Selecting one
+      // from each container and moving forward should advance both.
+      service.setSelection([stack, nested[0]]);
+      service.reorderSelection('forward');
+
+      expect(root.children).toEqual([rootLabel, stack]);
+      expect(stack.children).toEqual([nested[1], nested[0]]);
+    });
+
+    it('refuses to restack the root, which has no siblings', () => {
+      service.selectElement(service.getRootElement());
+
+      expect(service.reorderSelection('front')).toBe(false);
+      expect(service.canReorderSelection()).toBe(false);
+    });
+
+    it('only offers to restack when there is something to restack against', () => {
+      const labels = addLabels(1);
+      service.selectElement(labels[0]);
+      expect(service.canReorderSelection()).toBe(false);
+
+      const second = service.createElement(ElementType.Label);
+      service.addElement(second, service.getRootElement());
+      expect(service.canReorderSelection()).toBe(true);
+    });
+  });
 });

--- a/src/app/services/element.ts
+++ b/src/app/services/element.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';import { MauiElement, ElementType, ElementProperties, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA } from '../models/maui-element';
 
+/**
+ * How to restack the selection among its siblings. Later children paint on top,
+ * so "front" is the end of the array.
+ */
+export type ReorderMode = 'front' | 'back' | 'forward' | 'backward';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -467,6 +473,107 @@ export class ElementService {
         }, { recordHistory: false })
       );
     });
+  }
+
+  /**
+   * Restacks the selection within its parent.
+   *
+   * Both the canvas and the generated XAML take their stacking order straight
+   * from `children`, so reordering the array is the whole feature -- there is no
+   * separate z-index to keep in sync.
+   */
+  reorderSelection(mode: ReorderMode): boolean {
+    const targets = this.selectedElements.filter(element => element !== this.rootElement && element.parent);
+    if (targets.length === 0) {
+      return false;
+    }
+
+    // A selection can span several parents, and "front" means the front of your
+    // own parent -- there is no ordering between separate containers.
+    const byParent = new Map<MauiElement, MauiElement[]>();
+    for (const element of targets) {
+      const siblings = byParent.get(element.parent!) ?? [];
+      siblings.push(element);
+      byParent.set(element.parent!, siblings);
+    }
+
+    let changed = false;
+    const willChange = [...byParent].some(([parent, group]) => this.wouldReorder(parent, group, mode));
+    if (!willChange) {
+      // Nothing to do -- bail before opening a history batch, or the selection
+      // being already at the edge would cost the user an empty undo step.
+      return false;
+    }
+
+    this.runAsSingleChange(() => {
+      byParent.forEach((group, parent) => {
+        if (this.reorderWithinParent(parent, group, mode)) {
+          changed = true;
+        }
+      });
+    });
+
+    if (changed) {
+      this.elementsSubject.next(this.rootElement);
+    }
+    return changed;
+  }
+
+  /** True when the selection sits in a container that has something to restack against. */
+  canReorderSelection(): boolean {
+    return this.selectedElements.some(
+      element => element !== this.rootElement && (element.parent?.children.length ?? 0) > 1
+    );
+  }
+
+  /**
+   * Whether the move would actually change anything.
+   *
+   * Moving up is a no-op exactly when the group already occupies a contiguous
+   * block at the end -- every member is either at the edge or blocked by another
+   * member. Moving down is the mirror image.
+   */
+  private wouldReorder(parent: MauiElement, group: MauiElement[], mode: ReorderMode): boolean {
+    const children = parent.children;
+    const indices = group.map(child => children.indexOf(child)).sort((a, b) => a - b);
+    const contiguous = indices.every((index, offset) => index === indices[0] + offset);
+
+    if (mode === 'front' || mode === 'forward') {
+      return !(contiguous && indices[indices.length - 1] === children.length - 1);
+    }
+    return !(contiguous && indices[0] === 0);
+  }
+
+  private reorderWithinParent(parent: MauiElement, group: MauiElement[], mode: ReorderMode): boolean {
+    const children = parent.children;
+    const before = [...children];
+
+    // Keep the group's own relative order intact whichever end it moves to.
+    const ordered = group.slice().sort((a, b) => children.indexOf(a) - children.indexOf(b));
+
+    if (mode === 'front' || mode === 'back') {
+      const rest = children.filter(child => !group.includes(child));
+      const next = mode === 'front' ? [...rest, ...ordered] : [...ordered, ...rest];
+      children.splice(0, children.length, ...next);
+    } else {
+      // One step at a time. Walking from the edge the group moves towards stops
+      // members of the same group from hopping over each other, which would
+      // scramble their relative order instead of moving them as a block.
+      const step = mode === 'forward' ? 1 : -1;
+      const walk = mode === 'forward' ? ordered.slice().reverse() : ordered;
+
+      for (const element of walk) {
+        const index = children.indexOf(element);
+        const swapWith = index + step;
+        if (swapWith < 0 || swapWith >= children.length || group.includes(children[swapWith])) {
+          continue;
+        }
+        children[index] = children[swapWith];
+        children[swapWith] = element;
+      }
+    }
+
+    return children.some((child, index) => child !== before[index]);
   }
 
   updateElementProperties(element: MauiElement, properties: Partial<ElementProperties>, options: { recordHistory?: boolean } = {}): void {


### PR DESCRIPTION
Implements **Z-Order / Layer Controls** from the WYSIWYG research backlog.

## The gap

Overlapping elements in an `AbsoluteLayout` had no user-facing stacking control. Order came
entirely from the order controls happened to be added in, and the only way to change it was
to delete and re-add the element.

## Approach

Stacking is not stored as a z-index anywhere — the canvas and the XAML generator both read
straight from `children`. So reordering that array *is* the whole feature, and the canvas
and the emitted document cannot drift apart.

Exposed as four toolbar buttons and `Ctrl+]` / `Ctrl+[`, with `Shift` to jump to either end.

## Two details worth review

**The selection lift had to go.** The canvas lifted whatever was selected to `z-index: 9999`.
That would have made this feature look broken — you send an element to the back, nothing
moves, because it is still selected and still on top. The lift now applies only while
resizing, with dragging covered by a `.cdk-drag-dragging` rule, so elements paint in their
real order at rest. `a selected element paints in its real stacking order` guards this;
I confirmed it fails against the old unconditional lift.

**Multi-selection spans parents.** There is no ordering between separate containers, so each
parent is restacked independently. Within a parent the selection moves as a block and keeps
its relative order — stepping members individually would let them hop over each other.

A move that changes nothing (already at the edge) returns `false` and deliberately opens no
history batch, so it does not cost the user an empty undo step.

## Verification

- 8 new e2e specs, asserting against emitted XAML order rather than pixels.
- 10 new unit specs (CI total: 124 -> 134). Karma cannot capture a browser in my environment, so I additionally
  bundled the service with esbuild and ran the same 18 assertions under plain node — all
  pass. CI runs the Karma versions.
- **Full suite green: 159/159 e2e.** This matters because of the z-index change; the drag,
  resize, selection and marquee specs all still pass.
