### PR TITLE
Let colours differ between light and dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Snap to Grid**: Configurable grid size with snapping while dragging
 - **Smart Guides**: Live guides when a dragged element lines up with a sibling or the page edges/centre
 - **Rulers**: Optional horizontal and vertical rulers around the design surface
+- **Theming**: Per-property light/dark colours emitted as `AppThemeBinding`, previewed against the toolbar theme
 - **Z-Order**: Bring to front, send to back and single-step restacking (`Ctrl+]` / `Ctrl+[`, add `Shift` to jump to either end)
 
 ### Clipboard, Templates & Starter Pages

--- a/e2e/theming.spec.ts
+++ b/e2e/theming.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Theming with AppThemeBinding', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('a light and dark pair is emitted as an AppThemeBinding', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('theme-light-TextColor').fill('#ffffff');
+    await page.getByTestId('theme-dark-TextColor').fill('#333333');
+
+    await designer.expectXamlToContain('TextColor="{AppThemeBinding Light=#ffffff, Dark=#333333}"');
+  });
+
+  test('the canvas previews the colour for the current theme', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('theme-light-BackgroundColor').fill('#ff0000');
+    await page.getByTestId('theme-dark-BackgroundColor').fill('#0000ff');
+
+    const label = page.locator('[data-element-type="Label"]').first();
+    const background = () => label.evaluate(node => getComputedStyle(node).backgroundColor);
+
+    await expect.poll(background).toBe('rgb(255, 0, 0)');
+
+    await page.getByTestId('toggle-theme').click();
+
+    // Same element, same design -- only the preview theme changed.
+    await expect.poll(background).toBe('rgb(0, 0, 255)');
+  });
+
+  test('clearing a theme colour restores the plain literal', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('theme-light-BackgroundColor').fill('#ff0000');
+    await designer.expectXamlToContain('AppThemeBinding');
+
+    await page.getByTestId('theme-clear-BackgroundColor').click();
+
+    await expect.poll(() => designer.getXaml()).not.toContain('AppThemeBinding');
+  });
+
+  test('the clear button is only enabled once a theme colour is set', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await expect(page.getByTestId('theme-clear-TextColor')).toBeDisabled();
+
+    await page.getByTestId('theme-light-TextColor').fill('#123456');
+
+    await expect(page.getByTestId('theme-clear-TextColor')).toBeEnabled();
+  });
+
+  test('hand written AppThemeBinding survives a round trip', async () => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Label x:Name="Themed" Text="Hi" TextColor="{AppThemeBinding Light=#FFFFFF, Dark=#333333}" />
+  </AbsoluteLayout>
+</ContentPage>`);
+
+    await designer.expectXamlToContain('TextColor="{AppThemeBinding Light=#FFFFFF, Dark=#333333}"');
+  });
+
+  test('only the colours that apply to the element type are offered', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    // A Label has text, so it gets a text colour; it is not a Path, so no fill.
+    await expect(page.getByTestId('theme-row-BackgroundColor')).toBeVisible();
+    await expect(page.getByTestId('theme-row-TextColor')).toBeVisible();
+    await expect(page.getByTestId('theme-row-Fill')).toHaveCount(0);
+  });
+});

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -199,8 +199,8 @@
            preserveAspectRatio="xMidYMid meet"
            aria-label="Icon path preview">
         <path [attr.d]="element.properties.pathData"
-              [attr.fill]="element.properties.fillColor || 'transparent'"
-              [attr.stroke]="element.properties.strokeColor || 'transparent'"
+              [attr.fill]="themedColor(element, 'Fill', element.properties.fillColor) || 'transparent'"
+              [attr.stroke]="themedColor(element, 'Stroke', element.properties.strokeColor) || 'transparent'"
               [attr.stroke-width]="element.properties.strokeThickness || 0"></path>
       </svg>
        
@@ -296,7 +296,7 @@
            [cdkDropListData]="element.children"
            (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
            (mouseenter)="setElementRef(element, layoutDiv)"
-           [style.border-color]="element.properties.borderColor || '#cccccc'"
+           [style.border-color]="themedColor(element, 'Stroke', element.properties.borderColor) || '#cccccc'"
            [style.border-width.px]="element.properties.borderWidth || 1"
            [style.border-radius.px]="element.properties.cornerRadius || 0">
         <ng-container *ngFor="let child of element.children">

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -538,12 +538,14 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
       transform: `translate3d(${props.x}px, ${props.y}px, 0px)`
     };
 
-    if (props.backgroundColor) {
-      styles.backgroundColor = props.backgroundColor;
+    const background = this.themedColor(element, 'BackgroundColor', props.backgroundColor);
+    if (background) {
+      styles.backgroundColor = background;
     }
 
-    if (props.textColor) {
-      styles.color = props.textColor;
+    const text = this.themedColor(element, 'TextColor', props.textColor);
+    if (text) {
+      styles.color = text;
     }
 
     if (props.fontSize) {
@@ -561,6 +563,20 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     }
 
     return styles;
+  }
+
+  /**
+   * The colour to paint for a property, honouring any AppThemeBinding against
+   * the current preview theme. Falls back to the literal designer value, so a
+   * property with only a light override still renders in dark mode.
+   */
+  themedColor(element: MauiElement, property: string, fallback?: string): string | undefined {
+    const theme = element.properties.appTheme?.[property];
+    if (!theme) {
+      return fallback;
+    }
+    const preferred = this.viewport.theme === 'dark' ? theme.dark : theme.light;
+    return preferred || theme.light || theme.dark || fallback;
   }
 
   isLayoutElement(element: MauiElement): boolean {

--- a/src/app/components/properties-panel/properties-panel.html
+++ b/src/app/components/properties-panel/properties-panel.html
@@ -155,6 +155,41 @@
       </div>
     </div>
 
+    <!-- Theming: per-property light/dark colours emitted as AppThemeBinding -->
+    <div class="property-section">
+      <h4 class="section-header">Theming</h4>
+      <p class="section-hint">Set a light and dark colour to emit an AppThemeBinding. The canvas previews whichever matches the toolbar theme.</p>
+
+      <div class="property-group theme-row" *ngFor="let color of themeableColors(element)"
+           [attr.data-testid]="'theme-row-' + color.name">
+        <label class="property-label">{{ color.label }}</label>
+        <div class="theme-swatches">
+          <label class="theme-swatch">
+            <span class="theme-swatch-label">Light</span>
+            <input type="color"
+                   class="property-input color-input"
+                   [attr.data-testid]="'theme-light-' + color.name"
+                   [value]="themeColor(element, color.name, 'light') || color.fallback"
+                   (input)="updateThemeColor(element, color.name, 'light', $any($event.target).value)">
+          </label>
+          <label class="theme-swatch">
+            <span class="theme-swatch-label">Dark</span>
+            <input type="color"
+                   class="property-input color-input"
+                   [attr.data-testid]="'theme-dark-' + color.name"
+                   [value]="themeColor(element, color.name, 'dark') || color.fallback"
+                   (input)="updateThemeColor(element, color.name, 'dark', $any($event.target).value)">
+          </label>
+          <button type="button"
+                  class="theme-clear"
+                  title="Remove the theme binding"
+                  [attr.data-testid]="'theme-clear-' + color.name"
+                  [disabled]="!hasThemeColor(element, color.name)"
+                  (click)="clearThemeColor(element, color.name)">Clear</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Text Properties -->
     <div class="property-section" *ngIf="element.properties.text !== undefined">
       <h4 class="section-header">Text</h4>

--- a/src/app/components/properties-panel/properties-panel.scss
+++ b/src/app/components/properties-panel/properties-panel.scss
@@ -182,3 +182,43 @@
   color: #6b7280;
   font-size: 11px;
 }
+
+/* Theming (AppThemeBinding) */
+.theme-swatches {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.theme-swatch {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.theme-swatch-label {
+  color: #6b7280;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.theme-clear {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #fff;
+  color: #374151;
+  font-size: 11px;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  &:not(:disabled):hover {
+    background: #f3f4f6;
+  }
+}

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -228,6 +228,57 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
     this.elementService.updateElementProperties(element, { bindings });
   }
 
+  // --- Theming (AppThemeBinding) -----------------------------------------------
+
+  /**
+   * The colour properties worth theming for this element. Derived from the
+   * element type rather than a fixed list because `Stroke` means the border of
+   * a Border but the outline of a Path, and only one applies at a time.
+   */
+  themeableColors(element: MauiElement): { name: string; label: string; fallback: string }[] {
+    const colors = [{ name: 'BackgroundColor', label: 'Background', fallback: '#ffffff' }];
+
+    if (element.properties.text !== undefined) {
+      colors.push({ name: 'TextColor', label: 'Text', fallback: '#000000' });
+    }
+    if (element.type === ElementType.Path) {
+      colors.push({ name: 'Fill', label: 'Fill', fallback: '#000000' });
+      colors.push({ name: 'Stroke', label: 'Stroke', fallback: '#000000' });
+    } else if (element.type === ElementType.Border) {
+      colors.push({ name: 'Stroke', label: 'Border', fallback: '#cccccc' });
+    }
+
+    return colors;
+  }
+
+  themeColor(element: MauiElement, property: string, mode: 'light' | 'dark'): string {
+    return element.properties.appTheme?.[property]?.[mode] || '';
+  }
+
+  hasThemeColor(element: MauiElement, property: string): boolean {
+    const theme = element.properties.appTheme?.[property];
+    return !!(theme?.light || theme?.dark);
+  }
+
+  updateThemeColor(element: MauiElement, property: string, mode: 'light' | 'dark', value: string) {
+    const appTheme = { ...(element.properties.appTheme || {}) };
+    const entry = { ...(appTheme[property] || {}), [mode]: value };
+
+    if (!entry.light && !entry.dark) {
+      delete appTheme[property];
+    } else {
+      appTheme[property] = entry;
+    }
+
+    this.elementService.updateElementProperties(element, { appTheme });
+  }
+
+  clearThemeColor(element: MauiElement, property: string) {
+    const appTheme = { ...(element.properties.appTheme || {}) };
+    delete appTheme[property];
+    this.elementService.updateElementProperties(element, { appTheme });
+  }
+
   isStackLayout(element: MauiElement): boolean {
     return element.type === ElementType.StackLayout || element.type === ElementType.VerticalStackLayout;
   }

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -115,6 +115,19 @@ export interface ElementProperties {
    * is generated as Text="{Binding UserName}".
    */
   bindings?: Record<string, string>;
+
+  /**
+   * Per-theme colour overrides keyed by MAUI property name, e.g.
+   * `{ BackgroundColor: { light: '#FFFFFF', dark: '#1E1E1E' } }` is generated as
+   * BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}".
+   */
+  appTheme?: Record<string, AppThemeColor>;
+}
+
+/** Light and dark values for a single colour property. */
+export interface AppThemeColor {
+  light?: string;
+  dark?: string;
 }
 
 /** Properties that can be bound to a view model, per element type. */

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -135,6 +135,7 @@ ${xamlContent}
     const props = element.properties;
     const attributes: string[] = [];
     const bindings = props.bindings || {};
+    const appTheme = props.appTheme || {};
 
     /** A bound property wins over the literal designer value. */
     const push = (name: string, value: string | number | undefined) => {
@@ -144,6 +145,25 @@ ${xamlContent}
       if (value !== undefined && value !== null && value !== '') {
         attributes.push(`${name}="${value}"`);
       }
+    };
+
+    /**
+     * Colours may carry per-theme values. Routing them through here rather than
+     * pushing directly also makes them honour bindings: attributes are
+     * de-duplicated first-writer-wins and the binding loop runs last, so a
+     * literal written directly would silently shadow the binding.
+     */
+    const pushColor = (name: string, value: string | undefined) => {
+      const theme = appTheme[name];
+      if (theme && (theme.light || theme.dark)) {
+        const parts = [
+          theme.light ? `Light=${theme.light}` : '',
+          theme.dark ? `Dark=${theme.dark}` : ''
+        ].filter(Boolean);
+        push(name, `{AppThemeBinding ${parts.join(', ')}}`);
+        return;
+      }
+      push(name, value === undefined ? undefined : this.escapeXml(value));
     };
     
     // Add name attribute
@@ -241,10 +261,10 @@ ${xamlContent}
         attributes.push(`Data="${this.escapeXml(props.pathData)}"`);
       }
       if (props.fillColor) {
-        attributes.push(`Fill="${this.escapeXml(props.fillColor)}"`);
+        pushColor('Fill', props.fillColor);
       }
       if (props.strokeColor) {
-        attributes.push(`Stroke="${this.escapeXml(props.strokeColor)}"`);
+        pushColor('Stroke', props.strokeColor);
       }
       if (props.strokeThickness !== undefined) {
         attributes.push(`StrokeThickness="${props.strokeThickness}"`);
@@ -252,11 +272,11 @@ ${xamlContent}
     }
     
     // Colors
-    if (props.backgroundColor) {
-      attributes.push(`BackgroundColor="${props.backgroundColor}"`);
+    if (props.backgroundColor || appTheme['BackgroundColor']) {
+      pushColor('BackgroundColor', props.backgroundColor);
     }
-    if (props.textColor) {
-      attributes.push(`TextColor="${props.textColor}"`);
+    if (props.textColor || appTheme['TextColor']) {
+      pushColor('TextColor', props.textColor);
     }
     
     // Font attributes

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA, AppThemeColor } from '../models/maui-element';
 import { CustomControlRegistryService } from './custom-control-registry';
 
 /** Attributes the designer models itself, so they never end up in rawAttributes. */
@@ -500,6 +500,26 @@ export class XamlParserService {
       return value === null || this.isBindingExpression(value) ? null : value;
     };
 
+    /**
+     * Reads a colour attribute, unpacking `{AppThemeBinding Light=..., Dark=...}`
+     * into `appTheme` and returning the value the canvas should paint with. The
+     * light value is the fallback so a design opened in light mode looks right.
+     */
+    const color = (name: string): string | null => {
+      const value = xmlElement.getAttribute(name);
+      if (value === null || this.isBindingExpression(value)) {
+        return null;
+      }
+
+      const theme = XamlParserService.parseAppThemeBinding(value);
+      if (!theme) {
+        return value;
+      }
+
+      properties.appTheme = { ...(properties.appTheme || {}), [name]: theme };
+      return theme.light ?? theme.dark ?? null;
+    };
+
     // Parse basic properties
     const text = literal('Text');
     if (text) properties.text = text;
@@ -544,7 +564,7 @@ export class XamlParserService {
     }
 
     if (elementType === ElementType.Border) {
-      const borderColor = literal('Stroke');
+      const borderColor = color('Stroke');
       if (borderColor) properties.borderColor = borderColor;
       const borderWidth = literal('StrokeThickness');
       if (borderWidth) properties.borderWidth = parseFloat(borderWidth);
@@ -553,10 +573,10 @@ export class XamlParserService {
     const pathData = xmlElement.getAttribute('Data');
     if (pathData) properties.pathData = pathData;
 
-    const fill = xmlElement.getAttribute('Fill');
+    const fill = color('Fill');
     if (fill) properties.fillColor = fill;
 
-    const stroke = xmlElement.getAttribute('Stroke');
+    const stroke = color('Stroke');
     if (stroke) properties.strokeColor = stroke;
 
     const strokeThickness = xmlElement.getAttribute('StrokeThickness');
@@ -568,10 +588,10 @@ export class XamlParserService {
     const heightRequest = xmlElement.getAttribute('HeightRequest');
     if (heightRequest) properties.height = parseFloat(heightRequest);
 
-    const backgroundColor = xmlElement.getAttribute('BackgroundColor');
+    const backgroundColor = color('BackgroundColor');
     if (backgroundColor) properties.backgroundColor = backgroundColor;
 
-    const textColor = xmlElement.getAttribute('TextColor');
+    const textColor = color('TextColor');
     if (textColor) properties.textColor = textColor;
 
     const fontSize = xmlElement.getAttribute('FontSize');
@@ -668,6 +688,35 @@ export class XamlParserService {
       bindings[attribute.name] = path.replace(/^Path\s*=\s*/i, '');
     }
     return bindings;
+  }
+
+  /**
+   * Reads `{AppThemeBinding Light=#FFF, Dark=#333}`. Returns null for anything
+   * that is not an AppThemeBinding so callers can fall back to a plain value.
+   * MAUI also allows a bare `Default=`, which is treated as the light value.
+   */
+  static parseAppThemeBinding(value: string): AppThemeColor | null {
+    if (!/^\s*\{\s*AppThemeBinding\b/i.test(value)) {
+      return null;
+    }
+
+    const body = value.trim().replace(/^\{\s*AppThemeBinding\s*/i, '').replace(/\}\s*$/, '');
+    const theme: AppThemeColor = {};
+
+    for (const part of body.split(',')) {
+      const match = /^\s*(Light|Dark|Default)\s*=\s*(.+?)\s*$/i.exec(part);
+      if (!match) {
+        continue;
+      }
+      const key = match[1].toLowerCase();
+      if (key === 'dark') {
+        theme.dark = match[2];
+      } else if (!theme.light) {
+        theme.light = match[2];
+      }
+    }
+
+    return theme.light || theme.dark ? theme : null;
   }
 
   private parseThickness(value: string): Thickness {

--- a/src/app/services/xaml.services.spec.ts
+++ b/src/app/services/xaml.services.spec.ts
@@ -127,4 +127,92 @@ describe('XAML Services', () => {
       expect(icon.properties.strokeThickness).toBe(1.5);
     });
   });
+
+  describe('AppThemeBinding', () => {
+    /** Builds a single-child page and returns the generated XAML. */
+    function generate(properties: Record<string, unknown>, type = ElementType.Label) {
+      const root = elementService.getRootElement();
+      const element = elementService.createElement(type, properties as any);
+      elementService.addElement(element, root);
+      return xamlGenerator.generateXaml(root);
+    }
+
+    it('emits a light and dark pair as an AppThemeBinding', () => {
+      const xaml = generate({
+        text: 'Hi',
+        textColor: '#112233',
+        appTheme: { TextColor: { light: '#FFFFFF', dark: '#333333' } }
+      });
+
+      expect(xaml).toContain('TextColor="{AppThemeBinding Light=#FFFFFF, Dark=#333333}"');
+      // The literal must not also be written, or the first one would win.
+      expect(xaml).not.toContain('TextColor="#112233"');
+    });
+
+    it('emits only the half that is set', () => {
+      expect(generate({ appTheme: { BackgroundColor: { light: '#ABCDEF' } } }))
+        .toContain('BackgroundColor="{AppThemeBinding Light=#ABCDEF}"');
+
+      elementService.clearDesign();
+
+      expect(generate({ appTheme: { BackgroundColor: { dark: '#101010' } } }))
+        .toContain('BackgroundColor="{AppThemeBinding Dark=#101010}"');
+    });
+
+    it('lets a data binding win over both the literal and the theme colour', () => {
+      const xaml = generate({
+        text: 'Hi',
+        textColor: '#112233',
+        bindings: { TextColor: 'Accent' },
+        appTheme: { TextColor: { light: '#FFFFFF' } }
+      });
+
+      // Regression guard: colours used to be written directly instead of going
+      // through the binding-aware push, and attributes are de-duplicated
+      // first-writer-wins, so the literal silently shadowed the binding.
+      expect(xaml).toContain('TextColor="{Binding Accent}"');
+      expect(xaml).not.toContain('TextColor="#112233"');
+      expect(xaml).not.toContain('AppThemeBinding');
+    });
+
+    it('parses an AppThemeBinding back into light and dark values', () => {
+      const page = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Label x:Name="L1" Text="Hi" TextColor="{AppThemeBinding Light=#FFFFFF, Dark=#333333}" />
+  </AbsoluteLayout>
+</ContentPage>`;
+
+      const label = xamlParser.parseXaml(page).children[0];
+
+      expect(label.properties.appTheme?.['TextColor']).toEqual({ light: '#FFFFFF', dark: '#333333' });
+      // The canvas needs something concrete to paint; light is the fallback.
+      expect(label.properties.textColor).toBe('#FFFFFF');
+    });
+
+    it('round trips an AppThemeBinding without losing either value', () => {
+      const page = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Label x:Name="L1" Text="Hi" BackgroundColor="{AppThemeBinding Light=#EEEEEE, Dark=#111111}" />
+  </AbsoluteLayout>
+</ContentPage>`;
+
+      const regenerated = xamlGenerator.generateXaml(xamlParser.parseXaml(page));
+
+      expect(regenerated).toContain('BackgroundColor="{AppThemeBinding Light=#EEEEEE, Dark=#111111}"');
+    });
+
+    it('treats Default as the light value', () => {
+      expect(XamlParserService.parseAppThemeBinding('{AppThemeBinding Default=#AAAAAA, Dark=#000000}'))
+        .toEqual({ light: '#AAAAAA', dark: '#000000' });
+    });
+
+    it('ignores anything that is not an AppThemeBinding', () => {
+      expect(XamlParserService.parseAppThemeBinding('#FFFFFF')).toBeNull();
+      expect(XamlParserService.parseAppThemeBinding('{Binding Accent}')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Implements **AppThemeBinding theming** (item 4) from the WYSIWYG research backlog.

## The gap

The canvas had a dark preview toggle, but it only restyled the chrome. There was no way to
say what a control should look like in dark mode, and nothing in the generated XAML
expressed it — so any design that needed theming had to be finished by hand.

Colour properties now carry an optional light/dark pair, generated as
`{AppThemeBinding Light=..., Dark=...}` and parsed back. The canvas paints whichever half
matches the preview theme, so **the existing toggle now previews the design itself**, not
just the surroundings.

## A pre-existing bug this would have inherited

Colours were written straight into the attribute list instead of going through the
binding-aware `push`. Attributes are de-duplicated first-writer-wins and the binding loop
runs last, so a literal colour **silently shadowed a data binding on the same property** —
binding `TextColor` on a Label emitted `TextColor="#112233"` and dropped the binding
entirely, with no warning. `TextColor` is in `BINDABLE_PROPERTIES`, so this was reachable
from the UI.

I confirmed it on `main` before changing anything:

```
<Label ... TextColor="#112233" />      <-- binding requested, literal emitted
```

Routing colours through `pushColor` fixes it, and there is a regression spec for it.

## Design notes

- **Which colours are offered is derived from the element type**, not a fixed list, because
  `Stroke` is the border of a `Border` but the outline of a `Path` — the same XAML
  attribute, different designer property, never both on one element.
- **Light is the canvas fallback** when parsing, so a design opened in light mode looks
  right immediately.
- MAUI's `Default=` is accepted and treated as the light value.
- Precedence is data binding > theme binding > literal.

## Verification

- 7 new unit specs covering emission, half-pairs, parsing, round-trip, `Default=`, and the
  binding-precedence regression.
- 6 new e2e specs, including one that sets a light and a dark colour, toggles the theme, and
  asserts the *computed* background actually changes — the feature's real promise.
- **Full suite green: 171/171 e2e.** Worth the full run because this touches the shared
  colour path in both the generator and the parser.