### PR TITLE
Surface accessibility problems while the design is being made

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Smart Guides**: Live guides when a dragged element lines up with a sibling or the page edges/centre
 - **Rulers**: Optional horizontal and vertical rulers around the design surface
 - **Theming**: Per-property light/dark colours emitted as `AppThemeBinding`, previewed against the toolbar theme
+- **Accessibility**: `SemanticProperties` editing plus live WCAG AA contrast checking
 - **Z-Order**: Bring to front, send to back and single-step restacking (`Ctrl+]` / `Ctrl+[`, add `Shift` to jump to either end)
 
 ### Clipboard, Templates & Starter Pages

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Accessibility', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('semantic properties reach the generated XAML', async ({ page }) => {
+    await designer.addControl('Image');
+    await designer.selectFirst('Image');
+
+    await page.getByTestId('prop-semanticDescription').fill('Team photo');
+    await page.getByTestId('prop-semanticHint').fill('Opens the profile');
+    await page.getByTestId('prop-semanticHeadingLevel').selectOption('Level1');
+
+    await designer.expectXamlToContain(
+      'SemanticProperties.Description="Team photo"',
+      'SemanticProperties.Hint="Opens the profile"',
+      'SemanticProperties.HeadingLevel="Level1"'
+    );
+  });
+
+  test('an image without a description is flagged', async ({ page }) => {
+    await designer.addControl('Image');
+    await designer.selectFirst('Image');
+
+    await expect(page.getByTestId('a11y-issue-missing-description')).toBeVisible();
+
+    await page.getByTestId('prop-semanticDescription').fill('Team photo');
+
+    await expect(page.getByTestId('a11y-issue-missing-description')).toHaveCount(0);
+  });
+
+  test('faint text is reported with its measured ratio', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('prop-textColor').fill('#eeeeee');
+
+    await expect(page.getByTestId('a11y-issue-low-contrast')).toBeVisible();
+    await expect(page.getByTestId('contrast-ratio')).toContainText(':1');
+
+    await page.getByTestId('prop-textColor').fill('#000000');
+
+    await expect(page.getByTestId('a11y-issue-low-contrast')).toHaveCount(0);
+  });
+
+  test('hand written semantic properties survive a round trip', async () => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Image x:Name="Photo" SemanticProperties.Description="Team photo" SemanticProperties.HeadingLevel="Level2" />
+  </AbsoluteLayout>
+</ContentPage>`);
+
+    await designer.expectXamlToContain(
+      'SemanticProperties.Description="Team photo"',
+      'SemanticProperties.HeadingLevel="Level2"'
+    );
+  });
+
+  test('no contrast verdict is shown for an element with no text', async ({ page }) => {
+    await designer.addControl('Grid');
+    await designer.selectFirst('Grid');
+
+    // Reporting a ratio here would be inventing one -- there is nothing to judge.
+    await expect(page.getByTestId('contrast-ratio')).toHaveCount(0);
+    await expect(page.getByTestId('a11y-issue-low-contrast')).toHaveCount(0);
+  });
+});

--- a/src/app/components/properties-panel/properties-panel.html
+++ b/src/app/components/properties-panel/properties-panel.html
@@ -471,6 +471,54 @@
       </div>
     </div>
 
+    <!-- Accessibility -->
+    <div class="property-section" data-testid="accessibility-section">
+      <h4 class="section-header">Accessibility</h4>
+
+      <div class="property-group">
+        <label class="property-label">Description</label>
+        <input
+          type="text"
+          class="property-input"
+          data-testid="prop-semanticDescription"
+          placeholder="What a screen reader announces"
+          [value]="element.properties.semanticDescription || ''"
+          (input)="updateProperty(element, 'semanticDescription', $any($event.target).value)">
+      </div>
+
+      <div class="property-group">
+        <label class="property-label">Hint</label>
+        <input
+          type="text"
+          class="property-input"
+          data-testid="prop-semanticHint"
+          placeholder="What happens when it is used"
+          [value]="element.properties.semanticHint || ''"
+          (input)="updateProperty(element, 'semanticHint', $any($event.target).value)">
+      </div>
+
+      <div class="property-group">
+        <label class="property-label">Heading Level</label>
+        <select
+          class="property-input"
+          data-testid="prop-semanticHeadingLevel"
+          [value]="element.properties.semanticHeadingLevel || ''"
+          (change)="updateProperty(element, 'semanticHeadingLevel', $any($event.target).value)">
+          <option *ngFor="let level of headingLevels" [value]="level">{{ level || 'None' }}</option>
+        </select>
+      </div>
+
+      <p class="contrast-readout" *ngIf="contrastRatio(element) as ratio" data-testid="contrast-ratio">
+        Contrast {{ ratio.toFixed(2) }}:1
+      </p>
+
+      <p class="accessibility-issue"
+         *ngFor="let issue of accessibilityIssues(element)"
+         [attr.data-testid]="'a11y-issue-' + issue.kind">
+        {{ issue.message }}
+      </p>
+    </div>
+
     <!-- Stack layout properties -->
     <div class="property-section" *ngIf="isStackLayout(element)">
       <h4 class="section-header">Layout</h4>

--- a/src/app/components/properties-panel/properties-panel.scss
+++ b/src/app/components/properties-panel/properties-panel.scss
@@ -222,3 +222,20 @@
     background: #f3f4f6;
   }
 }
+
+/* Accessibility */
+.contrast-readout {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 11px;
+}
+
+.accessibility-issue {
+  margin: 6px 0 0;
+  padding: 6px 8px;
+  border-left: 3px solid #d97706;
+  background: #fffbeb;
+  color: #92400e;
+  font-size: 11px;
+  line-height: 1.4;
+}

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -17,6 +17,7 @@ import { Observable, Subscription } from 'rxjs';
 import { AlignmentService, AlignMode } from '../../services/alignment';
 import { CustomControlRegistryService } from '../../services/custom-control-registry';
 import { CustomControlDefinition, CustomPropertyDefinition } from '../../models/custom-control';
+import { AccessibilityService, AccessibilityIssue } from '../../services/accessibility';
 
 @Component({
   selector: 'app-properties-panel',
@@ -37,7 +38,8 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
   constructor(
     private elementService: ElementService,
     private alignmentService: AlignmentService,
-    private registry: CustomControlRegistryService
+    private registry: CustomControlRegistryService,
+    private accessibilityService: AccessibilityService
   ) {
     this.selectedElement$ = this.elementService.selectedElement$;
   }
@@ -277,6 +279,19 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
     const appTheme = { ...(element.properties.appTheme || {}) };
     delete appTheme[property];
     this.elementService.updateElementProperties(element, { appTheme });
+  }
+
+  // --- Accessibility -----------------------------------------------------------
+
+  readonly headingLevels = ['', 'Level1', 'Level2', 'Level3', 'Level4', 'Level5', 'Level6', 'Level7', 'Level8', 'Level9'];
+
+  accessibilityIssues(element: MauiElement): AccessibilityIssue[] {
+    return this.accessibilityService.inspect(element);
+  }
+
+  /** The measured contrast, shown so the user can see how close to the line they are. */
+  contrastRatio(element: MauiElement): number | null {
+    return this.accessibilityService.contrastOf(element);
   }
 
   isStackLayout(element: MauiElement): boolean {

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -110,6 +110,13 @@ export interface ElementProperties {
   isVisible?: boolean;
   isEnabled?: boolean;
 
+  /** MAUI SemanticProperties.Description -- what a screen reader announces. */
+  semanticDescription?: string;
+  /** MAUI SemanticProperties.Hint -- extra context about what the control does. */
+  semanticHint?: string;
+  /** MAUI SemanticProperties.HeadingLevel, e.g. `Level1`. */
+  semanticHeadingLevel?: string;
+
   /**
    * Data bindings keyed by MAUI property name, e.g. `{ Text: 'UserName' }`
    * is generated as Text="{Binding UserName}".

--- a/src/app/services/accessibility.service.spec.ts
+++ b/src/app/services/accessibility.service.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+import { AccessibilityService } from './accessibility';
+import { ElementService } from './element';
+import { ElementType, MauiElement } from '../models/maui-element';
+import { XamlGeneratorService } from './xaml-generator';
+import { XamlParserService } from './xaml-parser';
+
+describe('AccessibilityService', () => {
+  let service: AccessibilityService;
+  let elements: ElementService;
+  let root: MauiElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AccessibilityService);
+    elements = TestBed.inject(ElementService);
+    root = elements.getRootElement();
+    elements.updateElementProperties(root, { backgroundColor: '#ffffff' });
+  });
+
+  function addLabel(properties: Record<string, unknown>): MauiElement {
+    const label = elements.createElement(ElementType.Label);
+    elements.addElement(label, root);
+    elements.updateElementProperties(label, properties as any);
+    return label;
+  }
+
+  describe('contrast ratio', () => {
+    // Checked against the WCAG reference values rather than against our own
+    // output, so a mistake in the luminance formula cannot pass unnoticed.
+    it('matches the published extremes', () => {
+      expect(service.contrastRatio([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 2);
+      expect(service.contrastRatio([255, 255, 255], [255, 255, 255])).toBeCloseTo(1, 2);
+    });
+
+    it('matches the canonical boundary example', () => {
+      // #767676 on white is the standard 4.5:1 borderline case.
+      expect(service.contrastRatio([118, 118, 118], [255, 255, 255])).toBeCloseTo(4.54, 1);
+    });
+  });
+
+  describe('colour parsing', () => {
+    it('reads the hex forms MAUI writes', () => {
+      expect(service.toRgb('#ff8000')).toEqual([255, 128, 0]);
+      expect(service.toRgb('#f80')).toEqual([255, 136, 0]);
+      // MAUI orders the channels #AARRGGBB, so the alpha leads and is dropped.
+      expect(service.toRgb('#80ff8000')).toEqual([255, 128, 0]);
+    });
+
+    it('reads the common named colours', () => {
+      expect(service.toRgb('White')).toEqual([255, 255, 255]);
+      expect(service.toRgb('black')).toEqual([0, 0, 0]);
+    });
+
+    it('returns null rather than guessing at what it does not know', () => {
+      expect(service.toRgb('chartreuse')).toBeNull();
+      expect(service.toRgb(undefined)).toBeNull();
+      expect(service.toRgb('not-a-colour')).toBeNull();
+    });
+  });
+
+  describe('auditing', () => {
+    it('flags text that is too faint against its background', () => {
+      const label = addLabel({ text: 'Hi', textColor: '#eeeeee' });
+
+      expect(service.inspect(label).some(issue => issue.kind === 'low-contrast')).toBe(true);
+    });
+
+    it('accepts text that clears the threshold', () => {
+      const label = addLabel({ text: 'Hi', textColor: '#000000' });
+
+      expect(service.inspect(label).some(issue => issue.kind === 'low-contrast')).toBe(false);
+    });
+
+    it('falls back to the nearest ancestor that paints a background', () => {
+      // The label sets no background of its own; the root's white is what the
+      // text actually sits on.
+      const label = addLabel({ text: 'Hi', textColor: '#000000' });
+
+      expect(service.contrastOf(label)).toBeCloseTo(21, 1);
+    });
+
+    it('holds large text to the lower 3:1 threshold', () => {
+      const label = addLabel({ text: 'Hi', textColor: '#949494', fontSize: 24 });
+      expect(service.inspect(label).some(issue => issue.kind === 'low-contrast')).toBe(false);
+
+      elements.updateElementProperties(label, { fontSize: 12 });
+      expect(service.inspect(label).some(issue => issue.kind === 'low-contrast')).toBe(true);
+    });
+
+    it('gives no verdict when there is no text to judge', () => {
+      const grid = elements.createElement(ElementType.Grid);
+      elements.addElement(grid, root);
+
+      expect(service.contrastOf(grid)).toBeNull();
+    });
+
+    it('gives no verdict when a colour cannot be resolved', () => {
+      const label = addLabel({ text: 'Hi', textColor: 'rebeccapurple' });
+
+      expect(service.contrastOf(label)).toBeNull();
+    });
+
+    it('asks for a description on elements that carry meaning', () => {
+      const image = elements.createElement(ElementType.Image);
+      elements.addElement(image, root);
+
+      expect(service.inspect(image).some(issue => issue.kind === 'missing-description')).toBe(true);
+
+      elements.updateElementProperties(image, { semanticDescription: 'Team photo' });
+      expect(service.inspect(image).some(issue => issue.kind === 'missing-description')).toBe(false);
+    });
+
+    it('does not demand a description from decorative containers', () => {
+      const grid = elements.createElement(ElementType.Grid);
+      elements.addElement(grid, root);
+
+      expect(service.inspect(grid)).toEqual([]);
+    });
+
+    it('walks the whole tree', () => {
+      const image = elements.createElement(ElementType.Image);
+      elements.addElement(image, root);
+      addLabel({ text: 'Hi', textColor: '#eeeeee' });
+
+      const kinds = service.audit(root).map(issue => issue.kind);
+
+      expect(kinds).toContain('missing-description');
+      expect(kinds).toContain('low-contrast');
+    });
+  });
+
+  describe('SemanticProperties in XAML', () => {
+    let generator: XamlGeneratorService;
+    let parser: XamlParserService;
+
+    beforeEach(() => {
+      generator = TestBed.inject(XamlGeneratorService);
+      parser = TestBed.inject(XamlParserService);
+    });
+
+    it('emits the attached properties', () => {
+      const image = elements.createElement(ElementType.Image);
+      elements.addElement(image, root);
+      elements.updateElementProperties(image, {
+        semanticDescription: 'Team photo',
+        semanticHint: 'Opens the profile',
+        semanticHeadingLevel: 'Level1'
+      });
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml).toContain('SemanticProperties.Description="Team photo"');
+      expect(xaml).toContain('SemanticProperties.Hint="Opens the profile"');
+      expect(xaml).toContain('SemanticProperties.HeadingLevel="Level1"');
+    });
+
+    it('round trips them without loss', () => {
+      const page = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <AbsoluteLayout>
+    <Image x:Name="Photo" SemanticProperties.Description="Team photo" SemanticProperties.HeadingLevel="Level2" />
+  </AbsoluteLayout>
+</ContentPage>`;
+
+      const parsed = parser.parseXaml(page);
+      const image = parsed.children[0];
+
+      expect(image.properties.semanticDescription).toBe('Team photo');
+      expect(image.properties.semanticHeadingLevel).toBe('Level2');
+      expect(generator.generateXaml(parsed)).toContain('SemanticProperties.Description="Team photo"');
+    });
+  });
+});

--- a/src/app/services/accessibility.ts
+++ b/src/app/services/accessibility.ts
@@ -1,0 +1,190 @@
+import { Injectable } from '@angular/core';
+import { ElementType, MauiElement } from '../models/maui-element';
+
+/** A problem found on a single element. */
+export interface AccessibilityIssue {
+  elementId: string;
+  elementName: string;
+  kind: 'missing-description' | 'low-contrast';
+  message: string;
+}
+
+/**
+ * MAUI accepts named colours as well as hex, and the canvas renders them, so
+ * the contrast check has to understand at least the common ones. Anything not
+ * listed here is skipped rather than guessed at.
+ */
+const NAMED_COLORS: Record<string, string> = {
+  black: '#000000',
+  white: '#ffffff',
+  red: '#ff0000',
+  green: '#008000',
+  blue: '#0000ff',
+  yellow: '#ffff00',
+  cyan: '#00ffff',
+  magenta: '#ff00ff',
+  gray: '#808080',
+  grey: '#808080',
+  silver: '#c0c0c0',
+  maroon: '#800000',
+  olive: '#808000',
+  lime: '#00ff00',
+  teal: '#008080',
+  navy: '#000080',
+  purple: '#800080',
+  orange: '#ffa500'
+};
+
+/** WCAG 2.1 AA requires 4.5:1 for normal text and 3:1 for large text. */
+const AA_NORMAL = 4.5;
+const AA_LARGE = 3;
+
+/** WCAG counts >=18pt, or >=14pt bold, as large text. */
+const LARGE_TEXT_SIZE = 18;
+const LARGE_BOLD_TEXT_SIZE = 14;
+
+@Injectable({ providedIn: 'root' })
+export class AccessibilityService {
+  /** Element types that convey meaning and so need a description for screen readers. */
+  private static readonly NEEDS_DESCRIPTION = [ElementType.Image, ElementType.Path];
+
+  /** Walks the tree and reports everything worth fixing. */
+  audit(root: MauiElement): AccessibilityIssue[] {
+    const issues: AccessibilityIssue[] = [];
+    this.visit(root, issues);
+    return issues;
+  }
+
+  private visit(element: MauiElement, issues: AccessibilityIssue[]): void {
+    issues.push(...this.inspect(element));
+    element.children.forEach(child => this.visit(child, issues));
+  }
+
+  /** The issues on one element, ignoring its children. */
+  inspect(element: MauiElement): AccessibilityIssue[] {
+    const issues: AccessibilityIssue[] = [];
+    const props = element.properties;
+    const identity = { elementId: element.id, elementName: element.name };
+
+    if (
+      AccessibilityService.NEEDS_DESCRIPTION.includes(element.type) &&
+      !props.semanticDescription
+    ) {
+      issues.push({
+        ...identity,
+        kind: 'missing-description',
+        message: `${element.name} has no SemanticProperties.Description, so a screen reader cannot describe it.`
+      });
+    }
+
+    const ratio = this.contrastOf(element);
+    if (ratio !== null) {
+      const required = this.isLargeText(element) ? AA_LARGE : AA_NORMAL;
+      if (ratio < required) {
+        issues.push({
+          ...identity,
+          kind: 'low-contrast',
+          message: `${element.name} has a contrast ratio of ${ratio.toFixed(2)}:1, below the WCAG AA minimum of ${required}:1.`
+        });
+      }
+    }
+
+    return issues;
+  }
+
+  /**
+   * The contrast between an element's text and its background, or null when
+   * that cannot be determined -- there is no text, or a colour is missing or
+   * not one we can resolve. Returning null rather than a guess keeps the panel
+   * from reporting confident nonsense.
+   */
+  contrastOf(element: MauiElement): number | null {
+    const props = element.properties;
+    if (!props.text) {
+      return null;
+    }
+
+    const foreground = this.toRgb(props.textColor);
+    const background = this.toRgb(props.backgroundColor) ?? this.inheritedBackground(element);
+    if (!foreground || !background) {
+      return null;
+    }
+
+    return this.contrastRatio(foreground, background);
+  }
+
+  /** Text sits on whatever the nearest ancestor with a background paints. */
+  private inheritedBackground(element: MauiElement): [number, number, number] | null {
+    for (let current = element.parent; current; current = current.parent) {
+      const color = this.toRgb(current.properties.backgroundColor);
+      if (color) {
+        return color;
+      }
+    }
+    return null;
+  }
+
+  private isLargeText(element: MauiElement): boolean {
+    const size = element.properties.fontSize ?? 14;
+    const bold = String(element.properties.fontAttributes ?? '').toLowerCase().includes('bold');
+    return size >= LARGE_TEXT_SIZE || (bold && size >= LARGE_BOLD_TEXT_SIZE);
+  }
+
+  /** Parses #rgb, #rrggbb, #aarrggbb (MAUI's order) and the named colours above. */
+  toRgb(value?: string): [number, number, number] | null {
+    if (!value) {
+      return null;
+    }
+
+    const named = NAMED_COLORS[value.trim().toLowerCase()];
+    const hex = (named ?? value).trim();
+    if (!hex.startsWith('#')) {
+      return null;
+    }
+
+    const digits = hex.slice(1);
+    if (!/^[0-9a-f]+$/i.test(digits)) {
+      return null;
+    }
+
+    if (digits.length === 3) {
+      return [
+        parseInt(digits[0] + digits[0], 16),
+        parseInt(digits[1] + digits[1], 16),
+        parseInt(digits[2] + digits[2], 16)
+      ];
+    }
+    if (digits.length === 6) {
+      return [
+        parseInt(digits.slice(0, 2), 16),
+        parseInt(digits.slice(2, 4), 16),
+        parseInt(digits.slice(4, 6), 16)
+      ];
+    }
+    // MAUI writes #AARRGGBB, so the alpha comes first and is dropped here.
+    if (digits.length === 8) {
+      return [
+        parseInt(digits.slice(2, 4), 16),
+        parseInt(digits.slice(4, 6), 16),
+        parseInt(digits.slice(6, 8), 16)
+      ];
+    }
+
+    return null;
+  }
+
+  /** WCAG relative luminance. */
+  private luminance([r, g, b]: [number, number, number]): number {
+    const channel = (value: number) => {
+      const scaled = value / 255;
+      return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+  }
+
+  contrastRatio(a: [number, number, number], b: [number, number, number]): number {
+    const lighter = Math.max(this.luminance(a), this.luminance(b));
+    const darker = Math.min(this.luminance(a), this.luminance(b));
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+}

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -311,6 +311,18 @@ ${xamlContent}
     if (props.isEnabled === false) {
       push('IsEnabled', 'False');
     }
+
+    // Accessibility. These are attached properties, so they read as
+    // SemanticProperties.X rather than plain attributes.
+    if (props.semanticDescription) {
+      push('SemanticProperties.Description', this.escapeXml(props.semanticDescription));
+    }
+    if (props.semanticHint) {
+      push('SemanticProperties.Hint', this.escapeXml(props.semanticHint));
+    }
+    if (props.semanticHeadingLevel) {
+      push('SemanticProperties.HeadingLevel', this.escapeXml(props.semanticHeadingLevel));
+    }
     
     // Layout specific attributes
     if (element.type === ElementType.StackLayout) {

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -18,7 +18,10 @@ const RESERVED_ATTRIBUTES = new Set([
   'margin',
   'padding',
   'isvisible',
-  'isenabled'
+  'isenabled',
+  'semanticproperties.description',
+  'semanticproperties.hint',
+  'semanticproperties.headinglevel'
 ]);
 
 @Injectable({
@@ -596,9 +599,17 @@ export class XamlParserService {
 
     const fontSize = xmlElement.getAttribute('FontSize');
     if (fontSize) properties.fontSize = parseFloat(fontSize);
-
     const fontFamily = xmlElement.getAttribute('FontFamily');
     if (fontFamily) properties.fontFamily = fontFamily;
+
+    const semanticDescription = literal('SemanticProperties.Description');
+    if (semanticDescription) properties.semanticDescription = semanticDescription;
+
+    const semanticHint = literal('SemanticProperties.Hint');
+    if (semanticHint) properties.semanticHint = semanticHint;
+
+    const semanticHeadingLevel = literal('SemanticProperties.HeadingLevel');
+    if (semanticHeadingLevel) properties.semanticHeadingLevel = semanticHeadingLevel;
 
     const fontAttributes = xmlElement.getAttribute('FontAttributes');
     if (fontAttributes) properties.fontAttributes = fontAttributes as any;


### PR DESCRIPTION
Implements **Accessibility annotations + contrast checking** (item 7) from the WYSIWYG
research backlog.

## The gap

MAUI has `SemanticProperties`, but the designer had no way to set them — so every design it
produced was inaccessible until someone remembered to go back and annotate the XAML by
hand. A screen reader user gets nothing from an unlabelled `Image`, and nothing in the tool
said so.

Adds **Description**, **Hint** and **HeadingLevel** to the properties panel, plus a check
that runs as you edit: images and icons without a description are flagged, and text is
measured against its background for WCAG AA contrast.

## Being honest rather than noisy

An accessibility checker that cries wolf gets ignored, so it declines to answer when it
cannot actually tell:

- **No verdict when a colour cannot be resolved.** `toRgb('chartreuse')` returns `null`, not
  a fabricated ratio. Only hex forms and the common named colours are understood.
- **No verdict when there is no text to judge.** A `Grid` gets no contrast readout at all.
- **Text is measured against the nearest ancestor that actually paints a background**, since
  an element with no background of its own still visually sits on something.
- **Large text is held to the correct 3:1 threshold**, not 4.5:1, per WCAG.
- MAUI's `#AARRGGBB` byte order is handled — the alpha leads, and naively slicing the first
  six digits would read the wrong channels.

## Verifying the maths against something external

A contrast implementation that is only tested against its own output can agree with itself
while being wrong. These specs check the **published WCAG reference values**: 21:1 for black
on white, 1:1 for white on white, and the canonical 4.54:1 for `#767676` on white that sits
right on the AA boundary.

## Verification

- 15 new unit specs (contrast maths, colour parsing, auditing, XAML round-trip).
- 5 new e2e specs.
- **Full suite green: 170/170 e2e.**

The round-trip specs live in `accessibility.service.spec.ts` rather than
`xaml.services.spec.ts` deliberately — #100 appends to the end of that file, and keeping
them apart means these two PRs merge in either order without conflicting.