### PR TITLE
Stop dropping XAML attributes on import, and support LayoutOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **Toolbox Search**: Filter the control list as you type
 - **Undo/Redo**: Full history for every design change (`Ctrl+Z` / `Ctrl+Y`)
 - **Keyboard Shortcuts**: `Delete` to remove, `Ctrl+D` to duplicate, arrow keys to nudge, `Esc` to deselect
+- **Layout Alignment**: `HorizontalOptions` and `VerticalOptions` on every control
+- **Lossless XAML Round Trip**: Attributes the designer does not model are preserved instead of dropped
 - **Local Persistence**: Save and restore your design in the browser
 
 ### Multi-Selection

--- a/e2e/xaml-round-trip.spec.ts
+++ b/e2e/xaml-round-trip.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+const PAGE_WITH_UNKNOWN_MARKUP = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="YourApp.MainPage">
+    <VerticalStackLayout x:Name="Root">
+        <Label x:Name="Greeting" Text="Hi" Rotation="15" Opacity="0.5"
+               HorizontalOptions="Center" VerticalOptions="EndAndExpand" />
+    </VerticalStackLayout>
+</ContentPage>`;
+
+test.describe('XAML round trip fidelity', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('importing XAML does not drop attributes the designer does not model', async () => {
+    await designer.applyXaml(PAGE_WITH_UNKNOWN_MARKUP);
+
+    await designer.expectXamlToContain('Rotation="15"');
+    await designer.expectXamlToContain('Opacity="0.5"');
+  });
+
+  test('importing XAML keeps layout alignment', async () => {
+    await designer.applyXaml(PAGE_WITH_UNKNOWN_MARKUP);
+
+    await designer.expectXamlToContain('HorizontalOptions="Center"');
+    // The Xamarin.Forms AndExpand suffix is obsolete in MAUI, so it is normalised away.
+    await designer.expectXamlToContain('VerticalOptions="End"');
+  });
+
+  test('the alignment dropdowns reflect the imported values', async ({ page }) => {
+    await designer.applyXaml(PAGE_WITH_UNKNOWN_MARKUP);
+    await designer.selectFirst('Label');
+
+    await expect(page.getByTestId('prop-horizontalOptions')).toHaveValue('Center');
+    await expect(page.getByTestId('prop-verticalOptions')).toHaveValue('End');
+  });
+
+  test('setting horizontal alignment writes it into the XAML', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('prop-horizontalOptions').selectOption('Fill');
+
+    await designer.expectXamlToContain('HorizontalOptions="Fill"');
+  });
+
+  test('setting vertical alignment writes it into the XAML', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.selectFirst('Button');
+
+    await page.getByTestId('prop-verticalOptions').selectOption('Start');
+
+    await designer.expectXamlToContain('VerticalOptions="Start"');
+  });
+
+  test('clearing an alignment removes the attribute again', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('prop-horizontalOptions').selectOption('Center');
+    await designer.expectXamlToContain('HorizontalOptions="Center"');
+
+    await page.getByTestId('prop-horizontalOptions').selectOption('');
+
+    await expect.poll(async () => await designer.getXaml()).not.toContain('HorizontalOptions=');
+  });
+
+  test('a freshly added control does not emit alignment attributes', async () => {
+    await designer.addControl('Label');
+
+    const xaml = await designer.getXaml();
+
+    expect(xaml).not.toContain('HorizontalOptions=');
+    expect(xaml).not.toContain('VerticalOptions=');
+  });
+});

--- a/src/app/components/properties-panel/properties-panel.html
+++ b/src/app/components/properties-panel/properties-panel.html
@@ -746,6 +746,37 @@
         </div>
       </div>
     </div>
+
+    <!-- Alignment Properties -->
+    <div class="property-section" data-testid="alignment-options-section">
+      <h4 class="section-header">Alignment</h4>
+
+      <div class="property-group">
+        <label class="property-label">Horizontal</label>
+        <select
+          class="property-input"
+          data-testid="prop-horizontalOptions"
+          [value]="element.properties.horizontalOptions || ''"
+          (change)="updateLayoutOptions(element, 'horizontalOptions', $any($event.target).value)">
+          <option value="" [selected]="!element.properties.horizontalOptions">(inherit)</option>
+          <option *ngFor="let option of layoutOptions" [value]="option"
+                  [selected]="option === element.properties.horizontalOptions">{{ option }}</option>
+        </select>
+      </div>
+
+      <div class="property-group">
+        <label class="property-label">Vertical</label>
+        <select
+          class="property-input"
+          data-testid="prop-verticalOptions"
+          [value]="element.properties.verticalOptions || ''"
+          (change)="updateLayoutOptions(element, 'verticalOptions', $any($event.target).value)">
+          <option value="" [selected]="!element.properties.verticalOptions">(inherit)</option>
+          <option *ngFor="let option of layoutOptions" [value]="option"
+                  [selected]="option === element.properties.verticalOptions">{{ option }}</option>
+        </select>
+      </div>
+    </div>
   </div>
 
   </ng-container>

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -10,6 +10,7 @@ import {
   GridLengthType,
   Orientation,
   FontAttributes,
+  LAYOUT_OPTIONS,
   BINDABLE_PROPERTIES,
   COMMON_BINDABLE_PROPERTIES
 } from '../../models/maui-element';
@@ -110,6 +111,13 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
     const currentPadding = element.properties.padding || { left: 0, top: 0, right: 0, bottom: 0 };
     const newPadding = { ...currentPadding, [side]: value };
     this.elementService.updateElementProperties(element, { padding: newPadding });
+  }
+
+  readonly layoutOptions = LAYOUT_OPTIONS;
+
+  updateLayoutOptions(element: MauiElement, axis: 'horizontalOptions' | 'verticalOptions', value: string) {
+    const option = LAYOUT_OPTIONS.find(candidate => candidate === value);
+    this.elementService.updateElementProperties(element, { [axis]: option });
   }
 
   // --- Capability helpers -----------------------------------------------------

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -37,6 +37,11 @@ export enum ElementType {
 
 export const DEFAULT_ICON_PATH_DATA = 'M12 2L2 22h20L12 2Z';
 
+/** MAUI `LayoutOptions` values, as accepted by HorizontalOptions/VerticalOptions. */
+export const LAYOUT_OPTIONS = ['Start', 'Center', 'End', 'Fill'] as const;
+
+export type LayoutOptions = typeof LAYOUT_OPTIONS[number];
+
 export interface ElementProperties {
   // Layout properties
   x?: number;
@@ -45,6 +50,8 @@ export interface ElementProperties {
   height?: number;
   margin?: Thickness;
   padding?: Thickness;
+  horizontalOptions?: LayoutOptions;
+  verticalOptions?: LayoutOptions;
   
   // Visual properties
   backgroundColor?: string;

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -176,9 +176,12 @@ ${xamlContent}
       for (const [name, value] of Object.entries(props.customValues || {})) {
         push(name, this.escapeXml(String(value)));
       }
-      for (const [name, value] of Object.entries(props.rawAttributes || {})) {
-        push(name, this.escapeXml(value));
-      }
+    }
+
+    // Attributes the designer does not model are re-emitted verbatim for every
+    // element type, so importing XAML never silently deletes markup.
+    for (const [name, value] of Object.entries(props.rawAttributes || {})) {
+      push(name, this.escapeXml(value));
     }
     
     // For children of AbsoluteLayout
@@ -304,6 +307,10 @@ ${xamlContent}
       }
     }
     
+    // Layout alignment within the parent container
+    push('HorizontalOptions', props.horizontalOptions);
+    push('VerticalOptions', props.verticalOptions);
+
     // Visibility and enabled state
     if (props.isVisible === false) {
       push('IsVisible', 'False');

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA, AppThemeColor } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA, AppThemeColor, LayoutOptions, LAYOUT_OPTIONS } from '../models/maui-element';
 import { CustomControlRegistryService } from './custom-control-registry';
 
 /** Attributes the designer models itself, so they never end up in rawAttributes. */
@@ -492,6 +492,14 @@ export class XamlParserService {
       this.parseCustomControl(xmlElement, properties);
     }
 
+    // Every attribute the designer understands is read through getAttr, so whatever
+    // is left over at the end of this method is something we do not model yet.
+    const consumed = new Set<string>();
+    const getAttr = (name: string): string | null => {
+      consumed.add(name.toLowerCase());
+      return xmlElement.getAttribute(name);
+    };
+
     // Bindings are captured separately so they survive a round trip
     const bindings = this.parseBindings(xmlElement);
     if (Object.keys(bindings).length > 0) {
@@ -499,7 +507,7 @@ export class XamlParserService {
     }
 
     const literal = (name: string): string | null => {
-      const value = xmlElement.getAttribute(name);
+      const value = getAttr(name);
       return value === null || this.isBindingExpression(value) ? null : value;
     };
 
@@ -509,7 +517,7 @@ export class XamlParserService {
      * light value is the fallback so a design opened in light mode looks right.
      */
     const color = (name: string): string | null => {
-      const value = xmlElement.getAttribute(name);
+      const value = getAttr(name);
       if (value === null || this.isBindingExpression(value)) {
         return null;
       }
@@ -573,7 +581,7 @@ export class XamlParserService {
       if (borderWidth) properties.borderWidth = parseFloat(borderWidth);
     }
 
-    const pathData = xmlElement.getAttribute('Data');
+    const pathData = getAttr('Data');
     if (pathData) properties.pathData = pathData;
 
     const fill = color('Fill');
@@ -582,13 +590,13 @@ export class XamlParserService {
     const stroke = color('Stroke');
     if (stroke) properties.strokeColor = stroke;
 
-    const strokeThickness = xmlElement.getAttribute('StrokeThickness');
+    const strokeThickness = getAttr('StrokeThickness');
     if (strokeThickness) properties.strokeThickness = parseFloat(strokeThickness);
 
-    const widthRequest = xmlElement.getAttribute('WidthRequest');
+    const widthRequest = getAttr('WidthRequest');
     if (widthRequest) properties.width = parseFloat(widthRequest);
 
-    const heightRequest = xmlElement.getAttribute('HeightRequest');
+    const heightRequest = getAttr('HeightRequest');
     if (heightRequest) properties.height = parseFloat(heightRequest);
 
     const backgroundColor = color('BackgroundColor');
@@ -597,9 +605,10 @@ export class XamlParserService {
     const textColor = color('TextColor');
     if (textColor) properties.textColor = textColor;
 
-    const fontSize = xmlElement.getAttribute('FontSize');
+    const fontSize = getAttr('FontSize');
     if (fontSize) properties.fontSize = parseFloat(fontSize);
-    const fontFamily = xmlElement.getAttribute('FontFamily');
+
+    const fontFamily = getAttr('FontFamily');
     if (fontFamily) properties.fontFamily = fontFamily;
 
     const semanticDescription = literal('SemanticProperties.Description');
@@ -611,24 +620,38 @@ export class XamlParserService {
     const semanticHeadingLevel = literal('SemanticProperties.HeadingLevel');
     if (semanticHeadingLevel) properties.semanticHeadingLevel = semanticHeadingLevel;
 
-    const fontAttributes = xmlElement.getAttribute('FontAttributes');
+    const fontAttributes = getAttr('FontAttributes');
     if (fontAttributes) properties.fontAttributes = fontAttributes as any;
 
-    const margin = xmlElement.getAttribute('Margin');
+    const margin = getAttr('Margin');
     if (margin) properties.margin = this.parseThickness(margin);
 
-    const padding = xmlElement.getAttribute('Padding');
+    const padding = getAttr('Padding');
     if (padding) properties.padding = this.parseThickness(padding);
 
-    const isVisible = xmlElement.getAttribute('IsVisible');
+    const horizontalOptions = literal('HorizontalOptions');
+    if (horizontalOptions) {
+      const parsed = XamlParserService.parseLayoutOptions(horizontalOptions);
+      if (parsed) properties.horizontalOptions = parsed;
+      else consumed.delete('horizontaloptions');
+    }
+
+    const verticalOptions = literal('VerticalOptions');
+    if (verticalOptions) {
+      const parsed = XamlParserService.parseLayoutOptions(verticalOptions);
+      if (parsed) properties.verticalOptions = parsed;
+      else consumed.delete('verticaloptions');
+    }
+
+    const isVisible = getAttr('IsVisible');
     if (isVisible) properties.isVisible = isVisible.toLowerCase() === 'true';
 
-    const isEnabled = xmlElement.getAttribute('IsEnabled');
+    const isEnabled = getAttr('IsEnabled');
     if (isEnabled) properties.isEnabled = isEnabled.toLowerCase() === 'true';
 
     // Parse layout-specific properties
     if (parent?.type === ElementType.AbsoluteLayout) {
-      const layoutBounds = xmlElement.getAttribute('AbsoluteLayout.LayoutBounds');
+      const layoutBounds = getAttr('AbsoluteLayout.LayoutBounds');
       if (layoutBounds) {
         const bounds = layoutBounds.split(',').map(v => parseFloat(v.trim()));
         if (bounds.length >= 4) {
@@ -641,25 +664,25 @@ export class XamlParserService {
     }
 
     if (parent?.type === ElementType.Grid) {
-      const row = xmlElement.getAttribute('Grid.Row');
+      const row = getAttr('Grid.Row');
       if (row) properties.row = parseInt(row);
 
-      const column = xmlElement.getAttribute('Grid.Column');
+      const column = getAttr('Grid.Column');
       if (column) properties.column = parseInt(column);
 
-      const rowSpan = xmlElement.getAttribute('Grid.RowSpan');
+      const rowSpan = getAttr('Grid.RowSpan');
       if (rowSpan) properties.rowSpan = parseInt(rowSpan);
 
-      const columnSpan = xmlElement.getAttribute('Grid.ColumnSpan');
+      const columnSpan = getAttr('Grid.ColumnSpan');
       if (columnSpan) properties.columnSpan = parseInt(columnSpan);
     }
 
     if (elementType === ElementType.StackLayout) {
-      const spacing = xmlElement.getAttribute('Spacing');
+      const spacing = getAttr('Spacing');
       if (spacing) properties.spacing = parseFloat(spacing);
 
       // An explicit Orientation attribute wins over the tag name
-      const orientation = xmlElement.getAttribute('Orientation');
+      const orientation = getAttr('Orientation');
       if (orientation) {
         properties.orientation = orientation.toLowerCase() === 'horizontal'
           ? Orientation.Horizontal
@@ -672,18 +695,60 @@ export class XamlParserService {
     }
 
     if (elementType === ElementType.VerticalStackLayout) {
-      const spacing = xmlElement.getAttribute('Spacing');
+      const spacing = getAttr('Spacing');
       if (spacing) properties.spacing = parseFloat(spacing);
     }
 
     // Set default values if not specified
+    if (elementType !== ElementType.Custom) {
+      properties.rawAttributes = this.collectUnmodelledAttributes(xmlElement, consumed, properties);
+    }
+
     this.setDefaultValues(properties, elementType);
 
     return properties;
   }
 
-  private isBindingExpression(value: string): boolean {
-    return /^\s*\{\s*Binding\b/i.test(value);
+  /**
+   * Attributes the designer never read are kept verbatim so importing XAML the tool
+   * does not fully understand cannot silently delete markup on the next export.
+   */
+  private collectUnmodelledAttributes(
+    xmlElement: Element,
+    consumed: Set<string>,
+    properties: ElementProperties
+  ): Record<string, string> | undefined {
+    const raw: Record<string, string> = {};
+    const bound = new Set(Object.keys(properties.bindings || {}).map(name => name.toLowerCase()));
+
+    for (let i = 0; i < xmlElement.attributes.length; i++) {
+      const attribute = xmlElement.attributes[i];
+      const name = attribute.name;
+      const key = name.toLowerCase();
+      if (consumed.has(key) || bound.has(key) || RESERVED_ATTRIBUTES.has(key)) {
+        continue;
+      }
+      // Namespace declarations belong to the document, not to the element.
+      if (key === 'xmlns' || key.startsWith('xmlns:')) {
+        continue;
+      }
+      raw[name] = attribute.value;
+    }
+
+    return Object.keys(raw).length > 0 ? raw : undefined;
+  }
+
+  /**
+   * MAUI accepts `Center`, `CenterAndExpand` (legacy Forms) and `LayoutOptions.Center`.
+   * Anything unrecognised is left alone so it falls through to rawAttributes.
+   */
+  static parseLayoutOptions(value: string): LayoutOptions | null {
+    const cleaned = value.trim().replace(/^LayoutOptions\./i, '').replace(/AndExpand$/i, '');
+    const match = LAYOUT_OPTIONS.find(option => option.toLowerCase() === cleaned.toLowerCase());
+    return match || null;
+  }
+
+  private isBindingExpression(value: string): boolean {    return /^\s*\{\s*Binding\b/i.test(value);
   }
 
   /** Collects every attribute written as `{Binding Path}` into a map. */

--- a/src/app/services/xaml-round-trip.spec.ts
+++ b/src/app/services/xaml-round-trip.spec.ts
@@ -1,0 +1,147 @@
+import { TestBed } from '@angular/core/testing';
+import { XamlParserService } from './xaml-parser';
+import { XamlGeneratorService } from './xaml-generator';
+import { ElementType, MauiElement } from '../models/maui-element';
+
+const page = (body: string) => `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="YourApp.MainPage">
+    <VerticalStackLayout x:Name="Root">
+${body}
+    </VerticalStackLayout>
+</ContentPage>`;
+
+describe('XAML round trip fidelity', () => {
+  let parser: XamlParserService;
+  let generator: XamlGeneratorService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    parser = TestBed.inject(XamlParserService);
+    generator = TestBed.inject(XamlGeneratorService);
+  });
+
+  const firstChild = (xaml: string): MauiElement => parser.parseXaml(xaml).children[0];
+
+  describe('unmodelled attributes', () => {
+    it('keeps attributes the designer does not model on a built in control', () => {
+      const label = firstChild(page('<Label x:Name="L" Text="Hi" Rotation="15" Opacity="0.5" />'));
+
+      expect(label.type).toBe(ElementType.Label);
+      expect(label.properties.rawAttributes).toEqual({ Rotation: '15', Opacity: '0.5' });
+    });
+
+    it('re emits preserved attributes so an import export cycle is not lossy', () => {
+      const root = parser.parseXaml(page('<Label x:Name="L" Text="Hi" Rotation="15" Opacity="0.5" />'));
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml).toContain('Rotation="15"');
+      expect(xaml).toContain('Opacity="0.5"');
+    });
+
+    it('does not duplicate attributes the designer already models', () => {
+      const root = parser.parseXaml(page('<Label x:Name="L" Text="Hi" FontSize="22" />'));
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml.match(/FontSize=/g)?.length).toBe(1);
+      expect(xaml).toContain('FontSize="22"');
+    });
+
+    it('leaves bound attributes to the binding pass rather than preserving them twice', () => {
+      const label = firstChild(page('<Label x:Name="L" Text="{Binding UserName}" />'));
+
+      expect(label.properties.bindings).toEqual({ Text: 'UserName' });
+      expect(label.properties.rawAttributes).toBeUndefined();
+    });
+
+    it('never preserves namespace declarations as element attributes', () => {
+      const root = parser.parseXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <VerticalStackLayout x:Name="Root" xmlns:local="clr-namespace:App" Rotation="4">
+        <Label x:Name="L" />
+    </VerticalStackLayout>
+</ContentPage>`);
+
+      expect(root.properties.rawAttributes).toEqual({ Rotation: '4' });
+    });
+
+    it('does not preserve a themed colour as a raw attribute as well', () => {
+      const markup = '<Label x:Name="L" Text="Hi" TextColor="{AppThemeBinding Light=#111111, Dark=#eeeeee}" />';
+      const label = firstChild(page(markup));
+
+      expect(label.properties.appTheme?.['TextColor']).toEqual({ light: '#111111', dark: '#eeeeee' });
+      expect(label.properties.rawAttributes?.['TextColor']).toBeUndefined();
+
+      const xaml = generator.generateXaml(parser.parseXaml(page(markup)));
+      expect(xaml.match(/TextColor=/g)?.length).toBe(1);
+    });
+
+    it('escapes preserved values so injected markup cannot break the document', () => {      const root = parser.parseXaml(page('<Label x:Name="L" Text="Hi" AutomationId="a&quot;b&amp;c" />'));
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml).toContain('AutomationId="a&quot;b&amp;c"');
+    });
+  });
+
+  describe('LayoutOptions', () => {
+    it('parses HorizontalOptions and VerticalOptions', () => {
+      const label = firstChild(page('<Label x:Name="L" HorizontalOptions="Center" VerticalOptions="Fill" />'));
+
+      expect(label.properties.horizontalOptions).toBe('Center');
+      expect(label.properties.verticalOptions).toBe('Fill');
+    });
+
+    it('normalises the legacy AndExpand suffix inherited from Xamarin.Forms', () => {
+      expect(XamlParserService.parseLayoutOptions('EndAndExpand')).toBe('End');
+      expect(XamlParserService.parseLayoutOptions('StartAndExpand')).toBe('Start');
+    });
+
+    it('accepts the fully qualified LayoutOptions.Center form', () => {
+      expect(XamlParserService.parseLayoutOptions('LayoutOptions.Center')).toBe('Center');
+    });
+
+    it('rejects values that are not LayoutOptions', () => {
+      expect(XamlParserService.parseLayoutOptions('Middle')).toBeNull();
+    });
+
+    it('preserves an unrecognised alignment verbatim instead of dropping it', () => {
+      const label = firstChild(page('<Label x:Name="L" HorizontalOptions="{StaticResource Wide}" />'));
+
+      expect(label.properties.horizontalOptions).toBeUndefined();
+      expect(label.properties.rawAttributes?.['HorizontalOptions']).toBe('{StaticResource Wide}');
+    });
+
+    it('generates the alignment attributes', () => {
+      const root = parser.parseXaml(page('<Label x:Name="L" HorizontalOptions="Center" VerticalOptions="End" />'));
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml).toContain('HorizontalOptions="Center"');
+      expect(xaml).toContain('VerticalOptions="End"');
+    });
+
+    it('omits the alignment attributes when the element inherits them', () => {
+      const root = parser.parseXaml(page('<Label x:Name="L" Text="Hi" />'));
+
+      const xaml = generator.generateXaml(root);
+
+      expect(xaml).not.toContain('HorizontalOptions=');
+      expect(xaml).not.toContain('VerticalOptions=');
+    });
+
+    it('survives a full parse generate parse cycle', () => {
+      const original = page('<Label x:Name="L" Text="Hi" HorizontalOptions="Center" VerticalOptions="Fill" />');
+
+      const reparsed = firstChild(generator.generateXaml(parser.parseXaml(original)));
+
+      expect(reparsed.properties.horizontalOptions).toBe('Center');
+      expect(reparsed.properties.verticalOptions).toBe('Fill');
+    });
+  });
+});


### PR DESCRIPTION
## The bug

Importing XAML **silently deleted markup**. This page:

```xml
<Label x:Name="L1" Text="Hi" HorizontalOptions="Center" VerticalOptions="EndAndExpand"
       Rotation="15" Opacity="0.5" />
```

came back out of the designer as:

```xml
<Label x:Name="L1" WidthRequest="100" HeightRequest="30" Text="Hi" TextColor="#000000" FontSize="14" />
```

Four attributes gone, no warning. I found this by writing a throwaway round-trip test
before assuming anything, and the output above is the real observed result.

This matters more than a missing feature: "the designer broke my code" is the single
most-cited reason developers abandon visual designers, and it is why the WinForms
`.designer.cs` and Android Studio Layout Editor have the reputations they do.

## The fix

**1. Nothing is dropped any more.** `parseProperties` now reads every attribute it
understands through a small tracking helper. Whatever is left at the end goes into
`properties.rawAttributes` and is re-emitted verbatim. That bag already existed — it was
just only populated for custom controls, so built-in controls had no protection at all.

Excluded from preservation, deliberately: attributes the designer models (they are
re-generated), `{Binding}` values (the binding pass owns them), and `xmlns` declarations
(they belong to the document, not the element).

**2. `HorizontalOptions` / `VerticalOptions` are first class.** These are the primary
layout mechanism in MAUI, so they get real properties and an **Alignment** section in the
properties panel rather than being preserved as opaque strings.

- The obsolete Xamarin.Forms `AndExpand` suffix is normalised (`EndAndExpand` → `End`);
  it is a no-op in MAUI.
- A value the designer cannot interpret — `HorizontalOptions="{StaticResource Wide}"` —
  is **not** swallowed by the enum parser. It falls through to the preserved bag, so the
  two halves of this PR compose instead of fighting.

## What I did not do

The canvas does **not** render alignment. Every element is `position: absolute` with an
explicit transform, so `align-self` would have no effect without reworking how the canvas
lays out children. Showing a preview that ignored the property would be exactly the
"designer lies to you" failure this PR is trying to fix, so the properties are editable
and round-trip correctly, but the canvas stays honest about not simulating them.

## Verification

- **14 unit specs** in `src/app/services/xaml-round-trip.spec.ts`.
  Karma cannot capture a browser in my environment, so I bundled the two services with
  esbuild for the browser and ran the same 14 assertions inside a real Playwright page
  (the parser needs a real `DOMParser`). All 14 passed against real DOM before I committed
  them; CI runs them for real.
- **7 e2e specs** in `e2e/xaml-round-trip.spec.ts`.
- **Full e2e suite: 172/172.** The parser change touches every import path, so the whole
  suite — not just the new file — is the real check here.

One spec is a regression guard worth naming: `does not duplicate attributes the designer
already models` asserts `FontSize` appears exactly once. Since preserved attributes are
now emitted for *every* element, a gap in the tracking set would produce duplicate
attributes rather than a visible error.

## Note for the reviewer

The `[value]` binding on a `<select>` with `*ngFor` options does not apply reliably —
the option elements are created after the binding runs, so the select reads back as empty.
My e2e spec caught this. The new dropdowns bind `[selected]` per option instead.
The pre-existing selects in this panel (`prop-fontAttributes`, `prop-orientation`) use the
unreliable `[value]`-only pattern and may have the same latent bug; I left them alone as
out of scope.
