### PR TITLE
Make grid spans, track types, and left/centre align actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 - **XAML Parsing**: Import existing XAML files to recreate visual designs
 - **Copy & Download**: Easy sharing and saving of generated XAML
 - **File Import**: Load a `.xaml` file, or convert an `.svg` icon into MAUI `Path` elements
-- **Grid Definitions**: Row/column definitions (`Auto`, `*`, absolute) round-trip through XAML
+- **Grid Definitions**: Row/column definitions (`Auto`, `*`, absolute) size the canvas tracks and round-trip through XAML. `RowSpan` / `ColumnSpan` stretch the child across those tracks.
 
 ### Supported MAUI Elements
 

--- a/e2e/alignment.spec.ts
+++ b/e2e/alignment.spec.ts
@@ -42,11 +42,19 @@ test.describe('Alignment and layout tools', () => {
     await designer.expectProperty('y', 30);
   });
 
-  test('align buttons are disabled without a multi selection', async ({ page }) => {
-    await addAt(designer, 'Label', 60, 40);
-
+  test('align buttons are disabled with nothing selected', async ({ page }) => {
     await expect(designer.alignButton('left')).toBeDisabled();
     await expect(page.getByTestId('distribute-horizontal')).toBeDisabled();
+  });
+
+  test('align centre on a single element snaps it to the parent centre', async () => {
+    await addAt(designer, 'Label', 60, 40);
+    await designer.selectFirst('Label');
+
+    await expect(designer.alignButton('center')).toBeEnabled();
+    await designer.alignButton('center').click();
+
+    await designer.expectProperty('x', 350);
   });
 
   test('distribute horizontally spaces three elements evenly', async ({ page }) => {

--- a/e2e/grid-layout.spec.ts
+++ b/e2e/grid-layout.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+const GRID_PAGE = `<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Grid x:Name="Board" ColumnDefinitions="*,*" RowDefinitions="*,*" WidthRequest="400" HeightRequest="300">
+    <Label x:Name="Cell" Text="Hi" Grid.Row="0" Grid.Column="0" />
+  </Grid>
+</ContentPage>`;
+
+test.describe('Grid layout', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+    await designer.applyXaml(GRID_PAGE);
+  });
+
+  test('column span stretches the child across both columns', async ({ page }) => {
+    await designer.selectFirst('Label');
+    const child = page.getByTestId(/^grid-child-/).first();
+    const before = (await child.boundingBox())!;
+
+    await designer.setProperty('columnSpan', '2');
+
+    await expect.poll(async () => {
+      const box = (await child.boundingBox())!;
+      return box.width;
+    }).toBeGreaterThan(before.width * 1.5);
+  });
+
+  test('row span stretches the child across both rows', async ({ page }) => {
+    await designer.selectFirst('Label');
+    const child = page.getByTestId(/^grid-child-/).first();
+    const before = (await child.boundingBox())!;
+
+    await designer.setProperty('rowSpan', '2');
+
+    await expect.poll(async () => {
+      const box = (await child.boundingBox())!;
+      return box.height;
+    }).toBeGreaterThan(before.height * 1.5);
+  });
+
+  test('an Absolute column is the requested number of pixels wide', async ({ page }) => {
+    await designer.canvas.locator('[data-element-type="Grid"]').first().click();
+
+    await page.getByTestId('grid-column-type-0').selectOption('Absolute');
+    await expect(page.getByTestId('grid-column-value-0')).toHaveValue('80');
+
+    const overlay = designer.canvas.locator('.grid-visualization').first();
+    await expect.poll(async () => {
+      return overlay.evaluate(node => {
+        const first = (node.children[0] as HTMLElement | undefined)?.offsetWidth || 0;
+        return first;
+      });
+    }).toBeCloseTo(80, 0);
+  });
+
+  test('a Star column grows when its neighbour is pinned to Absolute', async ({ page }) => {
+    await designer.canvas.locator('[data-element-type="Grid"]').first().click();
+
+    await page.getByTestId('grid-column-type-0').selectOption('Absolute');
+
+    const overlay = designer.canvas.locator('.grid-visualization').first();
+    await expect.poll(async () => {
+      return overlay.evaluate(node => {
+        const first = (node.children[0] as HTMLElement | undefined)?.offsetWidth || 0;
+        const second = (node.children[1] as HTMLElement | undefined)?.offsetWidth || 0;
+        return second - first;
+      });
+    }).toBeGreaterThan(100);
+  });
+
+  test('align centre on a grid child writes HorizontalOptions rather than x', async ({ page }) => {
+    await designer.selectFirst('Label');
+    await designer.alignButton('center').click();
+
+    await expect(page.getByTestId('prop-horizontalOptions')).toHaveValue('Center');
+    await designer.expectXamlToContain('HorizontalOptions="Center"');
+  });
+});

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -218,6 +218,7 @@
       <div *ngSwitchCase="'StackLayout'" class="element-stack-layout"
            #layoutDiv
            cdkDropList
+           [attr.data-orientation]="element.properties.orientation || 'Vertical'"
            [cdkDropListData]="element.children"
            (cdkDropListDropped)="onElementDroppedOnLayout(element, $event)"
            (mouseenter)="setElementRef(element, layoutDiv)">
@@ -262,11 +263,12 @@
         
         <!-- Grid children -->
         <ng-container *ngFor="let child of element.children">
-          <div class="grid-child" 
-               [style.grid-row-start]="child.properties.row + 1" 
-               [style.grid-row-end]="child.properties.row + 1 + (child.properties.rowSpan || 1)"
-               [style.grid-column-start]="child.properties.column + 1"
-               [style.grid-column-end]="child.properties.column + 1 + (child.properties.columnSpan || 1)">
+          <div class="grid-child"
+               [attr.data-testid]="'grid-child-' + child.id"
+               [style.grid-row]="gridChildRow(child)"
+               [style.grid-column]="gridChildColumn(child)"
+               [style.justify-self]="gridChildJustify(child)"
+               [style.align-self]="gridChildAlign(child)">
             <ng-container *ngTemplateOutlet="elementTemplate; context: { $implicit: child }"></ng-container>
           </div>
         </ng-container>

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -305,18 +305,16 @@
 
     .grid-child {
       position: relative;
-      width: 100%;
-      height: 100%;
-      display: flex;
       min-width: 0;
       min-height: 0;
+      display: flex;
 
       > .canvas-element {
         position: relative !important;
         transform: none !important;
         margin: 0;
-        width: 100%;
-        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
       }
     }
   }
@@ -331,15 +329,21 @@
     }
   }
 
+  .element-stack-layout,
   .element-vertical-stack-layout {
     display: flex;
     flex-direction: column;
-    gap: 4px; // Add some default spacing between children
+    gap: 4px;
 
     >.canvas-element {
-      position: relative !important; // Override absolute positioning for children
+      position: relative !important;
+      transform: none !important;
       flex-shrink: 0;
     }
+  }
+
+  .element-stack-layout[data-orientation='Horizontal'] {
+    flex-direction: row;
   }
 
   .element-default {

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -4,7 +4,7 @@ import { DragDropModule, CdkDropList, CdkDragDrop, CdkDragEnd, CdkDragMove } fro
 import { ElementService } from '../../services/element';
 import { DragDropService, TOOLBOX_DRAG_MIME } from '../../services/drag-drop';
 import { LayoutDesignerService } from '../../services/layout-designer';
-import { MauiElement, ElementType } from '../../models/maui-element';
+import { MauiElement, ElementType, LayoutOptions } from '../../models/maui-element';
 import { AlignmentService, AlignmentGuide } from '../../services/alignment';
 import { ClipboardService } from '../../services/clipboard';
 import { CustomControlRegistryService } from '../../services/custom-control-registry';
@@ -538,6 +538,36 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
       transform: `translate3d(${props.x}px, ${props.y}px, 0px)`
     };
 
+    // Grid children are placed by CSS grid, not by a translate. Stretching to
+    // the cell is what makes RowSpan/ColumnSpan visible; a leftover 100×30
+    // pixel box would sit in the first cell and look like span was ignored.
+    if (element.parent?.type === ElementType.Grid) {
+      styles.transform = 'none';
+      styles.width = this.fillsAxis(props.horizontalOptions) ? '100%' : (props.width || 0) + 'px';
+      styles.height = this.fillsAxis(props.verticalOptions) ? '100%' : (props.height || 0) + 'px';
+      styles.minWidth = (props.width || 0) + 'px';
+      styles.minHeight = (props.height || 0) + 'px';
+    } else if (this.isStackParent(element.parent)) {
+      styles.transform = 'none';
+      const vertical = element.parent!.type === ElementType.VerticalStackLayout
+        || element.parent!.properties.orientation !== 'Horizontal';
+      if (vertical) {
+        styles.alignSelf = this.layoutDesigner.selfAlignment(props.horizontalOptions);
+        if (!this.fillsAxis(props.horizontalOptions)) {
+          styles.width = (props.width || 0) + 'px';
+        } else {
+          styles.width = '100%';
+        }
+      } else {
+        styles.alignSelf = this.layoutDesigner.selfAlignment(props.verticalOptions);
+        if (!this.fillsAxis(props.verticalOptions)) {
+          styles.height = (props.height || 0) + 'px';
+        } else {
+          styles.height = '100%';
+        }
+      }
+    }
+
     const background = this.themedColor(element, 'BackgroundColor', props.backgroundColor);
     if (background) {
       styles.backgroundColor = background;
@@ -1051,23 +1081,38 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   }
 
   getGridTemplateColumns(element: MauiElement): string {
-    const gridDef = element.properties.gridDefinition;
-    if (!gridDef) return 'repeat(2, 1fr)'; // Default 2 equal columns
-    return gridDef.columns.map(col => 
-      col.width.type === 'Star' ? `${col.width.value}fr` : 
-      col.width.type === 'Auto' ? 'auto' : 
-      `${col.width.value}px`
-    ).join(' ');
+    return this.layoutDesigner.templateColumnsCss(element);
   }
 
   getGridTemplateRows(element: MauiElement): string {
-    const gridDef = element.properties.gridDefinition;
-    if (!gridDef) return 'repeat(2, 1fr)'; // Default 2 equal rows
-    return gridDef.rows.map(row => 
-      row.height.type === 'Star' ? `${row.height.value}fr` : 
-      row.height.type === 'Auto' ? 'auto' : 
-      `${row.height.value}px`
-    ).join(' ');
+    return this.layoutDesigner.templateRowsCss(element);
+  }
+
+  gridChildRow(child: MauiElement): string {
+    return this.layoutDesigner.childPlacement(child).row;
+  }
+
+  gridChildColumn(child: MauiElement): string {
+    return this.layoutDesigner.childPlacement(child).column;
+  }
+
+  gridChildJustify(child: MauiElement): string {
+    return this.layoutDesigner.selfAlignment(child.properties.horizontalOptions);
+  }
+
+  gridChildAlign(child: MauiElement): string {
+    return this.layoutDesigner.selfAlignment(child.properties.verticalOptions);
+  }
+
+  private fillsAxis(option: LayoutOptions | undefined): boolean {
+    return !option || option === 'Fill';
+  }
+
+  private isStackParent(parent?: MauiElement): boolean {
+    return !!parent && (
+      parent.type === ElementType.StackLayout ||
+      parent.type === ElementType.VerticalStackLayout
+    );
   }
 
   getGridRowPosition(index: number, element: MauiElement): string {

--- a/src/app/components/properties-panel/properties-panel.ts
+++ b/src/app/components/properties-panel/properties-panel.ts
@@ -354,7 +354,10 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
 
   updateRowType(element: MauiElement, index: number, type: string) {
     const current = this.gridRows(element)[index].height;
-    this.elementService.updateGridRow(element, index, { value: current.value, type: type as GridLengthType });
+    this.elementService.updateGridRow(element, index, {
+      value: this.defaultLengthValue(type as GridLengthType, current),
+      type: type as GridLengthType
+    });
   }
 
   updateRowValue(element: MauiElement, index: number, value: number) {
@@ -364,7 +367,28 @@ export class PropertiesPanelComponent implements OnInit, OnDestroy {
 
   updateColumnType(element: MauiElement, index: number, type: string) {
     const current = this.gridColumns(element)[index].width;
-    this.elementService.updateGridColumn(element, index, { value: current.value, type: type as GridLengthType });
+    this.elementService.updateGridColumn(element, index, {
+      value: this.defaultLengthValue(type as GridLengthType, current),
+      type: type as GridLengthType
+    });
+  }
+
+  /**
+   * Switching Star → Absolute used to keep `value: 1`, which is a 1px track
+   * and looks exactly like "Absolute does nothing". Pick a visible default
+   * when the type actually changes.
+   */
+  private defaultLengthValue(type: GridLengthType, current: GridLength): number {
+    if (type === current.type) {
+      return current.value;
+    }
+    if (type === GridLengthType.Absolute) {
+      return 80;
+    }
+    if (type === GridLengthType.Star) {
+      return 1;
+    }
+    return current.value;
   }
 
   updateColumnValue(element: MauiElement, index: number, value: number) {

--- a/src/app/services/alignment.service.spec.ts
+++ b/src/app/services/alignment.service.spec.ts
@@ -62,25 +62,49 @@ describe('AlignmentService', () => {
     expect(a.properties.y! + 30).toBe(140);
   });
 
-  it('ignores single elements', () => {
+  it('aligns a single element to the matching edge of its parent', () => {
+    const root = elements.getRootElement();
+    elements.updateElementProperties(root, { width: 800, height: 600 });
     const a = add(ElementType.Label, 50, 10, 100, 30);
 
+    expect(service.canAlign([a])).toBeTrue();
     service.align([a], 'left');
+    expect(a.properties.x).toBe(0);
 
-    expect(a.properties.x).toBe(50);
-    expect(service.canAlign([a])).toBeFalse();
+    service.align([a], 'center');
+    expect(a.properties.x).toBe(350);
+
+    service.align([a], 'right');
+    expect(a.properties.x).toBe(700);
   });
 
-  it('only aligns children of an absolute layout', () => {
-    const stack = elements.createElement(ElementType.VerticalStackLayout);
-    elements.addElement(stack, elements.getRootElement());
+  it('sets HorizontalOptions on a grid child instead of moving x', () => {
+    const grid = elements.createElement(ElementType.Grid);
+    elements.addElement(grid, elements.getRootElement());
     const child = elements.createElement(ElementType.Label);
-    elements.addElement(child, stack);
-    elements.updateElementProperties(child, { x: 40 });
+    elements.addElement(child, grid);
+    elements.updateElementProperties(child, { x: 40, column: 0, row: 0 });
 
-    expect(service.canAlign([child, stack])).toBeFalse();
-    service.align([child, stack], 'left');
+    expect(service.canAlign([child])).toBeTrue();
+    service.align([child], 'center');
+
     expect(child.properties.x).toBe(40);
+    expect(child.properties.horizontalOptions).toBe('Center');
+  });
+
+  it('centres a single element vertically in its parent', () => {
+    const root = elements.getRootElement();
+    elements.updateElementProperties(root, { width: 800, height: 600 });
+    const a = add(ElementType.Label, 50, 10, 100, 30);
+
+    service.align([a], 'middle');
+
+    expect(a.properties.y).toBe(285);
+  });
+
+  it('does nothing when nothing is selected', () => {
+    expect(service.canAlign([])).toBeFalse();
+    service.align([], 'center');
   });
 
   it('distributes three elements with equal gaps', () => {

--- a/src/app/services/alignment.ts
+++ b/src/app/services/alignment.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ElementService } from './element';
-import { MauiElement, ElementType } from '../models/maui-element';
+import { MauiElement, ElementType, LayoutOptions } from '../models/maui-element';
 
 export type AlignMode = 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom';
 export type DistributeMode = 'horizontal' | 'vertical';
@@ -30,48 +30,115 @@ export class AlignmentService {
 
   constructor(private elementService: ElementService) {}
 
-  /** Only absolutely positioned elements can be aligned. */
+  /**
+   * Align is offered whenever something can actually move: one or more
+   * absolutely positioned children, or any child of a Grid/Stack (those use
+   * HorizontalOptions / VerticalOptions instead of x/y).
+   */
   canAlign(elements: MauiElement[]): boolean {
-    return this.positionable(elements).length > 1;
+    return this.positionable(elements).length > 0 || this.flowChildren(elements).length > 0;
   }
 
   align(elements: MauiElement[], mode: AlignMode): void {
     const boxes = this.toBoxes(this.positionable(elements));
-    if (boxes.length < 2) {
+    const flow = this.flowChildren(elements);
+    if (boxes.length === 0 && flow.length === 0) {
       return;
     }
 
+    this.elementService.runAsSingleChange(() => {
+      if (boxes.length === 1) {
+        this.alignToParent(boxes[0], mode);
+      } else if (boxes.length > 1) {
+        this.alignToSelection(boxes, mode);
+      }
+
+      for (const element of flow) {
+        this.applyLayoutOptions(element, mode);
+      }
+    });
+  }
+
+  /** One selected control snaps to the edges / centre of its parent. */
+  private alignToParent(box: Box, mode: AlignMode): void {
+    const parent = box.element.parent;
+    const parentWidth = parent?.properties.width || 0;
+    const parentHeight = parent?.properties.height || 0;
+    this.elementService.updateElementProperties(
+      box.element,
+      this.patchForMode(mode, 0, parentWidth, 0, parentHeight, box),
+      { recordHistory: false }
+    );
+  }
+
+  private alignToSelection(boxes: Box[], mode: AlignMode): void {
     const left = Math.min(...boxes.map(box => box.x));
     const right = Math.max(...boxes.map(box => box.x + box.width));
     const top = Math.min(...boxes.map(box => box.y));
     const bottom = Math.max(...boxes.map(box => box.y + box.height));
 
-    this.elementService.runAsSingleChange(() => {
-      for (const box of boxes) {
-        const patch: { x?: number; y?: number } = {};
-        switch (mode) {
-          case 'left':
-            patch.x = left;
-            break;
-          case 'right':
-            patch.x = right - box.width;
-            break;
-          case 'center':
-            patch.x = Math.round((left + right) / 2 - box.width / 2);
-            break;
-          case 'top':
-            patch.y = top;
-            break;
-          case 'bottom':
-            patch.y = bottom - box.height;
-            break;
-          case 'middle':
-            patch.y = Math.round((top + bottom) / 2 - box.height / 2);
-            break;
-        }
-        this.elementService.updateElementProperties(box.element, patch, { recordHistory: false });
-      }
-    });
+    for (const box of boxes) {
+      this.elementService.updateElementProperties(
+        box.element,
+        this.patchForMode(mode, left, right, top, bottom, box),
+        { recordHistory: false }
+      );
+    }
+  }
+
+  private patchForMode(
+    mode: AlignMode,
+    left: number,
+    right: number,
+    top: number,
+    bottom: number,
+    box: Box
+  ): { x?: number; y?: number } {
+    switch (mode) {
+      case 'left':
+        return { x: left };
+      case 'right':
+        return { x: right - box.width };
+      case 'center':
+        return { x: Math.round((left + right) / 2 - box.width / 2) };
+      case 'top':
+        return { y: top };
+      case 'bottom':
+        return { y: bottom - box.height };
+      case 'middle':
+        return { y: Math.round((top + bottom) / 2 - box.height / 2) };
+    }
+  }
+
+  /**
+   * Grid and stack children have no pixel position of their own. Left/centre/right
+   * become HorizontalOptions; top/middle/bottom become VerticalOptions.
+   */
+  private applyLayoutOptions(element: MauiElement, mode: AlignMode): void {
+    const horizontal: Record<string, LayoutOptions> = {
+      left: 'Start',
+      center: 'Center',
+      right: 'End'
+    };
+    const vertical: Record<string, LayoutOptions> = {
+      top: 'Start',
+      middle: 'Center',
+      bottom: 'End'
+    };
+    if (horizontal[mode]) {
+      this.elementService.updateElementProperties(
+        element,
+        { horizontalOptions: horizontal[mode] },
+        { recordHistory: false }
+      );
+    }
+    if (vertical[mode]) {
+      this.elementService.updateElementProperties(
+        element,
+        { verticalOptions: vertical[mode] },
+        { recordHistory: false }
+      );
+    }
   }
 
   /** Spreads elements so the gaps between them are equal. */
@@ -183,6 +250,18 @@ export class AlignmentService {
 
   private positionable(elements: MauiElement[]): MauiElement[] {
     return elements.filter(element => element.parent?.type === ElementType.AbsoluteLayout);
+  }
+
+  private flowChildren(elements: MauiElement[]): MauiElement[] {
+    const flowParents = new Set<ElementType>([
+      ElementType.Grid,
+      ElementType.StackLayout,
+      ElementType.VerticalStackLayout,
+      ElementType.Frame,
+      ElementType.Border,
+      ElementType.ScrollView
+    ]);
+    return elements.filter(element => !!element.parent && flowParents.has(element.parent.type));
   }
 
   private toBoxes(elements: MauiElement[]): Box[] {

--- a/src/app/services/layout-designer.service.spec.ts
+++ b/src/app/services/layout-designer.service.spec.ts
@@ -157,3 +157,80 @@ describe('LayoutDesignerService grid hit-testing', () => {
     expect(service.calculateDropPosition(element, event, container)).toEqual({ x: 1, y: 1 });
   });
 });
+
+describe('LayoutDesignerService grid tracks', () => {
+  let service: LayoutDesignerService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LayoutDesignerService);
+  });
+
+  it('emits distinct CSS for Auto, Star and Absolute tracks', () => {
+    expect(service.trackCss({ value: 1, type: 'Auto' as any })).toBe('auto');
+    expect(service.trackCss({ value: 2, type: 'Star' as any })).toBe('minmax(0, 2fr)');
+    expect(service.trackCss({ value: 80, type: 'Absolute' as any })).toBe('80px');
+  });
+
+  it('builds a template string from the grid definition, not a uniform repeat', () => {
+    const grid = {
+      id: 'grid',
+      type: ElementType.Grid,
+      properties: {
+        gridDefinition: {
+          columns: [
+            { width: { value: 40, type: 'Absolute' } },
+            { width: { value: 1, type: 'Star' } },
+            { width: { value: 1, type: 'Auto' } }
+          ],
+          rows: [{ height: { value: 1, type: 'Star' } }]
+        }
+      },
+      children: []
+    } as unknown as MauiElement;
+
+    expect(service.templateColumnsCss(grid)).toBe('40px minmax(0, 1fr) auto');
+  });
+
+  it('places a child across the rows and columns it spans', () => {
+    const grid = {
+      id: 'grid',
+      type: ElementType.Grid,
+      properties: {
+        gridDefinition: {
+          rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }],
+          columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
+        }
+      },
+      children: []
+    } as unknown as MauiElement;
+    const child = {
+      id: 'c',
+      type: ElementType.Label,
+      parent: grid,
+      properties: { row: 0, column: 0, rowSpan: 2, columnSpan: 2 },
+      children: []
+    } as unknown as MauiElement;
+
+    expect(service.childPlacement(child)).toEqual({ row: '1 / span 2', column: '1 / span 2' });
+  });
+
+  it('treats a missing row or column as the first cell instead of NaN', () => {
+    const child = {
+      id: 'c',
+      type: ElementType.Label,
+      properties: {},
+      children: []
+    } as unknown as MauiElement;
+
+    expect(service.childPlacement(child)).toEqual({ row: '1 / span 1', column: '1 / span 1' });
+  });
+
+  it('maps LayoutOptions onto CSS self-alignment', () => {
+    expect(service.selfAlignment('Start')).toBe('start');
+    expect(service.selfAlignment('Center')).toBe('center');
+    expect(service.selfAlignment('End')).toBe('end');
+    expect(service.selfAlignment(undefined)).toBe('stretch');
+  });
+});

--- a/src/app/services/layout-designer.ts
+++ b/src/app/services/layout-designer.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType } from '../models/maui-element';
+import { MauiElement, ElementType, GridDefinition, GridLength, GridLengthType, LayoutOptions } from '../models/maui-element';
 
 export interface LayoutInfo {
   canHaveChildren: boolean;
@@ -13,9 +13,9 @@ export interface LayoutInfo {
  *
  * Shared so hit-testing and sizing cannot disagree about the fallback.
  */
-export const DEFAULT_GRID_DEFINITION = {
-  rows: [{ height: { value: 1, type: 'Star' } }, { height: { value: 1, type: 'Star' } }],
-  columns: [{ width: { value: 1, type: 'Star' } }, { width: { value: 1, type: 'Star' } }]
+export const DEFAULT_GRID_DEFINITION: GridDefinition = {
+  rows: [{ height: { value: 1, type: GridLengthType.Star } }, { height: { value: 1, type: GridLengthType.Star } }],
+  columns: [{ width: { value: 1, type: GridLengthType.Star } }, { width: { value: 1, type: GridLengthType.Star } }]
 };
 
 @Injectable({
@@ -366,5 +366,76 @@ export class LayoutDesignerService {
     });
 
     return sizes;
+  }
+
+  /**
+   * CSS `grid-template-*` value for one MAUI GridLength.
+   *
+   * Star tracks use `minmax(0, Nfr)` so a neighbouring Auto track can shrink
+   * them instead of every track pretending to be equal. Absolute is pixels.
+   * Auto is `auto` so the track sizes to the child's WidthRequest/HeightRequest.
+   */
+  trackCss(length: GridLength | undefined): string {
+    if (!length) {
+      return 'minmax(0, 1fr)';
+    }
+    switch (length.type) {
+      case GridLengthType.Auto:
+        return 'auto';
+      case GridLengthType.Absolute:
+        return `${Math.max(0, length.value || 0)}px`;
+      case GridLengthType.Star:
+      default:
+        return `minmax(0, ${length.value || 1}fr)`;
+    }
+  }
+
+  templateColumnsCss(grid: MauiElement): string {
+    const columns = (grid.properties.gridDefinition || DEFAULT_GRID_DEFINITION).columns;
+    return columns.map(column => this.trackCss(column.width)).join(' ') || 'minmax(0, 1fr)';
+  }
+
+  templateRowsCss(grid: MauiElement): string {
+    const rows = (grid.properties.gridDefinition || DEFAULT_GRID_DEFINITION).rows;
+    return rows.map(row => this.trackCss(row.height)).join(' ') || 'minmax(0, 1fr)';
+  }
+
+  /**
+   * CSS grid-row / grid-column placement, 1-based, honouring span.
+   * Missing coordinates are treated as 0 so imported XAML without Grid.Row
+   * still occupies the first cell instead of `NaN`.
+   */
+  childPlacement(child: MauiElement): { row: string; column: string } {
+    const definition = child.parent?.properties.gridDefinition || DEFAULT_GRID_DEFINITION;
+    const rowStart = Math.max(0, child.properties.row || 0);
+    const columnStart = Math.max(0, child.properties.column || 0);
+    const rowSpan = this.clampSpan(child.properties.rowSpan || 1, definition.rows.length - rowStart);
+    const columnSpan = this.clampSpan(child.properties.columnSpan || 1, definition.columns.length - columnStart);
+    return {
+      row: `${rowStart + 1} / span ${rowSpan}`,
+      column: `${columnStart + 1} / span ${columnSpan}`
+    };
+  }
+
+  private clampSpan(span: number, remaining: number): number {
+    if (!Number.isFinite(span) || span < 1) {
+      return 1;
+    }
+    return Math.max(1, Math.min(Math.floor(span), Math.max(1, remaining)));
+  }
+
+  /** Maps MAUI LayoutOptions onto CSS justify-self / align-self. */
+  selfAlignment(option: LayoutOptions | undefined): string {
+    switch (option) {
+      case 'Start':
+        return 'start';
+      case 'Center':
+        return 'center';
+      case 'End':
+        return 'end';
+      case 'Fill':
+      default:
+        return 'stretch';
+    }
   }
 }


### PR DESCRIPTION
Depends on #102 (LayoutOptions). Base is `feat/layout-options`.

## What was actually broken

I reproduced all three reports on the canvas rather than trusting the property panel.

**RowSpan / ColumnSpan.** The template already set `grid-row-end` / `grid-column-end`. The child still had `width: 100px; height: 30px` as an inline style, which beats the stylesheet's `width: 100%`. The cell grew; the control did not. Changing span looked like a no-op.

**Auto / Star / Absolute.** The generator already emitted `Auto` / `*` / `80`. Two canvas bugs made that invisible:
- Switching Star → Absolute kept `value: 1`, so the track became **1px**.
- Star tracks were plain `1fr`, so a neighbouring Auto track could not shrink them.

**Align left / centre.** The toolbar required a multi-selection of AbsoluteLayout children. One selected Label (the normal case) left the buttons disabled. A Grid/Stack child made them silently do nothing, because those elements have no `x`/`y`.

## The fix

- Grid children **Fill** (MAUI default) stretch to the cells they span. Start/Center/End keep the requested size and `justify-self` / `align-self` inside the cell.
- Track CSS is now `auto` / `Npx` / `minmax(0, Nfr)`. Switching to Absolute defaults the value to **80px**.
- One selected AbsoluteLayout child snaps to its parent (centre of an 800×600 page is `x = 350` for a 100-wide Label). Grid/Stack children get `HorizontalOptions` / `VerticalOptions` instead.

## Verification

- 5 new layout-designer unit specs + updated alignment specs.
- 5 new e2e specs in `e2e/grid-layout.spec.ts` plus a single-element centre-align spec.
- **Full e2e: 189/189.**
