### PR TITLE
Fit to parent, clamp drops, and reorder the hierarchy

### DIFF
--- a/e2e/element-move.spec.ts
+++ b/e2e/element-move.spec.ts
@@ -33,7 +33,7 @@ test.describe('Moving elements on the canvas', () => {
   }
 
   async function drag(page: any, name: string, dx: number, dy: number) {
-    const element = page.locator(`[data-element-name="${name}"]`);
+    const element = page.getByTestId('designer-canvas').locator(`[data-element-name="${name}"]`);
     await expect(element).toBeVisible();
     await element.click({ position: { x: 6, y: 6 } });
     await expect(element).toHaveAttribute('data-selected', 'true');
@@ -115,7 +115,7 @@ test.describe('Moving elements on the canvas', () => {
   test('an element stays selected after it has been dragged', async ({ page }) => {
     await applyStarter(page, 'login');
 
-    const element = page.locator('[data-element-name="Busy"]');
+    const element = page.getByTestId('designer-canvas').locator('[data-element-name="Busy"]');
     await drag(page, 'Busy', 60, 40);
     await expect(element).toHaveAttribute('data-selected', 'true');
 

--- a/e2e/fit-drop-hierarchy.spec.ts
+++ b/e2e/fit-drop-hierarchy.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+test.describe('Fit to parent, drop clamp, hierarchy reorder', () => {
+  let designer: DesignerPage;
+
+  test.beforeEach(async ({ page }) => {
+    designer = new DesignerPage(page);
+    await designer.goto();
+  });
+
+  test('double-clicking an east handle fits the element to the parent width', async ({ page }) => {
+    await designer.addControl('Button');
+    await designer.selectFirst('Button');
+
+    await page.getByTestId('resize-handle-e').dblclick();
+
+    await designer.expectProperty('width', 800);
+    await designer.expectProperty('x', 0);
+    await designer.expectPropertyNumber('height', value => value < 800);
+  });
+
+  test('double-clicking a south-east handle fits both axes', async ({ page }) => {
+    await designer.addControl('Label');
+    await designer.selectFirst('Label');
+
+    await page.getByTestId('resize-handle-se').dblclick();
+
+    await designer.expectProperty('width', 800);
+    await designer.expectProperty('height', 600);
+    await designer.expectProperty('x', 0);
+    await designer.expectProperty('y', 0);
+  });
+
+  test('adding a control into a smaller layout clamps its size', async ({ page }) => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout WidthRequest="800" HeightRequest="600">
+        <AbsoluteLayout x:Name="Narrow" BackgroundColor="#eeeeee"
+                        AbsoluteLayout.LayoutBounds="10,10,80,200"
+                        WidthRequest="80" HeightRequest="200" />
+    </AbsoluteLayout>
+</ContentPage>`);
+
+    await designer.canvas.locator('[data-element-name="Narrow"]').click();
+    await designer.addControl('Button');
+
+    await designer.expectPropertyNumber('width', value => value <= 80);
+    const xaml = await designer.getXaml();
+    expect(xaml).toMatch(/<AbsoluteLayout x:Name="Narrow"[\s\S]*?<Button/);
+  });
+
+  test('dropping an oversized control into a nested layout shrinks it', async ({ page }) => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout WidthRequest="800" HeightRequest="600">
+        <AbsoluteLayout x:Name="Narrow" BackgroundColor="#eeeeee"
+                        AbsoluteLayout.LayoutBounds="10,10,80,200"
+                        WidthRequest="80" HeightRequest="200" />
+        <Button x:Name="Wide" Text="Wide" WidthRequest="160" HeightRequest="40"
+                AbsoluteLayout.LayoutBounds="200,20,160,40" />
+    </AbsoluteLayout>
+</ContentPage>`);
+
+    const button = designer.canvas.locator('[data-element-name="Wide"]');
+    const panel = designer.canvas.locator('[data-element-name="Narrow"]');
+    await expect(button).toBeVisible();
+    await expect(panel).toBeVisible();
+
+    await button.click({ position: { x: 6, y: 6 } });
+    await expect(button).toHaveAttribute('data-selected', 'true');
+
+    const from = (await button.boundingBox())!;
+    const to = (await panel.boundingBox())!;
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(to.x + to.width / 2, to.y + 30, { steps: 12 });
+    await page.mouse.up();
+
+    await expect.poll(async () => designer.getXaml()).toMatch(
+      /<AbsoluteLayout x:Name="Narrow"[\s\S]*?<Button x:Name="Wide"/
+    );
+    await designer.selectFirst('Button');
+    await designer.expectPropertyNumber('width', value => value <= 80);
+  });
+
+  test('hierarchy move buttons change XAML child order', async ({ page }) => {
+    await designer.applyXaml(`<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <AbsoluteLayout WidthRequest="800" HeightRequest="600">
+        <Label x:Name="First" Text="First" AbsoluteLayout.LayoutBounds="10,10,80,30" WidthRequest="80" HeightRequest="30" />
+        <Label x:Name="Second" Text="Second" AbsoluteLayout.LayoutBounds="10,50,80,30" WidthRequest="80" HeightRequest="30" />
+    </AbsoluteLayout>
+</ContentPage>`);
+
+    await designer.openHierarchy();
+    const first = designer.hierarchy.locator('[data-element-name="First"]');
+    await expect(first).toBeVisible();
+    const id = (await first.getAttribute('data-testid'))!.replace('hierarchy-node-', '');
+    await page.getByTestId(`hierarchy-move-down-${id}`).click({ force: true });
+
+    const xaml = await designer.xamlWhen(value =>
+      value.indexOf('x:Name="Second"') < value.indexOf('x:Name="First"')
+    );
+    expect(xaml.indexOf('x:Name="Second"')).toBeLessThan(xaml.indexOf('x:Name="First"'));
+  });
+});

--- a/e2e/hierarchy-panel.spec.ts
+++ b/e2e/hierarchy-panel.spec.ts
@@ -54,8 +54,8 @@ test.describe('Hierarchy panel', () => {
     const gridNode = designer.hierarchy.locator('[data-element-type="Grid"]');
     const labelNode = designer.hierarchy.locator('[data-element-type="Label"]');
 
-    const gridPadding = await gridNode.locator('xpath=..').evaluate(node => getComputedStyle(node).paddingLeft);
-    const labelPadding = await labelNode.locator('xpath=..').evaluate(node => getComputedStyle(node).paddingLeft);
+    const gridPadding = await gridNode.locator('xpath=ancestor::*[contains(@class,"hierarchy-node")][1]').evaluate(node => getComputedStyle(node).paddingLeft);
+    const labelPadding = await labelNode.locator('xpath=ancestor::*[contains(@class,"hierarchy-node")][1]').evaluate(node => getComputedStyle(node).paddingLeft);
 
     expect(parseFloat(labelPadding)).toBeGreaterThan(parseFloat(gridPadding));
   });

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -365,24 +365,39 @@
     <!-- Selection handles -->
     <div class="selection-handles" *ngIf="isPrimarySelection(element) && element.id !== 'root'">
       <!-- Corner handles (blue) -->
-      <div class="handle handle-corner handle-nw" 
+      <div class="handle handle-corner handle-nw"
+           data-testid="resize-handle-nw"
+           title="Double-click to fit parent"
            (mousedown)="onResizeStart($event, 'nw', element)"></div>
-      <div class="handle handle-corner handle-ne" 
+      <div class="handle handle-corner handle-ne"
+           data-testid="resize-handle-ne"
+           title="Double-click to fit parent"
            (mousedown)="onResizeStart($event, 'ne', element)"></div>
-      <div class="handle handle-corner handle-sw" 
+      <div class="handle handle-corner handle-sw"
+           data-testid="resize-handle-sw"
+           title="Double-click to fit parent"
            (mousedown)="onResizeStart($event, 'sw', element)"></div>
       <div class="handle handle-corner handle-se" 
            data-testid="resize-handle-se"
+           title="Double-click to fit parent"
            (mousedown)="onResizeStart($event, 'se', element)"></div>
       
       <!-- Edge handles (green) -->
-      <div class="handle handle-edge handle-n" 
+      <div class="handle handle-edge handle-n"
+           data-testid="resize-handle-n"
+           title="Double-click to fit parent height"
            (mousedown)="onResizeStart($event, 'n', element)"></div>
-      <div class="handle handle-edge handle-s" 
+      <div class="handle handle-edge handle-s"
+           data-testid="resize-handle-s"
+           title="Double-click to fit parent height"
            (mousedown)="onResizeStart($event, 's', element)"></div>
-      <div class="handle handle-edge handle-w" 
+      <div class="handle handle-edge handle-w"
+           data-testid="resize-handle-w"
+           title="Double-click to fit parent width"
            (mousedown)="onResizeStart($event, 'w', element)"></div>
-      <div class="handle handle-edge handle-e" 
+      <div class="handle handle-edge handle-e"
+           data-testid="resize-handle-e"
+           title="Double-click to fit parent width"
            (mousedown)="onResizeStart($event, 'e', element)"></div>
     </div>
   </div>

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -813,6 +813,14 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
   onResizeStart(event: MouseEvent, direction: ResizeDirection, element: MauiElement) {
     event.preventDefault();
     event.stopPropagation();
+
+    // The second mousedown of a double-click fits the parent instead of
+    // starting another drag. The first click is a no-op resize that ends
+    // on mouseup with no movement.
+    if (event.detail >= 2) {
+      this.fitElementToParent(element, direction);
+      return;
+    }
     
     this.isResizing = true;
     this.elementService.beginBatch();
@@ -834,6 +842,20 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     // Set cursor
     document.body.style.cursor = this.getResizeCursor(direction);
     document.body.style.userSelect = 'none';
+  }
+
+  /** Double-clicking an edge fits that axis; a corner fits both. */
+  private fitElementToParent(element: MauiElement, direction: ResizeDirection): void {
+    const axis = (direction === 'e' || direction === 'w')
+      ? 'width'
+      : (direction === 'n' || direction === 's')
+        ? 'height'
+        : 'both';
+    const patch = this.layoutDesigner.fitToParent(element, axis);
+    if (Object.keys(patch).length === 0) {
+      return;
+    }
+    this.elementService.updateElementProperties(element, patch);
   }
 
   @HostListener('document:mousemove', ['$event'])

--- a/src/app/components/hierarchy-panel/hierarchy-panel.html
+++ b/src/app/components/hierarchy-panel/hierarchy-panel.html
@@ -1,5 +1,5 @@
 <div class="hierarchy-panel" data-testid="hierarchy-panel">
-  <div class="hierarchy-tree" *ngIf="rootElement$ | async as rootElement">
+  <div class="hierarchy-tree" cdkDropListGroup *ngIf="rootElement$ | async as rootElement">
     <ng-container *ngTemplateOutlet="hierarchyNode; context: { $implicit: rootElement, level: 0 }"></ng-container>
   </div>
   
@@ -12,31 +12,61 @@
 
 <!-- Template for recursive hierarchy node rendering -->
 <ng-template #hierarchyNode let-element let-level="level">
-  <div class="hierarchy-node" [style.padding-left.px]="level * 20">
-    <div 
-      class="node-content"
-      [class.selected]="isSelected(element)"
-      [attr.data-testid]="'hierarchy-node-' + element.id"
-      [attr.data-element-type]="element.type"
-      [attr.data-selected]="isSelected(element)"
-      (click)="onElementSelect(element)">
-      
-      <div class="node-icon">
-        <span class="material-icons">{{ getElementIcon(element) }}</span>
+  <div class="hierarchy-node"
+       [style.padding-left.px]="level * 20"
+       cdkDrag
+       [cdkDragData]="element"
+       [cdkDragDisabled]="element.id === 'root'">
+    <div class="node-row">
+      <div 
+        class="node-content"
+        cdkDragHandle
+        tabindex="0"
+        [class.selected]="isSelected(element)"
+        [attr.data-testid]="'hierarchy-node-' + element.id"
+        [attr.data-element-type]="element.type"
+        [attr.data-element-name]="element.name"
+        [attr.data-selected]="isSelected(element)"
+        (click)="onElementSelect(element)"
+        (keydown)="onNodeKeydown($event, element)">
+        
+        <div class="node-icon">
+          <span class="material-icons">{{ getElementIcon(element) }}</span>
+        </div>
+        
+        <div class="node-label">
+          {{ element.name }}
+        </div>
+        
+        <div class="node-type">
+          ({{ element.type }})
+        </div>
       </div>
-      
-      <div class="node-label">
-        {{ element.name }}
-      </div>
-      
-      <div class="node-type">
-        ({{ element.type }})
-      </div>
-      
+
       <div class="node-actions" *ngIf="element.id !== 'root'">
-        <button 
+        <button
+          type="button"
+          class="action-button"
+          [attr.data-testid]="'hierarchy-move-up-' + element.id"
+          (mousedown)="$event.stopPropagation()"
+          (click)="onMoveSibling(element, -1, $event)"
+          title="Move up">
+          <span class="material-icons">keyboard_arrow_up</span>
+        </button>
+        <button
+          type="button"
+          class="action-button"
+          [attr.data-testid]="'hierarchy-move-down-' + element.id"
+          (mousedown)="$event.stopPropagation()"
+          (click)="onMoveSibling(element, 1, $event)"
+          title="Move down">
+          <span class="material-icons">keyboard_arrow_down</span>
+        </button>
+        <button
+          type="button"
           class="action-button delete-button"
           [attr.data-testid]="'hierarchy-delete-' + element.id"
+          (mousedown)="$event.stopPropagation()"
           (click)="onElementDelete(element, $event)"
           title="Delete element">
           <span class="material-icons">delete</span>
@@ -44,8 +74,12 @@
       </div>
     </div>
     
-    <!-- Render children recursively -->
-    <div class="node-children" *ngIf="element.children?.length">
+    <div class="node-children"
+         cdkDropList
+         [cdkDropListData]="element"
+         [cdkDropListEnterPredicate]="canEnter"
+         [attr.data-testid]="'hierarchy-drop-' + element.id"
+         (cdkDropListDropped)="onDrop($event, element)">
       <ng-container *ngFor="let child of element.children">
         <ng-container *ngTemplateOutlet="hierarchyNode; context: { $implicit: child, level: level + 1 }"></ng-container>
       </ng-container>

--- a/src/app/components/hierarchy-panel/hierarchy-panel.scss
+++ b/src/app/components/hierarchy-panel/hierarchy-panel.scss
@@ -9,12 +9,19 @@
 }
 
 .hierarchy-node {
+  .node-row {
+    display: flex;
+    align-items: center;
+  }
+
   .node-content {
     display: flex;
     align-items: center;
     padding: 6px 8px;
     border-radius: 4px;
     cursor: pointer;
+    flex: 1;
+    min-width: 0;
     transition: background-color 0.2s ease;
     
     &:hover {
@@ -72,17 +79,26 @@
       justify-content: center;
       
       &:hover {
-        background-color: #fed7d7;
+        background-color: #e2e8f0;
       }
-      
+
       .material-icons {
         font-size: 16px;
+        color: #4a5568;
+      }
+    }
+
+    .delete-button:hover {
+      background-color: #fed7d7;
+
+      .material-icons {
         color: #e53e3e;
       }
     }
   }
   
-  .node-content:hover .node-actions {
+  .node-row:hover .node-actions,
+  .node-content.selected + .node-actions {
     opacity: 1;
   }
 }
@@ -90,6 +106,26 @@
 .node-children {
   border-left: 1px solid #e2e8f0;
   margin-left: 12px;
+  min-height: 8px;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.35;
+}
+
+.cdk-drag-animating {
+  transition: transform 150ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.node-content {
+  cursor: grab;
 }
 
 .empty-state {

--- a/src/app/components/hierarchy-panel/hierarchy-panel.ts
+++ b/src/app/components/hierarchy-panel/hierarchy-panel.ts
@@ -1,13 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CdkDrag, CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
 import { ElementService } from '../../services/element';
+import { LayoutDesignerService } from '../../services/layout-designer';
+import { DragDropService } from '../../services/drag-drop';
 import { MauiElement } from '../../models/maui-element';
 import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-hierarchy-panel',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, DragDropModule],
   templateUrl: './hierarchy-panel.html',
   styleUrl: './hierarchy-panel.scss'
 })
@@ -15,7 +18,11 @@ export class HierarchyPanelComponent implements OnInit {
   rootElement$: Observable<MauiElement>;
   selectedElement$: Observable<MauiElement | null>;
 
-  constructor(private elementService: ElementService) {
+  constructor(
+    private elementService: ElementService,
+    private layoutDesigner: LayoutDesignerService,
+    private dragDropService: DragDropService
+  ) {
     this.rootElement$ = this.elementService.elements$;
     this.selectedElement$ = this.elementService.selectedElement$;
   }
@@ -31,6 +38,50 @@ export class HierarchyPanelComponent implements OnInit {
   onElementDelete(element: MauiElement, event: Event) {
     event.stopPropagation();
     this.elementService.removeElement(element);
+  }
+
+  onMoveSibling(element: MauiElement, delta: -1 | 1, event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.elementService.moveSibling(element, delta);
+  }
+
+  onNodeKeydown(event: KeyboardEvent, element: MauiElement) {
+    if (!event.altKey) {
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.elementService.moveSibling(element, -1);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.elementService.moveSibling(element, 1);
+    }
+  }
+
+  readonly canEnter = (drag: CdkDrag<MauiElement>, drop: CdkDropList<MauiElement>): boolean => {
+    return this.layoutDesigner.canDropOn(drop.data, drag.data);
+  };
+
+  onDrop(event: CdkDragDrop<MauiElement>, parent: MauiElement) {
+    const child = event.item.data as MauiElement;
+    if (!child || child.id === 'root') {
+      return;
+    }
+
+    if (event.previousContainer === event.container) {
+      this.elementService.reorderChild(parent, event.previousIndex, event.currentIndex);
+      return;
+    }
+
+    if (!this.layoutDesigner.canDropOn(parent, child)) {
+      return;
+    }
+
+    this.elementService.runAsSingleChange(() => {
+      this.elementService.moveElement(child, parent, 0, 0, event.currentIndex);
+      this.dragDropService.constrainToParent(child);
+    });
   }
 
   isSelected(element: MauiElement): boolean {

--- a/src/app/components/toolbox/toolbox.ts
+++ b/src/app/components/toolbox/toolbox.ts
@@ -58,6 +58,7 @@ export class ToolboxComponent {
       this.registry.defaultProperties({ manifest, definition: control })
     );
     this.elementService.addElement(element, parent);
+    this.dragDropService.constrainToParent(element);
     this.elementService.selectElement(element);
   }
 
@@ -160,6 +161,7 @@ export class ToolboxComponent {
     const parent = this.resolveTargetParent();
     const newElement = this.elementService.createElement(item.type as ElementType, { x: 0, y: 0 });
     this.elementService.addElement(newElement, parent);
+    this.dragDropService.constrainToParent(newElement);
     this.elementService.selectElement(newElement);
   }
 

--- a/src/app/services/drag-drop.ts
+++ b/src/app/services/drag-drop.ts
@@ -76,8 +76,21 @@ export class DragDropService {
       this.resolveLocalPosition(targetLayout, dropX, dropY, canvasElement)
     );
     this.elementService.updateElementProperties(newElement, position, { recordHistory: false });
+    this.constrainToParent(newElement);
     this.elementService.selectElement(newElement);
     return newElement;
+  }
+
+  /**
+   * Shrinks an element so it cannot overflow its parent. Used after a drop
+   * or a toolbox click that targets a smaller layout.
+   */
+  constrainToParent(element: MauiElement): void {
+    const patch = this.layoutDesigner.clampToParent(element);
+    if (Object.keys(patch).length === 0) {
+      return;
+    }
+    this.elementService.updateElementProperties(element, patch, { recordHistory: false });
   }
 
   /**
@@ -149,6 +162,8 @@ export class DragDropService {
       // Just update position if same parent
       this.elementService.updateElementProperties(element, { x: position.x, y: position.y });
     }
+
+    this.constrainToParent(element);
   }
 
   showDragPreview(x: number, y: number): void {

--- a/src/app/services/element.service.spec.ts
+++ b/src/app/services/element.service.spec.ts
@@ -184,5 +184,22 @@ describe('ElementService', () => {
       service.addElement(second, service.getRootElement());
       expect(service.canReorderSelection()).toBe(true);
     });
+
+    it('reorders siblings with the CDK drop-list index convention', () => {
+      const labels = addLabels(3);
+      const root = service.getRootElement();
+
+      expect(service.reorderChild(root, 0, 2)).toBe(true);
+      expect(root.children.map(child => child.id)).toEqual([labels[1].id, labels[2].id, labels[0].id]);
+    });
+
+    it('moves a sibling one slot at a time', () => {
+      const labels = addLabels(2);
+      const root = service.getRootElement();
+
+      expect(service.moveSibling(labels[0], 1)).toBe(true);
+      expect(root.children.map(child => child.id)).toEqual([labels[1].id, labels[0].id]);
+      expect(service.moveSibling(labels[0], 1)).toBe(false);
+    });
   });
 });

--- a/src/app/services/element.ts
+++ b/src/app/services/element.ts
@@ -672,6 +672,66 @@ export class ElementService {
     this.elementsSubject.next(this.rootElement);
   }
 
+  /**
+   * Reorders a child among its siblings.
+   *
+   * `toIndex` is the destination index after the move (CDK `moveItemInArray`
+   * / drop-list `currentIndex`).
+   */
+  reorderChild(parent: MauiElement, fromIndex: number, toIndex: number): boolean {
+    const children = parent.children;
+    if (fromIndex === toIndex) {
+      return false;
+    }
+    if (fromIndex < 0 || toIndex < 0 || fromIndex >= children.length || toIndex >= children.length) {
+      return false;
+    }
+
+    this.pushHistory();
+    const [item] = children.splice(fromIndex, 1);
+    children.splice(toIndex, 0, item);
+    this.elementsSubject.next(this.rootElement);
+    return true;
+  }
+
+  /** Moves an element one slot among its siblings. */
+  moveSibling(element: MauiElement, delta: -1 | 1): boolean {
+    const live = this.findElementById(element.id) ?? element;
+    if (live === this.rootElement) {
+      return false;
+    }
+    const parent = this.findOwningParent(live);
+    if (!parent) {
+      return false;
+    }
+    const from = parent.children.indexOf(live);
+    const to = from + delta;
+    if (from < 0 || to < 0 || to >= parent.children.length) {
+      return false;
+    }
+    return this.reorderChild(parent, from, to);
+  }
+
+  /** The parent whose `children` array actually contains the element. */
+  private findOwningParent(element: MauiElement): MauiElement | null {
+    if (element.parent?.children.includes(element)) {
+      return element.parent;
+    }
+    const walk = (node: MauiElement): MauiElement | null => {
+      if (node.children.includes(element)) {
+        return node;
+      }
+      for (const child of node.children) {
+        const found = walk(child);
+        if (found) {
+          return found;
+        }
+      }
+      return null;
+    };
+    return walk(this.rootElement);
+  }
+
   getRootElement(): MauiElement {
     return this.rootElement;
   }

--- a/src/app/services/layout-designer.service.spec.ts
+++ b/src/app/services/layout-designer.service.spec.ts
@@ -234,3 +234,69 @@ describe('LayoutDesignerService grid tracks', () => {
     expect(service.selfAlignment(undefined)).toBe('stretch');
   });
 });
+
+describe('LayoutDesignerService fit and clamp', () => {
+  let service: LayoutDesignerService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LayoutDesignerService);
+  });
+
+  function absolute(width: number, height: number): MauiElement {
+    return {
+      id: 'parent',
+      type: ElementType.AbsoluteLayout,
+      properties: { width, height },
+      children: []
+    } as unknown as MauiElement;
+  }
+
+  function child(parent: MauiElement, properties: MauiElement['properties']): MauiElement {
+    const element = {
+      id: 'child',
+      type: ElementType.Button,
+      parent,
+      properties,
+      children: []
+    } as unknown as MauiElement;
+    parent.children.push(element);
+    return element;
+  }
+
+  it('fits an AbsoluteLayout child to the parent and snaps it to the origin', () => {
+    const parent = absolute(800, 600);
+    const button = child(parent, { x: 40, y: 20, width: 100, height: 30 });
+
+    expect(service.fitToParent(button, 'width')).toEqual({ width: 800, x: 0 });
+    expect(service.fitToParent(button, 'height')).toEqual({ height: 600, y: 0 });
+    expect(service.fitToParent(button, 'both')).toEqual({ width: 800, x: 0, height: 600, y: 0 });
+  });
+
+  it('clamps a dropped child so it cannot overflow the remaining parent space', () => {
+    const parent = absolute(80, 200);
+    const button = child(parent, { x: 20, y: 0, width: 120, height: 40 });
+
+    expect(service.clampToParent(button)).toEqual({ width: 60 });
+  });
+
+  it('clamps a grid child to the cells it spans', () => {
+    const grid = {
+      id: 'grid',
+      type: ElementType.Grid,
+      properties: {
+        width: 200,
+        height: 100,
+        gridDefinition: {
+          columns: [{ width: { value: 80, type: 'Absolute' } }, { width: { value: 1, type: 'Star' } }],
+          rows: [{ height: { value: 1, type: 'Star' } }]
+        }
+      },
+      children: []
+    } as unknown as MauiElement;
+    const button = child(grid, { column: 0, row: 0, width: 160, height: 200 });
+
+    expect(service.clampToParent(button)).toEqual({ width: 80, height: 100 });
+  });
+});

--- a/src/app/services/layout-designer.ts
+++ b/src/app/services/layout-designer.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType, GridDefinition, GridLength, GridLengthType, LayoutOptions } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties, GridDefinition, GridLength, GridLengthType, LayoutOptions } from '../models/maui-element';
+
+/** Smallest width or height a control may shrink to when fitting or clamping. */
+export const MIN_ELEMENT_SIZE = 20;
+
+export type FitAxis = 'width' | 'height' | 'both';
 
 export interface LayoutInfo {
   canHaveChildren: boolean;
@@ -422,6 +427,126 @@ export class LayoutDesignerService {
       return 1;
     }
     return Math.max(1, Math.min(Math.floor(span), Math.max(1, remaining)));
+  }
+
+  /**
+   * How much room a child may occupy inside its parent.
+   *
+   * Grid children are capped to the cells they span. Absolute and stack
+   * children are capped to the parent's WidthRequest/HeightRequest. Zero
+   * means the parent has no usable size (do not clamp that axis).
+   */
+  getAvailableSize(parent: MauiElement, child: MauiElement): { width: number; height: number } {
+    if (this.getLayoutInfo(parent.type).supportsGridPositioning) {
+      if (parent.domElement) {
+        const spanned = this.getGridChildMaxDimensions(child, parent, parent.domElement);
+        if (spanned) {
+          return { width: spanned.maxWidth, height: spanned.maxHeight };
+        }
+      }
+      const definition = parent.properties.gridDefinition || DEFAULT_GRID_DEFINITION;
+      const parentWidth = parent.properties.width || 0;
+      const parentHeight = parent.properties.height || 0;
+      const columnWidths = this.calculateGridSizes(definition.columns.map(column => column.width), parentWidth);
+      const rowHeights = this.calculateGridSizes(definition.rows.map(row => row.height), parentHeight);
+      const column = child.properties.column || 0;
+      const row = child.properties.row || 0;
+      const columnSpan = child.properties.columnSpan || 1;
+      const rowSpan = child.properties.rowSpan || 1;
+      let width = 0;
+      let height = 0;
+      for (let i = column; i < Math.min(column + columnSpan, columnWidths.length); i++) {
+        width += columnWidths[i];
+      }
+      for (let i = row; i < Math.min(row + rowSpan, rowHeights.length); i++) {
+        height += rowHeights[i];
+      }
+      return { width, height };
+    }
+
+    return {
+      width: parent.properties.width || 0,
+      height: parent.properties.height || 0
+    };
+  }
+
+  /**
+   * Stretches a child to its parent on the requested axis.
+   *
+   * AbsoluteLayout children also snap to the origin on that axis so the
+   * control actually fills the layout instead of overflowing past it.
+   * Grid and stack children pick Fill so CSS can stretch them too.
+   */
+  fitToParent(element: MauiElement, axis: FitAxis): Partial<ElementProperties> {
+    const parent = element.parent;
+    if (!parent) {
+      return {};
+    }
+
+    const size = this.getAvailableSize(parent, element);
+    const patch: Partial<ElementProperties> = {};
+    const fitWidth = axis === 'width' || axis === 'both';
+    const fitHeight = axis === 'height' || axis === 'both';
+    const absolute = this.getLayoutInfo(parent.type).supportsAbsolutePositioning;
+    const flow = parent.type === ElementType.Grid
+      || parent.type === ElementType.StackLayout
+      || parent.type === ElementType.VerticalStackLayout;
+
+    if (fitWidth && size.width > 0) {
+      patch.width = Math.max(MIN_ELEMENT_SIZE, Math.round(size.width));
+      if (absolute) {
+        patch.x = 0;
+      }
+      if (flow) {
+        patch.horizontalOptions = 'Fill';
+      }
+    }
+    if (fitHeight && size.height > 0) {
+      patch.height = Math.max(MIN_ELEMENT_SIZE, Math.round(size.height));
+      if (absolute) {
+        patch.y = 0;
+      }
+      if (flow) {
+        patch.verticalOptions = 'Fill';
+      }
+    }
+    return patch;
+  }
+
+  /**
+   * Caps a child's width/height so it cannot overflow its parent.
+   *
+   * In AbsoluteLayout the remaining space after x/y is what counts, so a
+   * 100-wide button dropped at x=40 into an 80-wide panel becomes 40 wide.
+   */
+  clampToParent(element: MauiElement): Partial<ElementProperties> {
+    const parent = element.parent;
+    if (!parent) {
+      return {};
+    }
+
+    const size = this.getAvailableSize(parent, element);
+    let maxWidth = size.width;
+    let maxHeight = size.height;
+    if (this.getLayoutInfo(parent.type).supportsAbsolutePositioning) {
+      if (size.width > 0) {
+        maxWidth = Math.max(MIN_ELEMENT_SIZE, size.width - (element.properties.x || 0));
+      }
+      if (size.height > 0) {
+        maxHeight = Math.max(MIN_ELEMENT_SIZE, size.height - (element.properties.y || 0));
+      }
+    }
+
+    const patch: Partial<ElementProperties> = {};
+    const width = element.properties.width ?? 0;
+    const height = element.properties.height ?? 0;
+    if (maxWidth > 0 && width > maxWidth) {
+      patch.width = Math.round(maxWidth);
+    }
+    if (maxHeight > 0 && height > maxHeight) {
+      patch.height = Math.round(maxHeight);
+    }
+    return patch;
   }
 
   /** Maps MAUI LayoutOptions onto CSS justify-self / align-self. */


### PR DESCRIPTION
## Why

#105 was merged into `fix/grid-layout` *after* that branch had already been squash-merged to `main` as #104. The fit / clamp / hierarchy work never reached `main`.

This is the same commit, rebased onto current `main`.

## What

- Double-click a resize handle to fit the parent (edge = that axis, corner = both)
- Toolbox add and canvas drop clamp size so a control cannot overflow its parent or grid cell
- Hierarchy reorder with up/down, Alt+↑/↓, or drag-and-drop

## Tests

Previously **194/194** on this change set.