### PR TITLE
Fix Visual Studio hosting and complex XAML support

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -195,6 +195,7 @@ jobs:
 
           $expected = @(
             "[`$RootKey`$\Packages\$env:PACKAGE_GUID]",
+            '"CodeBase"="$PackageFolder$\MauiDesigner.Vsix.dll"',
             "[`$RootKey`$\Editors\$env:EDITOR_FACTORY_GUID]",
             "[`$RootKey`$\Editors\$env:EDITOR_FACTORY_GUID\Extensions]",
             '"xaml"=dword:00000010',

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,6 @@ Thumbs.db
 [Oo]bj/
 *.user
 *.vsix
+!extension/src/MauiDesigner.Vsix/
+/extension/src/MauiDesigner.Vsix/LICENSE.txt
 .vs/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MAUI Designer - Angular
 
+**Buy me a coffee!**
+
+[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.me/gmprakhar)
+
 A powerful web-based visual designer for creating MAUI (Microsoft App UI) layouts with drag-and-drop functionality. This Angular application provides an intuitive interface for designing XAML-based user interfaces with real-time preview capabilities.
 
 **Live demo:** https://gmprakhar.github.io/MAUI-Designer/ (deployed to GitHub Pages from `main`)

--- a/e2e/complex-xaml.spec.ts
+++ b/e2e/complex-xaml.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { DesignerPage } from './helpers/designer-page';
+
+// Adapted from the MIT-licensed dotnet/maui EntryPage.xaml:
+// https://github.com/dotnet/maui/blob/d2edf1972d09f6689a4621ba9ff42346ced6f1b1/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+const COMPLEX_ENTRY_PAGE = `<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels"
+    x:Class="Maui.Controls.Sample.Pages.EntryPage"
+    Title="Entry">
+  <views:BasePage.Resources>
+    <ResourceDictionary>
+      <Style x:Key="EntryVisualStatesStyle" TargetType="Entry">
+        <Setter Property="VisualStateManager.VisualStateGroups">
+          <VisualStateGroupList>
+            <VisualStateGroup x:Name="CommonStates">
+              <VisualState x:Name="Focused">
+                <VisualState.Setters>
+                  <Setter Property="BackgroundColor" Value="Yellow" />
+                </VisualState.Setters>
+              </VisualState>
+            </VisualStateGroup>
+          </VisualStateGroupList>
+        </Setter>
+      </Style>
+    </ResourceDictionary>
+  </views:BasePage.Resources>
+  <views:BasePage.BindingContext>
+    <viewmodels:EntryViewModel />
+  </views:BasePage.BindingContext>
+  <views:BasePage.Content>
+    <ScrollView>
+      <VerticalStackLayout Padding="12">
+        <Label Text="Password" Style="{StaticResource Headline}" />
+        <Entry Text="Disabled" IsEnabled="False" />
+        <HorizontalStackLayout>
+          <CheckBox x:Name="chkIsPassword" IsChecked="true" />
+          <Label Text="Is Password" VerticalOptions="Center" />
+        </HorizontalStackLayout>
+        <Entry IsPassword="{Binding IsChecked, Source={Reference chkIsPassword}}" />
+        <Entry Text="Background">
+          <Entry.Background>
+            <LinearGradientBrush EndPoint="1,0">
+              <GradientStop Color="Yellow" Offset="0.1" />
+              <GradientStop Color="Green" Offset="1.0" />
+            </LinearGradientBrush>
+          </Entry.Background>
+        </Entry>
+        <controls:TransparentEntry />
+        <HorizontalStackLayout>
+          <Label Text="CursorPosition = 4" />
+          <Slider x:Name="sldCursorPosition" WidthRequest="100" />
+        </HorizontalStackLayout>
+      </VerticalStackLayout>
+    </ScrollView>
+  </views:BasePage.Content>
+</views:BasePage>`;
+
+test('renders and preserves a complex official MAUI page', async ({ page }) => {
+  const designer = new DesignerPage(page);
+  await designer.goto();
+  await page.locator('#device-select').selectOption('phone');
+  await designer.applyXaml(COMPLEX_ENTRY_PAGE);
+
+  await expect(designer.xamlStatus).toContainText('applied successfully');
+  await expect(designer.canvasElements('ScrollView')).toHaveCount(1);
+  await expect(designer.canvasElements('VerticalStackLayout')).toHaveCount(1);
+  await expect(designer.canvasElements('StackLayout')).toHaveCount(2);
+  await expect(designer.canvasElements('Label')).toHaveCount(3);
+  await expect(designer.canvasElements('Entry')).toHaveCount(3);
+  await expect(designer.canvasElements('CheckBox')).toHaveCount(1);
+  await expect(designer.canvasElements('Slider')).toHaveCount(1);
+  await expect(designer.canvasElements('ScrollView')).toHaveCSS('width', '390px');
+  await expect(designer.canvasElements('ScrollView')).toHaveCSS('height', '844px');
+  await expect(designer.canvasElements('VerticalStackLayout')).toHaveCSS('width', '388px');
+
+  const horizontalStacks = designer.canvasElements('StackLayout');
+  await expect(horizontalStacks.locator('.element-stack-layout')).toHaveCount(2);
+  expect(await horizontalStacks.locator('.element-stack-layout')
+    .evaluateAll(elements => elements.map(element => element.getAttribute('data-orientation'))))
+    .toEqual(['Horizontal', 'Horizontal']);
+  await expect(designer.canvasElements('CheckBox').locator('.material-icons')).toHaveText('check_box');
+
+  const disabledEntry = designer.canvasElements('Entry').nth(0);
+  await expect(disabledEntry).toHaveAttribute('data-enabled', 'false');
+  await expect(disabledEntry.locator('input')).toHaveValue('Disabled');
+  await expect(disabledEntry.locator('input')).toBeDisabled();
+
+  const gradientEntry = designer.canvasElements('Entry').nth(2);
+  await expect(gradientEntry.locator('input')).toHaveValue('Background');
+  await expect(gradientEntry).toHaveCSS(
+    'background-image',
+    'linear-gradient(90deg, rgb(255, 255, 0) 10%, rgb(0, 128, 0) 100%)'
+  );
+  await expect(designer.canvas.locator('[data-custom-tag="TransparentEntry"]')).toHaveCount(1);
+  await expect(designer.canvasElements('Slider')).toHaveCSS('width', '100px');
+
+  const roundTripped = await designer.getXaml();
+  expect(roundTripped).toContain('<views:BasePage');
+  expect(roundTripped).toContain('<views:BasePage.Resources>');
+  expect(roundTripped).toContain('<views:BasePage.BindingContext>');
+  expect(roundTripped).toContain('IsPassword="{Binding IsChecked, Source={Reference chkIsPassword}}"');
+  expect(roundTripped).toContain('<LinearGradientBrush EndPoint="1,0">');
+  expect(roundTripped).toContain('<controls:TransparentEntry');
+});

--- a/e2e/ide-host.spec.ts
+++ b/e2e/ide-host.spec.ts
@@ -12,14 +12,14 @@ import { DesignerPage } from './helpers/designer-page';
 async function hostAsVisualStudio(page: Page) {
   await page.addInitScript(() => {
     const outbound: unknown[] = [];
-    (window as any).__hostMessages = outbound;
-    (window as any).chrome = {
-      webview: {
-        postMessage: (message: string) => outbound.push(JSON.parse(message))
-      }
+    const webview = new EventTarget() as EventTarget & {
+      postMessage(message: string): void;
     };
+    webview.postMessage = (message: string) => outbound.push(JSON.parse(message));
+    (window as any).__hostMessages = outbound;
+    (window as any).chrome = { webview };
     (window as any).__sendToDesigner = (message: unknown) => {
-      window.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(message) }));
+      webview.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(message) }));
     };
   });
 }
@@ -42,6 +42,9 @@ test.describe('IDE host integration', () => {
     await expect
       .poll(async () => (await outbound(page)).map(m => m.type))
       .toContain('designer.ready');
+
+    await expect(page.getByText('XAML Editor', { exact: true })).toHaveCount(0);
+    expect((await outbound(page)).map(m => m.type)).not.toContain('document.changed');
 
     await sendToDesigner(page, { type: 'host.ready', host: 'visual-studio', fileName: 'MainPage.xaml' });
 
@@ -67,8 +70,8 @@ test.describe('IDE host integration', () => {
 </ContentPage>`
     });
 
-    await designer.expectXamlToContain('Hosted label');
     await expect(designer.canvas.locator('[data-element-type="Label"]')).toHaveCount(1);
+    await expect(designer.canvas.getByText('Hosted label')).toBeVisible();
   });
 
   test('streams every edit back to the host', async ({ page }) => {
@@ -76,6 +79,11 @@ test.describe('IDE host integration', () => {
     const designer = new DesignerPage(page);
     await designer.goto();
 
+    await sendToDesigner(page, {
+      type: 'document.load',
+      fileName: 'MainPage.xaml',
+      xaml: '<ContentPage><AbsoluteLayout /></ContentPage>'
+    });
     await designer.addControl('Button');
 
     await expect

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerPane.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using MauiDesigner.Core.Manifests;
@@ -8,8 +9,11 @@ using MauiDesigner.Core.Protocol;
 using MauiDesigner.Vsix.Projects;
 
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
 
@@ -26,6 +30,8 @@ namespace MauiDesigner.Vsix
         private readonly IVsHierarchy _hierarchy;
         private readonly DesignerControl _control;
         private readonly DesignerSession _session;
+        private ITextBuffer? _textBuffer;
+        private CancellationTokenSource? _bufferReloadCancellation;
 
         /// <summary>
         /// Taken from the package rather than <see cref="ThreadHelper"/>, whose
@@ -36,6 +42,7 @@ namespace MauiDesigner.Vsix
         private readonly JoinableTaskFactory _joinableTaskFactory;
 
         private bool _applyingDesignerEdit;
+        private bool _disposed;
 
         public DesignerPane(
             AsyncPackage package,
@@ -72,18 +79,58 @@ namespace MauiDesigner.Vsix
         {
             base.Initialize();
 
-            _joinableTaskFactory.RunAsync(() => _control.InitializeAsync(WebAssetLocator.WebRootDirectory))
-                .FileAndForget("vs/mauidesigner/initialize");
+            _joinableTaskFactory.RunAsync(async () =>
+            {
+                await _control.InitializeAsync(WebAssetLocator.WebRootDirectory);
+                await _joinableTaskFactory.SwitchToMainThreadAsync();
+                if (_disposed)
+                {
+                    return;
+                }
+
+                SubscribeToBufferChanges();
+                _session.OpenDocument(ReadBuffer(), _documentMoniker);
+            }).FileAndForget("vs/mauidesigner/initialize");
 
             ThreadHelper.ThrowIfNotOnUIThread();
             _session.OpenDocument(ReadBuffer(), _documentMoniker);
         }
 
+        private void SubscribeToBufferChanges()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_textBuffer is not null)
+            {
+                return;
+            }
+
+            var componentModel = GetService(typeof(SComponentModel)) as IComponentModel
+                ?? throw new InvalidOperationException("Visual Studio's component model is unavailable.");
+            var adapters = componentModel.GetService<IVsEditorAdaptersFactoryService>()
+                ?? throw new InvalidOperationException("Visual Studio's editor adapter service is unavailable.");
+
+            _textBuffer = adapters.GetDataBuffer(_textLines)
+                ?? throw new InvalidOperationException("The XAML document has no shared text buffer.");
+            _textBuffer.Changed += OnTextBufferChanged;
+        }
+
         private void OnDesignerEdited(object sender, DocumentChangedEventArgs args)
         {
+            if (Volatile.Read(ref _bufferReloadCancellation) is not null)
+            {
+                return;
+            }
+
             _joinableTaskFactory.RunAsync(async () =>
             {
                 await _joinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (_bufferReloadCancellation is not null)
+                {
+                    return;
+                }
+
                 WriteBuffer(args.Xaml);
             }).FileAndForget("vs/mauidesigner/documentchanged");
         }
@@ -182,6 +229,41 @@ namespace MauiDesigner.Vsix
             }
         }
 
+        private void OnTextBufferChanged(object sender, TextContentChangedEventArgs args)
+        {
+            if (_applyingDesignerEdit || _disposed)
+            {
+                return;
+            }
+
+            var xaml = args.After.GetText();
+            var cancellation = new CancellationTokenSource();
+            var previous = Interlocked.Exchange(ref _bufferReloadCancellation, cancellation);
+            previous?.Cancel();
+
+            _joinableTaskFactory.RunAsync(async () =>
+            {
+                try
+                {
+                    await Task.Delay(250, cancellation.Token);
+                    await _joinableTaskFactory.SwitchToMainThreadAsync(cancellation.Token);
+
+                    if (!_applyingDesignerEdit && !_disposed)
+                    {
+                        _session.OpenDocument(xaml, _documentMoniker);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                {
+                }
+                finally
+                {
+                    Interlocked.CompareExchange(ref _bufferReloadCancellation, null, cancellation);
+                    cancellation.Dispose();
+                }
+            }).FileAndForget("vs/mauidesigner/bufferchanged");
+        }
+
         private void WriteToOutput(string message)
         {
             _joinableTaskFactory.RunAsync(async () =>
@@ -198,8 +280,22 @@ namespace MauiDesigner.Vsix
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (disposing)
             {
+                _disposed = true;
+
+                var cancellation = Interlocked.Exchange(ref _bufferReloadCancellation, null);
+                cancellation?.Cancel();
+                cancellation?.Dispose();
+
+                if (_textBuffer is not null)
+                {
+                    _textBuffer.Changed -= OnTextBufferChanged;
+                    _textBuffer = null;
+                }
+
                 _control.Dispose();
             }
 

--- a/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
+++ b/extension/src/MauiDesigner.Vsix/MauiDesigner.Vsix.csproj
@@ -18,7 +18,9 @@
     <AssemblyName>MauiDesigner.Vsix</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <UseCodeBase>true</UseCodeBase>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
@@ -77,6 +79,11 @@
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
+    <EmbeddedResource Include="VsPackage.resx">
+      <SubType>Designer</SubType>
+      <MergeWithCTO>true</MergeWithCTO>
+      <ManifestResourceName>VSPackage</ManifestResourceName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!--

--- a/extension/src/MauiDesigner.Vsix/VsPackage.resx
+++ b/extension/src/MauiDesigner.Vsix/VsPackage.resx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="110" xml:space="preserve">
+    <value>MAUI Designer</value>
+    <comment>Editor name shown in Visual Studio's Open With dialog.</comment>
+  </data>
+</root>

--- a/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
@@ -89,6 +89,51 @@ namespace MauiDesigner.Core.Tests
         }
 
         [Fact]
+        public void Every_registered_editor_name_has_a_managed_string_resource()
+        {
+            var package = _extension.GetType(PackageTypeName, throwOnError: true)!;
+            var factoryRegistration = Attribute(package, "ProvideEditorFactoryAttribute");
+            var extensionRegistration = Attribute(package, "ProvideEditorExtensionAttribute");
+            var projectDirectory = Path.Combine(ExtensionDirectory(), "src", "MauiDesigner.Vsix");
+            var project = XDocument.Load(Path.Combine(projectDirectory, "MauiDesigner.Vsix.csproj"));
+            var useCodeBase = project.Descendants()
+                .Single(element => element.Name.LocalName == "UseCodeBase")
+                .Value;
+            var resourceItem = project.Descendants()
+                .Single(element => element.Name.LocalName == "EmbeddedResource"
+                                   && element.Attribute("Include")?.Value == "VsPackage.resx");
+
+            Assert.Equal("true", useCodeBase);
+            Assert.Equal(
+                "VSPackage",
+                resourceItem.Elements().Single(element => element.Name.LocalName == "ManifestResourceName").Value);
+            Assert.Equal(
+                "true",
+                resourceItem.Elements().Single(element => element.Name.LocalName == "MergeWithCTO").Value);
+
+            var referencedIds = new[]
+            {
+                Convert.ToInt32(factoryRegistration.ConstructorArguments[1].Value),
+                Convert.ToInt32(extensionRegistration.NamedArguments
+                    .Single(argument => argument.MemberName == "NameResourceID")
+                    .TypedValue.Value)
+            };
+
+            var resources = XDocument.Load(
+                    Path.Combine(projectDirectory, "VsPackage.resx"))
+                .Root!
+                .Elements("data")
+                .Select(element => element.Attribute("name")?.Value)
+                .Where(name => name is not null)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var resourceId in referencedIds)
+            {
+                Assert.Contains(resourceId.ToString(), resources);
+            }
+        }
+
+        [Fact]
         public void The_built_in_xaml_editor_keeps_priority()
         {
             var package = _extension.GetType(PackageTypeName, throwOnError: true)!;
@@ -131,6 +176,16 @@ namespace MauiDesigner.Core.Tests
             Assert.Contains(
                 factory.GetInterfaces(),
                 candidate => candidate.FullName == "Microsoft.VisualStudio.Shell.Interop.IVsEditorFactory");
+        }
+
+        [Fact]
+        public void The_designer_pane_tracks_the_shared_text_buffer()
+        {
+            var pane = _extension.GetType("MauiDesigner.Vsix.DesignerPane", throwOnError: true)!;
+
+            Assert.Contains(
+                pane.GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+                field => field.FieldType.FullName == "Microsoft.VisualStudio.Text.ITextBuffer");
         }
 
         [Fact]

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -121,11 +121,14 @@
   </div>
   
   <!-- Bottom Resize Handle -->
-  <div class="resize-handle vertical" 
+  <div *ngIf="!isHosted"
+       class="resize-handle vertical"
        (mousedown)="onResizeStart($event, 'bottom')"></div>
   
   <!-- Bottom Panel -->
-  <div class="bottom-panel" [style.height.px]="bottomPanelHeight">
+  <div *ngIf="!isHosted"
+       class="bottom-panel"
+       [style.height.px]="bottomPanelHeight">
     <div class="panel-tabs">
       <button 
         class="tab-button" 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -56,6 +56,7 @@ export class App implements OnInit, OnDestroy {
 
   private toastTimeout: any;
   private subscription = new Subscription();
+  private hostDocumentLoaded = false;
 
   // Resize state
   private isResizing = false;
@@ -116,16 +117,21 @@ export class App implements OnInit, OnDestroy {
     // Every change flows back so the host can keep the document in sync
     this.subscription.add(
       this.elementService.elements$.subscribe(root => {
-        this.hostBridge.notifyChanged(this.xamlGenerator.generateXaml(root));
+        if (this.hostDocumentLoaded) {
+          this.hostBridge.notifyChanged(this.xamlGenerator.generateXaml(root));
+        }
       })
     );
 
     this.subscription.add(this.hostBridge.fileName$.subscribe(name => (this.hostFileName = name)));
+    this.hostBridge.start();
   }
 
   private loadFromHost(xaml: string) {
+    this.hostDocumentLoaded = false;
     try {
       this.elementService.setRootElement(this.xamlParser.parseXaml(xaml));
+      this.hostDocumentLoaded = true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.hostBridge.reportError(message);

--- a/src/app/components/designer-canvas/designer-canvas.html
+++ b/src/app/components/designer-canvas/designer-canvas.html
@@ -91,12 +91,16 @@
     [class.selected]="isSelected(element)"
     [class.layout-element]="isLayoutElement(element)"
     [class.root-element]="element.id === 'root'"
+    [class.element-disabled]="element.properties.isEnabled === false"
+    [class.element-not-visible]="element.properties.isVisible === false"
     [style]="getElementStyles(element)"
     [attr.data-element-id]="element.id"
     [attr.data-element-type]="element.type"
     [attr.data-element-name]="element.name"
     [attr.data-custom-tag]="element.properties.customTag"
     [attr.data-selected]="isSelected(element)"
+    [attr.data-enabled]="element.properties.isEnabled !== false"
+    [attr.data-visible]="element.properties.isVisible !== false"
     cdkDrag
     [cdkDragDisabled]="!isPrimarySelection(element) || element.id === 'root'"
     (cdkDragStarted)="onDragStarted(element); setElementRef(element, elementDiv)"
@@ -119,7 +123,8 @@
       </span>
       
       <!-- Button -->
-      <button *ngSwitchCase="'Button'" class="element-button" type="button">
+      <button *ngSwitchCase="'Button'" class="element-button" type="button"
+              [disabled]="element.properties.isEnabled === false">
         {{ element.properties.text || 'Button' }}
       </button>
       
@@ -129,6 +134,7 @@
              type="text" 
              [value]="element.properties.text || ''"
              [attr.placeholder]="element.properties.placeholder || 'Enter text'"
+             [disabled]="element.properties.isEnabled === false"
              readonly>
       
       <!-- Editor -->
@@ -136,6 +142,7 @@
                 class="element-textarea"
                 [value]="element.properties.text || ''"
                 [attr.placeholder]="element.properties.placeholder || 'Enter text'"
+                [disabled]="element.properties.isEnabled === false"
                 readonly>
       </textarea>
 

--- a/src/app/components/designer-canvas/designer-canvas.scss
+++ b/src/app/components/designer-canvas/designer-canvas.scss
@@ -320,12 +320,13 @@
   }
 
   .element-scroll-view {
-    .element-stack-layout,
-    .element-vertical-stack-layout,
-    .element-grid,
-    .element-absolute-layout,
-    .element-scroll-view {
-      overflow: auto !important;
+    overflow: auto;
+
+    > .element-stack-layout,
+    > .element-vertical-stack-layout,
+    > .element-grid,
+    > .element-absolute-layout {
+      overflow: visible !important;
     }
   }
 
@@ -581,6 +582,18 @@
 // --- Additional control previews ---------------------------------------------
 
 .canvas-element {
+  &.element-disabled {
+    opacity: 0.55;
+    filter: grayscale(0.35);
+  }
+
+  // Hidden controls remain selectable on a design surface, but are ghosted so
+  // the preview still communicates their runtime visibility.
+  &.element-not-visible {
+    opacity: 0.25;
+    outline: 1px dashed #64748b;
+  }
+
   .element-search-bar,
   .element-date-picker {
     display: flex;

--- a/src/app/components/designer-canvas/designer-canvas.ts
+++ b/src/app/components/designer-canvas/designer-canvas.ts
@@ -104,8 +104,14 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
 
     this.subscription.add(
       this.elementService.elements$.subscribe(root => {
-        this.designWidth = root.properties.width || 800;
-        this.designHeight = root.properties.height || 600;
+        const document = root.properties.document;
+        const device = this.viewportService.getDevice(this.viewport.deviceId);
+        this.designWidth = document && !document.contentWidthExplicit
+          ? device?.width || 800
+          : root.properties.width || 800;
+        this.designHeight = document && !document.contentHeightExplicit
+          ? device?.height || 600
+          : root.properties.height || 600;
         this.rebuildRulers();
       })
     );
@@ -547,6 +553,11 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
       styles.height = this.fillsAxis(props.verticalOptions) ? '100%' : (props.height || 0) + 'px';
       styles.minWidth = (props.width || 0) + 'px';
       styles.minHeight = (props.height || 0) + 'px';
+    } else if (element.parent?.type === ElementType.ScrollView) {
+      styles.transform = 'none';
+      styles.width = '100%';
+      styles.height = 'max-content';
+      styles.minHeight = '100%';
     } else if (this.isStackParent(element.parent)) {
       styles.transform = 'none';
       const vertical = element.parent!.type === ElementType.VerticalStackLayout
@@ -572,6 +583,9 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     if (background) {
       styles.backgroundColor = background;
     }
+    if (props.backgroundGradient) {
+      styles.backgroundImage = props.backgroundGradient;
+    }
 
     const text = this.themedColor(element, 'TextColor', props.textColor);
     if (text) {
@@ -590,6 +604,12 @@ export class DesignerCanvasComponent implements OnInit, OnDestroy {
     if (props.padding) {
       const p = props.padding;
       styles.padding = `${p.top}px ${p.right}px ${p.bottom}px ${p.left}px`;
+    }
+
+    if (element.id === 'root') {
+      styles.transform = 'none';
+      styles.width = '100%';
+      styles.height = '100%';
     }
 
     return styles;

--- a/src/app/models/maui-element.ts
+++ b/src/app/models/maui-element.ts
@@ -55,6 +55,8 @@ export interface ElementProperties {
   
   // Visual properties
   backgroundColor?: string;
+  /** CSS preview generated from a MAUI LinearGradientBrush property element. */
+  backgroundGradient?: string;
   textColor?: string;
   fontSize?: number;
   fontFamily?: string;
@@ -113,6 +115,9 @@ export interface ElementProperties {
   /** Property elements of a custom control (e.g. Expander.Header), kept as XML. */
   rawContentXml?: string[];
 
+  /** Original page wrapper and non-visual property elements retained on import. */
+  document?: XamlDocumentMetadata;
+
   // Other properties
   isVisible?: boolean;
   isEnabled?: boolean;
@@ -136,6 +141,18 @@ export interface ElementProperties {
    * BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}".
    */
   appTheme?: Record<string, AppThemeColor>;
+}
+
+export interface XamlDocumentMetadata {
+  rootTag: string;
+  defaultNamespace?: string;
+  namespaces: Record<string, string>;
+  attributes: Record<string, string>;
+  contentPropertyTag?: string;
+  contentWidthExplicit: boolean;
+  contentHeightExplicit: boolean;
+  rawBeforeContent: string[];
+  rawAfterContent: string[];
 }
 
 /** Light and dark values for a single colour property. */

--- a/src/app/services/host-bridge.spec.ts
+++ b/src/app/services/host-bridge.spec.ts
@@ -12,6 +12,11 @@ describe('HostBridgeService', () => {
   });
 
   function create(): HostBridgeService {
+    const webview = (window as any).chrome?.webview;
+    if (webview && typeof webview.addEventListener !== 'function') {
+      webview.addEventListener = window.addEventListener.bind(window);
+    }
+
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({});
     return TestBed.inject(HostBridgeService);
@@ -49,7 +54,10 @@ describe('HostBridgeService', () => {
 
     expect(service.host).toBe('visual-studio');
     expect(service.isHosted).toBeTrue();
-    // The designer announces itself as soon as it is hosted
+    expect(posted).toEqual([]);
+
+    service.start();
+
     expect(posted).toEqual([JSON.stringify({ type: 'designer.ready' })]);
   });
 
@@ -58,6 +66,7 @@ describe('HostBridgeService', () => {
     (window as any).chrome = { webview: { postMessage: (m: string) => posted.push(m) } };
 
     const service = create();
+    service.start();
     service.save('<ContentPage />');
 
     expect(JSON.parse(posted[1])).toEqual({ type: 'document.save', xaml: '<ContentPage />' });
@@ -69,6 +78,7 @@ describe('HostBridgeService', () => {
     (window as any).acquireVsCodeApi = () => ({ postMessage: (m: unknown) => posted.push(m) });
 
     const service = create();
+    service.start();
     service.notifyChanged('<ContentPage />');
 
     expect(service.host).toBe('vscode');
@@ -92,6 +102,26 @@ describe('HostBridgeService', () => {
 
     expect(calls).toBe(1);
     expect(service.host).toBe('vscode');
+  });
+
+  it('subscribes before starting the host handshake', () => {
+    (window as any).chrome = {
+      webview: {
+        postMessage: (message: string) => {
+          if (JSON.parse(message).type === 'designer.ready') {
+            post({ type: 'document.load', xaml: '<ContentPage><Label /></ContentPage>' });
+          }
+        }
+      }
+    };
+    const service = create();
+    const received: HostInboundMessage[] = [];
+    service.messages$.subscribe(message => received.push(message));
+
+    service.start();
+    service.start();
+
+    expect(received.map(message => message.type)).toEqual(['document.load']);
   });
 
   it('forwards messages received from the host', () => {

--- a/src/app/services/host-bridge.ts
+++ b/src/app/services/host-bridge.ts
@@ -24,9 +24,14 @@ interface VsCodeApi {
   postMessage(message: unknown): void;
 }
 
+interface VisualStudioWebView {
+  postMessage(message: unknown): void;
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+}
+
 declare global {
   interface Window {
-    chrome?: { webview?: { postMessage(message: unknown): void } };
+    chrome?: { webview?: VisualStudioWebView };
     acquireVsCodeApi?: () => VsCodeApi;
   }
 }
@@ -47,6 +52,7 @@ export class HostBridgeService {
   private readonly messageSubject = new Subject<HostInboundMessage>();
   private readonly fileNameSubject = new BehaviorSubject<string | null>(null);
   private vsCodeApi: VsCodeApi | null = null;
+  private started = false;
 
   /** The host the designer is currently running in. */
   readonly host$: Observable<HostKind>;
@@ -59,9 +65,10 @@ export class HostBridgeService {
     this.hostSubject = new BehaviorSubject<HostKind>(this.detectHost());
     this.host$ = this.hostSubject.asObservable();
 
-    if (this.isHosted) {
+    if (this.host === 'visual-studio') {
+      window.chrome!.webview!.addEventListener('message', this.onWindowMessage);
+    } else if (this.host === 'vscode') {
       window.addEventListener('message', this.onWindowMessage);
-      this.send({ type: 'designer.ready' });
     }
   }
 
@@ -76,6 +83,16 @@ export class HostBridgeService {
 
   get fileName(): string | null {
     return this.fileNameSubject.value;
+  }
+
+  /** Starts the host handshake after consumers have subscribed to inbound messages. */
+  start(): void {
+    if (this.started || !this.isHosted) {
+      return;
+    }
+
+    this.started = true;
+    this.send({ type: 'designer.ready' });
   }
 
   /** Sends a message to the host. Does nothing in a plain browser. */
@@ -111,7 +128,7 @@ export class HostBridgeService {
     this.send({ type: 'designer.error', message });
   }
 
-  /** Entry point used by the hosts: both post a message event onto the window. */
+  /** Entry point for host messages from WebView2 or VS Code. */
   private readonly onWindowMessage = (event: MessageEvent) => {
     const message = this.parse(event.data);
     if (!message) {

--- a/src/app/services/xaml-generator.ts
+++ b/src/app/services/xaml-generator.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridLength, GridLengthType, Orientation } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridLength, GridLengthType, Orientation, XamlDocumentMetadata } from '../models/maui-element';
 
 @Injectable({
   providedIn: 'root'
@@ -10,35 +10,87 @@ export class XamlGeneratorService {
 
   generateXaml(rootElement: MauiElement): string {
     const xamlContent = this.generateElementXaml(rootElement, 0);
-    const namespaces = this.collectNamespaceDeclarations(rootElement);
+    const document = rootElement.properties.document;
+    const rootTag = document?.rootTag || 'ContentPage';
+    const defaultNamespace = document?.defaultNamespace || 'http://schemas.microsoft.com/dotnet/2021/maui';
+    const namespaces = this.collectNamespaceDeclarations(rootElement, document);
+    const rootAttributes = document
+      ? Object.entries(document.attributes)
+          .map(([name, value]) => `\n             ${name}="${this.escapeXml(value)}"`)
+          .join('')
+      : '\n             x:Class="YourApp.MainPage"';
+    const before = this.generateRawDocumentContent(document?.rawBeforeContent || []);
+    const after = this.generateRawDocumentContent(document?.rawAfterContent || []);
+    const content = document?.contentPropertyTag
+      ? `    <${document.contentPropertyTag}>\n${this.indent(xamlContent)}\n    </${document.contentPropertyTag}>`
+      : xamlContent;
 
     return `<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"${namespaces}
-             x:Class="YourApp.MainPage">
-${xamlContent}
-</ContentPage>`;
+<${rootTag} xmlns="${defaultNamespace}"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"${namespaces}${rootAttributes}>
+${before}${content}${after}
+</${rootTag}>`;
   }
 
-  /**
-   * Only the namespaces actually used by custom controls in the tree are
-   * declared, so the generated page stays clean.
-   */
-  private collectNamespaceDeclarations(rootElement: MauiElement): string {
-    const used = new Map<string, string>();
+  /** Only namespaces still referenced by retained markup are declared. */
+  private collectNamespaceDeclarations(rootElement: MauiElement, document?: XamlDocumentMetadata): string {
+    const elementNamespaces = new Map<string, string>();
+    const references = document
+      ? [
+        document.rootTag,
+        document.contentPropertyTag || '',
+        ...Object.keys(document.attributes),
+        ...Object.values(document.attributes),
+        ...document.rawBeforeContent,
+        ...document.rawAfterContent
+      ]
+      : [];
 
     const walk = (element: MauiElement) => {
-      const { customPrefix, customNamespace } = element.properties;
-      if (element.type === ElementType.Custom && customPrefix && customNamespace) {
-        used.set(customPrefix, customNamespace);
+      const {
+        customPrefix,
+        customNamespace,
+        rawAttributes,
+        customValues,
+        bindings,
+        rawContentXml
+      } = element.properties;
+      if (customPrefix && customNamespace) {
+        elementNamespaces.set(customPrefix, customNamespace);
       }
+      references.push(
+        customPrefix ? `${customPrefix}:` : '',
+        ...Object.keys(rawAttributes || {}),
+        ...Object.values(rawAttributes || {}),
+        ...Object.keys(customValues || {}),
+        ...Object.values(customValues || {}),
+        ...Object.keys(bindings || {}),
+        ...Object.values(bindings || {}),
+        ...(rawContentXml || [])
+      );
       element.children.forEach(walk);
     };
     walk(rootElement);
 
+    const retainedMarkup = references.join(' ');
+    const used = new Map<string, string>(
+      Object.entries(document?.namespaces || {}).filter(([prefix]) =>
+        prefix !== 'x' && retainedMarkup.includes(`${prefix}:`)
+      )
+    );
+    elementNamespaces.forEach((uri, prefix) => used.set(prefix, uri));
+
     return [...used.entries()]
       .map(([prefix, uri]) => `\n             xmlns:${prefix}="${uri}"`)
       .join('');
+  }
+
+  private generateRawDocumentContent(elements: string[]): string {
+    return elements.length ? elements.map(element => `    ${element}\n`).join('') : '';
+  }
+
+  private indent(xaml: string): string {
+    return xaml.split('\n').map(line => `    ${line}`).join('\n');
   }
 
   private generateElementXaml(element: MauiElement, indentLevel: number): string {
@@ -61,7 +113,7 @@ ${xamlContent}
       xaml += this.generateGridDefinitions(element, indentLevel + 1);
     }
 
-    // Property elements of custom controls are re-emitted verbatim
+    // Unmodelled property elements are re-emitted verbatim
     for (const raw of rawContent) {
       xaml += `\n${'    '.repeat(indentLevel + 2)}${raw}`;
     }

--- a/src/app/services/xaml-parser.ts
+++ b/src/app/services/xaml-parser.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA, AppThemeColor, LayoutOptions, LAYOUT_OPTIONS } from '../models/maui-element';
+import { MauiElement, ElementType, ElementProperties, Thickness, GridDefinition, GridRowDefinition, GridColumnDefinition, GridLength, GridLengthType, Orientation, DEFAULT_ICON_PATH_DATA, AppThemeColor, LayoutOptions, LAYOUT_OPTIONS, XamlDocumentMetadata } from '../models/maui-element';
 import { CustomControlRegistryService } from './custom-control-registry';
 
 /** Attributes the designer models itself, so they never end up in rawAttributes. */
@@ -64,7 +64,12 @@ export class XamlParserService {
         throw new Error('No valid layout element found. Please ensure your XAML contains a layout like AbsoluteLayout, Grid, or StackLayout.');
       }
       
-      return this.parseElement(rootLayoutElement, null);
+      const root = this.parseElement(rootLayoutElement, null);
+      root.id = 'root';
+      if (rootLayoutElement !== contentPage) {
+        root.properties.document = this.parseDocumentMetadata(contentPage, rootLayoutElement);
+      }
+      return root;
     } catch (error: any) {
       console.error('XAML parsing error:', error);
       throw error;
@@ -86,7 +91,58 @@ export class XamlParserService {
         return child;
       }
     }
+
+    // Custom ContentPage subclasses commonly wrap their visual tree in a
+    // `<prefix:Page.Content>` property element.
+    for (let i = 0; i < contentPage.children.length; i++) {
+      const child = contentPage.children[i];
+      if (child.tagName.toLowerCase().endsWith('.content')) {
+        const content = this.findRootLayoutElement(child);
+        if (content) {
+          return content;
+        }
+      }
+    }
     return null;
+  }
+
+  private parseDocumentMetadata(contentPage: Element, rootLayout: Element): XamlDocumentMetadata {
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < contentPage.attributes.length; i++) {
+      const attribute = contentPage.attributes[i];
+      if (attribute.name !== 'xmlns' && !attribute.name.startsWith('xmlns:')) {
+        attributes[attribute.name] = attribute.value;
+      }
+    }
+
+    let contentContainer = rootLayout;
+    while (contentContainer.parentElement && contentContainer.parentElement !== contentPage) {
+      contentContainer = contentContainer.parentElement;
+    }
+
+    const before: string[] = [];
+    const after: string[] = [];
+    let foundContent = false;
+    for (let i = 0; i < contentPage.children.length; i++) {
+      const child = contentPage.children[i];
+      if (child === contentContainer) {
+        foundContent = true;
+        continue;
+      }
+      (foundContent ? after : before).push(this.serializeRetainedElement(child));
+    }
+
+    return {
+      rootTag: contentPage.tagName,
+      defaultNamespace: contentPage.getAttribute('xmlns') || undefined,
+      namespaces: this.collectNamespaces(contentPage),
+      attributes,
+      contentPropertyTag: contentContainer.tagName.includes('.') ? contentContainer.tagName : undefined,
+      contentWidthExplicit: rootLayout.hasAttribute('WidthRequest'),
+      contentHeightExplicit: rootLayout.hasAttribute('HeightRequest'),
+      rawBeforeContent: before,
+      rawAfterContent: after
+    };
   }
 
   private isLayoutType(type: ElementType | null): boolean {
@@ -116,12 +172,11 @@ export class XamlParserService {
       parent: parent || undefined
     };
 
-    // Property elements of a custom control cannot be modelled, so keep the XML
-    if (elementType === ElementType.Custom) {
-      const rawContent = this.collectRawPropertyElements(xmlElement);
-      if (rawContent.length) {
-        element.properties.rawContentXml = rawContent;
-      }
+    // Keep property elements the designer does not model so importing a brush,
+    // gesture recognizer, or third-party property cannot make the XAML lossy.
+    const rawContent = this.collectRawPropertyElements(xmlElement);
+    if (rawContent.length) {
+      element.properties.rawContentXml = rawContent;
     }
 
     // Parse child elements: unknown tags become custom elements, never dropped
@@ -408,18 +463,33 @@ export class XamlParserService {
 
   /** Serialises property elements such as `<toolkit:Expander.Header>` verbatim. */
   private collectRawPropertyElements(xmlElement: Element): string[] {
-    const serializer = new XMLSerializer();
     const raw: string[] = [];
 
     for (let i = 0; i < xmlElement.children.length; i++) {
       const child = xmlElement.children[i];
-      if (child.tagName.includes('.')) {
-        // The serializer repeats every namespace: they are declared on the page
-        raw.push(serializer.serializeToString(child).replace(/\s+xmlns(:[\w.-]+)?="[^"]*"/g, ''));
+      if (
+        child.tagName.includes('.') &&
+        !child.tagName.includes('.RowDefinitions') &&
+        !child.tagName.includes('.ColumnDefinitions') &&
+        !child.tagName.includes('.ItemTemplate')
+      ) {
+        raw.push(this.serializeRetainedElement(child));
       }
     }
 
     return raw;
+  }
+
+  private serializeRetainedElement(element: Element): string {
+    return new XMLSerializer()
+      .serializeToString(element)
+      .replace(
+        /\s+xmlns(?::([\w.-]+))?="([^"]*)"/g,
+        (declaration, prefix: string | undefined, uri: string) => {
+          const rootUri = element.ownerDocument.documentElement.lookupNamespaceURI(prefix || null);
+          return rootUri === uri ? '' : declaration;
+        }
+      );
   }
 
   /** Reads `xmlns:prefix="uri"` declarations from the document root. */
@@ -445,7 +515,7 @@ export class XamlParserService {
 
     const prefix = rawPrefix;
     const tag = rawTag;
-    const uri = this.namespaces[prefix] || '';
+    const uri = xmlElement.lookupNamespaceURI(prefix || null) || this.namespaces[prefix] || '';
 
     const attributes: Record<string, string> = {};
     for (let i = 0; i < xmlElement.attributes.length; i++) {
@@ -601,6 +671,7 @@ export class XamlParserService {
 
     const backgroundColor = color('BackgroundColor');
     if (backgroundColor) properties.backgroundColor = backgroundColor;
+    properties.backgroundGradient = this.parseLinearGradient(xmlElement) || undefined;
 
     const textColor = color('TextColor');
     if (textColor) properties.textColor = textColor;
@@ -709,6 +780,37 @@ export class XamlParserService {
     return properties;
   }
 
+  private parseLinearGradient(xmlElement: Element): string | null {
+    const propertyElement = Array.from(xmlElement.children)
+      .find(child => child.tagName.endsWith('.Background'));
+    const brush = propertyElement?.querySelector('LinearGradientBrush');
+    if (!brush) {
+      return null;
+    }
+
+    const [startX, startY] = (brush.getAttribute('StartPoint') || '0,0')
+      .split(',')
+      .map(value => parseFloat(value.trim()));
+    const [endX, endY] = (brush.getAttribute('EndPoint') || '1,1')
+      .split(',')
+      .map(value => parseFloat(value.trim()));
+    const angle = [startX, startY, endX, endY].every(Number.isFinite)
+      ? Math.round(Math.atan2(endY - startY, endX - startX) * 180 / Math.PI + 90)
+      : 135;
+    const stops = Array.from(brush.querySelectorAll('GradientStop'))
+      .map(stop => {
+        const color = stop.getAttribute('Color');
+        const offset = parseFloat(stop.getAttribute('Offset') || '');
+        if (!color) {
+          return null;
+        }
+        return Number.isFinite(offset) ? `${color} ${offset * 100}%` : color;
+      })
+      .filter((stop): stop is string => stop !== null);
+
+    return stops.length ? `linear-gradient(${angle}deg, ${stops.join(', ')})` : null;
+  }
+
   /**
    * Attributes the designer never read are kept verbatim so importing XAML the tool
    * does not fully understand cannot silently delete markup on the next export.
@@ -759,9 +861,9 @@ export class XamlParserService {
       if (!this.isBindingExpression(attribute.value)) {
         continue;
       }
-      const match = /\{\s*Binding\s+([^},]*)/i.exec(attribute.value);
-      const path = (match?.[1] || '').trim();
-      bindings[attribute.name] = path.replace(/^Path\s*=\s*/i, '');
+      const match = /^\s*\{\s*Binding(?:\s+([\s\S]*?))?\s*\}\s*$/i.exec(attribute.value);
+      const expression = (match?.[1] || '.').trim();
+      bindings[attribute.name] = expression.replace(/^Path\s*=\s*/i, '');
     }
     return bindings;
   }

--- a/src/app/services/xaml-round-trip.spec.ts
+++ b/src/app/services/xaml-round-trip.spec.ts
@@ -143,5 +143,164 @@ describe('XAML round trip fidelity', () => {
       expect(reparsed.properties.horizontalOptions).toBe('Center');
       expect(reparsed.properties.verticalOptions).toBe('Fill');
     });
+
+    describe('real-world custom pages', () => {
+      // Adapted from dotnet/maui EntryPage.xaml at d2edf1972d09f6689a4621ba9ff42346ced6f1b1.
+      // The source is MIT licensed by the .NET Foundation and Contributors.
+      const entryPageExcerpt = `<views:BasePage
+      xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+      xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+      xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"
+      xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+      xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels"
+      x:Class="Maui.Controls.Sample.Pages.EntryPage"
+      Title="Entry">
+    <views:BasePage.Resources>
+      <ResourceDictionary>
+        <Style x:Key="EntryVisualStatesStyle" TargetType="Entry">
+          <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Focused">
+                  <VisualState.Setters>
+                    <Setter Property="BackgroundColor" Value="Yellow" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateGroupList>
+          </Setter>
+        </Style>
+      </ResourceDictionary>
+    </views:BasePage.Resources>
+    <views:BasePage.BindingContext>
+      <viewmodels:EntryViewModel />
+    </views:BasePage.BindingContext>
+    <views:BasePage.Content>
+      <ScrollView>
+        <VerticalStackLayout Padding="12">
+          <Label Text="Password" Style="{StaticResource Headline}" />
+          <HorizontalStackLayout>
+            <CheckBox x:Name="chkIsPassword" IsChecked="true" />
+            <Label Text="Is Password" VerticalOptions="Center" />
+          </HorizontalStackLayout>
+          <Entry IsPassword="{Binding IsChecked, Source={Reference chkIsPassword}}" />
+          <Entry Text="Background">
+            <Entry.Background>
+              <LinearGradientBrush EndPoint="1,0">
+                <GradientStop Color="Yellow" Offset="0.1" />
+                <GradientStop Color="Green" Offset="1.0" />
+              </LinearGradientBrush>
+            </Entry.Background>
+          </Entry>
+          <controls:TransparentEntry />
+          <HorizontalStackLayout>
+            <Label Text="CursorPosition = 4" />
+            <Slider x:Name="sldCursorPosition" WidthRequest="100" />
+          </HorizontalStackLayout>
+        </VerticalStackLayout>
+      </ScrollView>
+    </views:BasePage.Content>
+  </views:BasePage>`;
+
+      it('finds the visual content inside a custom page Content property', () => {
+        const root = parser.parseXaml(entryPageExcerpt);
+
+        expect(root.type).toBe(ElementType.ScrollView);
+        expect(root.children[0].type).toBe(ElementType.VerticalStackLayout);
+        expect(root.children[0].children.map(child => child.type)).toEqual([
+          ElementType.Label,
+          ElementType.StackLayout,
+          ElementType.Entry,
+          ElementType.Entry,
+          ElementType.Custom,
+          ElementType.StackLayout
+        ]);
+      });
+
+      it('preserves page resources, binding context, namespaces, and the custom page root', () => {
+        const generated = generator.generateXaml(parser.parseXaml(entryPageExcerpt));
+
+        expect(generated).toContain('<views:BasePage');
+        expect(generated).toContain('xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"');
+        expect(generated).toContain('x:Class="Maui.Controls.Sample.Pages.EntryPage"');
+        expect(generated).toContain('Title="Entry"');
+        expect(generated).toContain('<views:BasePage.Resources>');
+        expect(generated).toContain('<VisualState x:Name="Focused">');
+        expect(generated).toContain('<views:BasePage.BindingContext>');
+        expect(generated).toContain('<viewmodels:EntryViewModel');
+        expect(generated).toContain('<views:BasePage.Content>');
+        expect(generated).toContain('</views:BasePage>');
+      });
+
+      it('round trips nested reference bindings and built-in property elements', () => {
+        const root = parser.parseXaml(entryPageExcerpt);
+        const generated = generator.generateXaml(root);
+        const gradientEntry = root.children[0].children[3];
+
+        expect(generated).toContain('IsPassword="{Binding IsChecked, Source={Reference chkIsPassword}}"');
+        expect(generated).toContain('<Entry.Background>');
+        expect(generated).toContain('<LinearGradientBrush EndPoint="1,0">');
+        expect(generated).toContain('<GradientStop Color="Green" Offset="1.0"');
+        expect(gradientEntry.properties.backgroundGradient)
+          .toBe('linear-gradient(90deg, Yellow 10%, Green 100%)');
+      });
+
+      it('renders a gradient from its StartPoint to its EndPoint', () => {
+        const xaml = entryPageExcerpt
+          .replace('EndPoint="1,0"', 'StartPoint="1,0" EndPoint="0,0"');
+        const gradientEntry = parser.parseXaml(xaml).children[0].children[3];
+
+        expect(gradientEntry.properties.backgroundGradient)
+          .toBe('linear-gradient(270deg, Yellow 10%, Green 100%)');
+      });
+
+      it('retains namespaces used only by visual-tree attributes and property elements', () => {
+        const xaml = entryPageExcerpt
+          .replace(
+            'xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"',
+            'xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"\n      xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"'
+          )
+          .replace(
+            '<Label Text="Password" Style="{StaticResource Headline}" />',
+            `<Label Text="Password" toolkit:SemanticOrderView.Order="1">
+              <Label.Behaviors>
+                <toolkit:TouchBehavior />
+              </Label.Behaviors>
+            </Label>`
+          );
+
+        const generated = generator.generateXaml(parser.parseXaml(xaml));
+
+        expect(generated).toContain(
+          'xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"'
+        );
+        expect(generated).toContain('toolkit:SemanticOrderView.Order="1"');
+        expect(generated).toContain('<toolkit:TouchBehavior');
+      });
+
+      it('preserves namespace declarations shadowed inside retained markup', () => {
+        const xaml = entryPageExcerpt
+          .replace(
+            'xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"',
+            'xmlns:controls="clr-namespace:Maui.Controls.Sample.Pages"\n      xmlns:local="clr-namespace:Root"'
+          )
+          .replace(
+            '<Label Text="Password" Style="{StaticResource Headline}" />',
+            `<Label Text="Password">
+              <Label.Behaviors xmlns:local="clr-namespace:Nested">
+                <local:NestedBehavior />
+              </Label.Behaviors>
+            </Label>`
+          );
+
+        const generated = generator.generateXaml(parser.parseXaml(xaml));
+
+        expect(generated).toContain('xmlns:local="clr-namespace:Root"');
+        expect(generated).toContain(
+          '<Label.Behaviors xmlns:local="clr-namespace:Nested">'
+        );
+        expect(generated).toContain('<local:NestedBehavior');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make the Visual Studio editor registration and WebView2 handshake reliable, keep the hosted XAML editor hidden, and synchronize external text-buffer edits without stale designer writes
- preserve custom page wrappers, resources, binding contexts, namespaces, raw property elements, and nested bindings when importing and exporting real-world MAUI XAML
- add gradient previews, disabled/hidden state presentation, device-sized imported roots, and correctly scrolling long layouts

## Real-world fixture
Validated against the .NET MAUI Controls sample `EntryPage.xaml` at commit `d2edf1972d09f6689a4621ba9ff42346ced6f1b1`:
https://github.com/dotnet/maui/blob/d2edf1972d09f6689a4621ba9ff42346ced6f1b1/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml

The regression excerpt is adapted from Microsoft/.NET Foundation code under the MIT License.

## Validation
- 199 Angular unit tests
- 195 Playwright tests
- 52 extension tests
- Angular production build
- Release VSIX build with warnings as errors: 0 warnings, 0 errors
- installed VSIX assembly hash matches the Release build
- Visual Studio Community 2026 rendered the exact 286-line page with matching counts: 6 Buttons, 35 Labels, 32 Entries, 1 CheckBox, 2 Sliders, 3 horizontal stacks, 1 vertical stack, 1 ScrollView, and 1 custom `TransparentEntry`
- confirmed phone-width layout, programmatic scrolling, one disabled Entry, custom control and binding preservation, and no hosted XAML editor