### PR TITLE
Complete native MAUI Designer UX parity

### DIFF
--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerViewportStateTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerViewportStateTests.cs
@@ -47,4 +47,16 @@ public sealed class DesignerViewportStateTests
         viewport.SetGridSize(500);
         Assert.Equal(200, viewport.GridSize);
     }
+
+    [Fact]
+    public void Center_on_places_the_requested_design_point_at_viewport_center()
+    {
+        var viewport = new DesignerViewportState();
+        viewport.ZoomAt(2, 0, 0);
+
+        viewport.CenterOn(120, 80, 1000, 600);
+
+        Assert.Equal(500, viewport.PanX + 120 * viewport.Zoom, 6);
+        Assert.Equal(300, viewport.PanY + 80 * viewport.Zoom, 6);
+    }
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerWorkspaceTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerWorkspaceTests.cs
@@ -1,6 +1,7 @@
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.App.Workspace;
 using MAUIDesigner.Fresh.Core.Documents;
+using MAUIDesigner.Fresh.Core.Geometry;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MAUIDesigner.Fresh.App.Tests;
@@ -41,6 +42,152 @@ public sealed class DesignerWorkspaceTests
         Assert.False(workspace.CanAcceptChild(innerId, outerId));
     }
 
+    [Fact]
+    public void Copy_and_paste_clone_subtrees_with_unique_ids_and_cascading_absolute_offsets()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor stack = Find(catalog, typeof(VerticalStackLayout));
+        ControlDescriptor label = Find(catalog, typeof(Label));
+        ElementId stackId = workspace.Add(stack);
+        ElementId labelId = workspace.Add(label);
+        workspace.Session.Execute(new SetPropertyCommand(
+            labelId,
+            nameof(Label.Text),
+            DesignerValue.Literal("Copied child")));
+        DesignerNode source = workspace.Session.Current.Find(stackId)!;
+        RectD sourceBounds = Assert.IsType<RectD>(source.Bounds);
+
+        workspace.Select(stackId);
+        workspace.CopySelection();
+        workspace.Select(workspace.Session.Current.Root.Id);
+        ElementId firstId = Assert.IsType<ElementId>(workspace.Paste());
+        workspace.Select(workspace.Session.Current.Root.Id);
+        ElementId secondId = Assert.IsType<ElementId>(workspace.Paste());
+
+        DesignerNode first = workspace.Session.Current.Find(firstId)!;
+        DesignerNode second = workspace.Session.Current.Find(secondId)!;
+        Assert.Equal(sourceBounds.X + 16, first.Bounds!.Value.X);
+        Assert.Equal(sourceBounds.Y + 16, first.Bounds.Value.Y);
+        Assert.Equal(sourceBounds.X + 32, second.Bounds!.Value.X);
+        Assert.Equal(sourceBounds.Y + 32, second.Bounds.Value.Y);
+        Assert.Equal("Copied child", Assert.Single(first.Children).Properties[nameof(Label.Text)].Text);
+        Assert.NotEqual(labelId, first.Children[0].Id);
+        Assert.NotEqual(first.Children[0].Id, second.Children[0].Id);
+        Assert.Equal(
+            workspace.Session.Current.Root
+                .SelectMany()
+                .Select(node => node.Id)
+                .Distinct()
+                .Count(),
+            workspace.Session.Current.Root.SelectMany().Count());
+    }
+
+    [Fact]
+    public void Paste_uses_the_nearest_valid_selected_container()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor stack = Find(catalog, typeof(VerticalStackLayout));
+        ControlDescriptor label = Find(catalog, typeof(Label));
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId stackId = workspace.Add(stack);
+        ElementId labelId = workspace.Add(label);
+        ElementId buttonId = workspace.Add(button, workspace.Session.Current.Root.Id);
+        workspace.Select(buttonId);
+        workspace.CopySelection();
+
+        workspace.Select(labelId);
+        Assert.True(workspace.CanPaste);
+        ElementId pastedId = Assert.IsType<ElementId>(workspace.Paste());
+
+        Assert.NotNull(workspace.Session.Current.Find(stackId)!.Find(pastedId));
+        Assert.Null(workspace.Session.Current.Find(pastedId)!.Bounds);
+    }
+
+    [Fact]
+    public void Cut_keeps_an_internal_snapshot_and_root_cannot_be_cut_or_deleted()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor label = Find(catalog, typeof(Label));
+        ElementId labelId = workspace.Add(label);
+        workspace.Session.Execute(new SetPropertyCommand(
+            labelId,
+            nameof(Label.Text),
+            DesignerValue.Literal("Cut me")));
+
+        workspace.CutSelection();
+
+        Assert.Null(workspace.Session.Current.Find(labelId));
+        Assert.Equal(workspace.Session.Current.Root.Id, workspace.SelectedId);
+        Assert.True(workspace.CanPaste);
+        Assert.True(workspace.Session.Undo());
+        Assert.NotNull(workspace.Session.Current.Find(labelId));
+
+        workspace.Select(workspace.Session.Current.Root.Id);
+        workspace.CopySelection();
+        workspace.CutSelection();
+        workspace.DeleteSelection();
+        ElementId pastedId = Assert.IsType<ElementId>(workspace.Paste());
+        Assert.NotNull(workspace.Session.Current.Root);
+        Assert.Equal("Cut me", workspace.Session.Current.Find(labelId)!.Properties[nameof(Label.Text)].Text);
+        Assert.Equal(label.Id, workspace.Session.Current.Find(pastedId)!.ControlType);
+    }
+
+    [Fact]
+    public void Duplicate_is_adjacent_offset_and_undoes_in_one_step()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId originalId = workspace.Add(button);
+        DesignerNode original = workspace.Session.Current.Find(originalId)!;
+
+        ElementId duplicateId = Assert.IsType<ElementId>(workspace.DuplicateSelection());
+
+        Assert.Equal(
+            new[] { originalId, duplicateId },
+            workspace.Session.Current.Root.Children.Select(child => child.Id));
+        DesignerNode duplicate = workspace.Session.Current.Find(duplicateId)!;
+        Assert.Equal(original.Bounds!.Value.X + 16, duplicate.Bounds!.Value.X);
+        Assert.Equal(original.Bounds.Value.Y + 16, duplicate.Bounds.Value.Y);
+        Assert.True(workspace.Session.Undo());
+        Assert.Null(workspace.Session.Current.Find(duplicateId));
+        Assert.NotNull(workspace.Session.Current.Find(originalId));
+    }
+
+    [Fact]
+    public void Hierarchy_reorder_moves_among_siblings_and_preserves_placement()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId firstId = workspace.Add(button);
+        ElementId secondId = workspace.Add(button);
+        ElementId thirdId = workspace.Add(button);
+        workspace.Select(secondId);
+        DesignerNode before = workspace.Session.Current.Find(secondId)!;
+
+        Assert.True(workspace.CanMoveSelectionUp);
+        Assert.True(workspace.CanMoveSelectionDown);
+        Assert.True(workspace.MoveSelectionUp());
+        Assert.Equal(
+            new[] { secondId, firstId, thirdId },
+            workspace.Session.Current.Root.Children.Select(child => child.Id));
+        Assert.Same(before, workspace.Session.Current.Find(secondId));
+        Assert.True(workspace.Session.Undo());
+        Assert.Equal(
+            new[] { firstId, secondId, thirdId },
+            workspace.Session.Current.Root.Children.Select(child => child.Id));
+
+        Assert.True(workspace.MoveSelectionDown());
+        Assert.Equal(
+            new[] { firstId, thirdId, secondId },
+            workspace.Session.Current.Root.Children.Select(child => child.Id));
+        Assert.False(workspace.CanMoveSelectionDown);
+    }
+
     private static ReflectionControlCatalog CreateCatalog()
     {
         var catalog = new ReflectionControlCatalog(
@@ -51,4 +198,19 @@ public sealed class DesignerWorkspaceTests
 
     private static ControlDescriptor Find(ReflectionControlCatalog catalog, Type type) =>
         catalog.Controls.Single(control => control.RuntimeType == type);
+}
+
+internal static class DesignerNodeTestExtensions
+{
+    public static IEnumerable<DesignerNode> SelectMany(this DesignerNode node)
+    {
+        yield return node;
+        foreach (DesignerNode child in node.Children)
+        {
+            foreach (DesignerNode descendant in child.SelectMany())
+            {
+                yield return descendant;
+            }
+        }
+    }
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/GridDefinitionsPropertyEditorTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/GridDefinitionsPropertyEditorTests.cs
@@ -1,0 +1,55 @@
+using MAUIDesigner.Fresh.App.Catalog;
+using MAUIDesigner.Fresh.App.PropertyEditing;
+
+namespace MAUIDesigner.Fresh.App.Tests;
+
+public sealed class GridDefinitionsPropertyEditorTests
+{
+    [Theory]
+    [InlineData("Auto,*,2*,120", "Auto,*,2*,120")]
+    [InlineData("auto, 1*, 80.5", "Auto,*,80.5")]
+    [InlineData("", "")]
+    public void Serializer_round_trips_maui_compatible_collection_strings(
+        string input,
+        string expected)
+    {
+        Assert.True(GridDefinitionSerializer.TryParse(input, out GridTrackDefinition[] values));
+
+        Assert.Equal(expected, GridDefinitionSerializer.Serialize(values));
+    }
+
+    [Theory]
+    [InlineData("Auto,,*")]
+    [InlineData("-1")]
+    [InlineData("NaN*")]
+    [InlineData("wat")]
+    public void Serializer_rejects_invalid_grid_lengths(string input)
+    {
+        Assert.False(GridDefinitionSerializer.TryParse(input, out _));
+    }
+
+    [Fact]
+    public void Specialized_editor_recognizes_grid_definition_collections()
+    {
+        var editor = new GridDefinitionsPropertyEditor();
+        var property = new PropertyDescriptor(
+            nameof(Grid.RowDefinitions),
+            typeof(RowDefinitionCollection),
+            true,
+            false,
+            false,
+            false);
+
+        Assert.True(editor.CanEdit(property));
+    }
+
+    [Fact]
+    public void Add_and_remove_commit_canonical_serialized_values()
+    {
+        var model = new GridDefinitionCollectionModel("80");
+
+        Assert.Equal("80,*", model.Add());
+
+        Assert.Equal("*", model.RemoveAt(0));
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/GridTrackOverlayDrawableTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/GridTrackOverlayDrawableTests.cs
@@ -1,0 +1,44 @@
+using MAUIDesigner.Fresh.App.Rendering;
+using Microsoft.Maui.Graphics;
+
+namespace MAUIDesigner.Fresh.App.Tests;
+
+public sealed class GridTrackOverlayDrawableTests
+{
+    [Fact]
+    public void Update_precomputes_track_boundaries_from_actual_definitions()
+    {
+        var drawable = new GridTrackOverlayDrawable();
+
+        drawable.UpdateActualTracks(
+            [40, 60, 124],
+            [100, 196],
+            new RectF(10, 20, 300, 240),
+            rowSpacing: 8,
+            columnSpacing: 4,
+            deviceZoom: 2);
+
+        Assert.Equal(3, drawable.LineCount);
+        Assert.Equal(new GridTrackLine(10, 64, 310, 64), drawable.GetLine(0));
+        Assert.Equal(new GridTrackLine(10, 132, 310, 132), drawable.GetLine(1));
+        Assert.Equal(new GridTrackLine(112, 20, 112, 260), drawable.GetLine(2));
+    }
+
+    [Fact]
+    public void Update_reuses_capacity_and_clear_removes_all_lines()
+    {
+        var drawable = new GridTrackOverlayDrawable();
+        drawable.UpdateActualTracks(
+            [50, 50],
+            [],
+            new RectF(0, 0, 100, 100),
+            0,
+            0,
+            1);
+        Assert.Single(Enumerable.Range(0, drawable.LineCount));
+
+        drawable.Clear();
+
+        Assert.Equal(0, drawable.LineCount);
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/ReflectionControlCatalogTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/ReflectionControlCatalogTests.cs
@@ -66,6 +66,21 @@ public sealed class ReflectionControlCatalogTests
         Assert.Same(services, observedProvider);
     }
 
+    [Fact]
+    public void Catalog_deduplicates_shadowed_inherited_properties()
+    {
+        var catalog = new ReflectionControlCatalog(
+            new ServiceCollection().BuildServiceProvider());
+        catalog.RegisterAssembly(typeof(View).Assembly);
+
+        ControlDescriptor stack = Find(catalog, typeof(VerticalStackLayout));
+
+        Assert.Equal(
+            stack.Properties.Length,
+            stack.Properties.Select(property => property.Name).Distinct().Count());
+        Assert.Single(stack.Properties, property => property.Name == nameof(Element.Handler));
+    }
+
     private static ControlDescriptor Find(ReflectionControlCatalog catalog, Type type) =>
         catalog.Controls.Single(control => control.RuntimeType == type);
 

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/RuntimePreviewTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/RuntimePreviewTests.cs
@@ -1,0 +1,76 @@
+using MAUIDesigner.Fresh.App.Catalog;
+using MAUIDesigner.Fresh.App.Preview;
+using MAUIDesigner.Fresh.Core.Documents;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MAUIDesigner.Fresh.App.Tests;
+
+public sealed class RuntimePreviewTests
+{
+    [Fact]
+    public void Fixed_device_options_have_stable_display_text()
+    {
+        var options = new RuntimePreviewOptions("Phone", 390, 844);
+
+        Assert.Equal("Phone · 390 × 844", options.DisplayText);
+    }
+
+    [Fact]
+    public void Responsive_options_do_not_claim_fixed_dimensions()
+    {
+        Assert.Equal("Responsive", RuntimePreviewOptions.Responsive.DisplayText);
+    }
+
+    [Fact]
+    public async Task Service_honors_cancellation_before_dispatching()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        ControlDescriptor label = catalog.Controls.Single(
+            control => control.RuntimeType == typeof(Label));
+        DesignerDocument document = DesignerDocument.Create(label.Id);
+        var dispatcher = new RecordingDispatcher();
+        var host = new RecordingWindowHost();
+        var service = new RuntimePreviewService(
+            new PreviewDocumentRenderer(catalog),
+            dispatcher,
+            host);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            service.OpenAsync(document, cancellationToken: cancellation.Token));
+
+        Assert.False(dispatcher.WasInvoked);
+        Assert.Null(host.Opened);
+    }
+
+    private static ReflectionControlCatalog CreateCatalog()
+    {
+        var catalog = new ReflectionControlCatalog(
+            new ServiceCollection().BuildServiceProvider());
+        catalog.RegisterAssembly(typeof(View).Assembly);
+        return catalog;
+    }
+
+    private sealed class RecordingDispatcher : IPreviewDispatcher
+    {
+        public bool WasInvoked { get; private set; }
+
+        public Task<T> InvokeAsync<T>(Func<T> action)
+        {
+            WasInvoked = true;
+            return Task.FromResult(action());
+        }
+    }
+
+    private sealed class RecordingWindowHost : IPreviewWindowHost
+    {
+        public Window? Opened { get; private set; }
+
+        public void Open(Window window) => Opened = window;
+
+        public void Close(Window window)
+        {
+        }
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/XamlTextIdentityTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/XamlTextIdentityTests.cs
@@ -1,0 +1,18 @@
+using MAUIDesigner.Fresh.App.Xaml;
+
+namespace MAUIDesigner.Fresh.App.Tests;
+
+public sealed class XamlTextIdentityTests
+{
+    [Theory]
+    [InlineData("<Grid>\r\n  <Label />\r\n</Grid>", "<Grid>\n  <Label />\n</Grid>")]
+    [InlineData("<Grid>\r  <Label />\r</Grid>", "<Grid>\n  <Label />\n</Grid>")]
+    public void Normalization_treats_editor_and_writer_line_endings_as_identical(
+        string editorText,
+        string writerText)
+    {
+        Assert.Equal(
+            XamlTextIdentity.Normalize(writerText),
+            XamlTextIdentity.Normalize(editorText));
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/App.xaml
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/App.xaml
@@ -1,24 +1,16 @@
 ﻿<?xml version = "1.0" encoding = "UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MAUIDesigner.Fresh.App"
-             x:Class="MAUIDesigner.Fresh.App.App">
+<Application
+    x:Class="MAUIDesigner.Fresh.App.App"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MAUIDesigner.Fresh.App"
+    UserAppTheme="Light">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <Style x:Key="ToolbarButton" TargetType="Button">
-                <Setter Property="BackgroundColor" Value="#202431" />
-                <Setter Property="BorderColor" Value="#353B4E" />
-                <Setter Property="BorderWidth" Value="1" />
-                <Setter Property="CornerRadius" Value="7" />
-                <Setter Property="FontSize" Value="11" />
-                <Setter Property="HeightRequest" Value="32" />
-                <Setter Property="Padding" Value="12,0" />
-                <Setter Property="TextColor" Value="#E6E9F2" />
-            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Catalog/ReflectionControlCatalog.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Catalog/ReflectionControlCatalog.cs
@@ -143,9 +143,8 @@ public sealed class ReflectionControlCatalog : IControlCatalog
                 : field.Name)
             .ToHashSet(StringComparer.Ordinal);
 
-        return type
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(property => property.GetIndexParameters().Length == 0 && property.GetMethod is not null)
+        return RuntimePropertyCache
+            .GetPublicProperties(type)
             .Select(property => new PropertyDescriptor(
                 property.Name,
                 property.PropertyType,

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Catalog/RuntimePropertyCache.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Catalog/RuntimePropertyCache.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace MAUIDesigner.Fresh.App.Catalog;
+
+internal static class RuntimePropertyCache
+{
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PublicProperties = new();
+    private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, PropertyInfo>>
+        WritableProperties = new();
+
+    public static IReadOnlyList<PropertyInfo> GetPublicProperties(Type type) =>
+        PublicProperties.GetOrAdd(
+            type,
+            runtimeType => runtimeType
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(property =>
+                    property.GetIndexParameters().Length == 0 &&
+                    property.GetMethod is not null)
+                .GroupBy(property => property.Name, StringComparer.Ordinal)
+                .Select(group => group
+                    .OrderBy(property => InheritanceDistance(
+                        runtimeType,
+                        property.DeclaringType))
+                    .First())
+                .ToArray());
+
+    public static IReadOnlyDictionary<string, PropertyInfo> GetWritableProperties(Type type) =>
+        WritableProperties.GetOrAdd(
+            type,
+            runtimeType => GetPublicProperties(runtimeType)
+                .Where(property => property.SetMethod?.IsPublic == true)
+                .ToDictionary(property => property.Name, StringComparer.Ordinal));
+
+    private static int InheritanceDistance(Type runtimeType, Type? declaringType)
+    {
+        int distance = 0;
+        for (Type? current = runtimeType; current is not null; current = current.BaseType)
+        {
+            if (current == declaringType)
+            {
+                return distance;
+            }
+
+            distance++;
+        }
+
+        return int.MaxValue;
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml
@@ -3,50 +3,66 @@
     x:Class="MAUIDesigner.Fresh.App.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:catalog="clr-namespace:MAUIDesigner.Fresh.App.Catalog"
     xmlns:controls="clr-namespace:MAUIDesigner.Fresh.App.Controls"
-    xmlns:workspace="clr-namespace:MAUIDesigner.Fresh.App.Workspace"
-    BackgroundColor="#0F1117">
+    BackgroundColor="{StaticResource SurfaceSubtle}">
 
-    <Grid x:Name="ApplicationGrid" RowDefinitions="56,*,Auto">
+    <Grid x:Name="ApplicationGrid" RowDefinitions="64,*,Auto">
         <Border
             Grid.Row="0"
-            Padding="20,0"
-            BackgroundColor="#171A23"
-            Stroke="#292E3D"
+            Padding="18,0"
+            BackgroundColor="{StaticResource Surface}"
+            Stroke="{StaticResource Border}"
             StrokeThickness="1">
             <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="18">
                 <HorizontalStackLayout VerticalOptions="Center" Spacing="10">
                     <Border
-                        WidthRequest="30"
-                        HeightRequest="30"
-                        BackgroundColor="#7C5CFF"
+                        WidthRequest="34"
+                        HeightRequest="34"
+                        BackgroundColor="{StaticResource Primary}"
                         StrokeThickness="0"
-                        StrokeShape="RoundRectangle 8">
+                        StrokeShape="RoundRectangle 9">
                         <Label
                             HorizontalOptions="Center"
                             VerticalOptions="Center"
                             FontAttributes="Bold"
-                            FontSize="16"
+                            FontSize="17"
                             Text="M"
                             TextColor="White" />
                     </Border>
-                    <VerticalStackLayout Spacing="-2" VerticalOptions="Center">
-                        <Label FontAttributes="Bold" FontSize="15" Text="MAUI Designer" TextColor="#F5F7FF" />
-                        <Label FontSize="10" Text="NATIVE PREVIEW" TextColor="#8D94A8" />
+                    <VerticalStackLayout Spacing="-1" VerticalOptions="Center">
+                        <Label FontAttributes="Bold" FontSize="15" Text="MAUI Designer" TextColor="{StaticResource TextPrimary}" />
+                        <Label CharacterSpacing="1.1" FontSize="9" Text="NATIVE DESIGN WORKSPACE" TextColor="{StaticResource TextMuted}" />
                     </VerticalStackLayout>
                 </HorizontalStackLayout>
 
-                <HorizontalStackLayout
-                    Grid.Column="2"
-                    VerticalOptions="Center"
-                    Spacing="8">
-                    <Button x:Name="UndoButton" AutomationId="toolbar-undo" Clicked="OnUndoClicked" Style="{StaticResource ToolbarButton}" Text="Undo" />
-                    <Button x:Name="RedoButton" AutomationId="toolbar-redo" Clicked="OnRedoClicked" Style="{StaticResource ToolbarButton}" Text="Redo" />
-                    <Button AutomationId="toolbar-load-controls" Clicked="OnLoadControlsClicked" Style="{StaticResource ToolbarButton}" Text="Load controls" />
-                    <Button AutomationId="toolbar-xaml" Clicked="OnToggleXamlClicked" Style="{StaticResource ToolbarButton}" Text="XAML" />
-                    <Button AutomationId="toolbar-delete" Clicked="OnDeleteClicked" Style="{StaticResource ToolbarButton}" Text="Delete" />
-                </HorizontalStackLayout>
+                <ScrollView Grid.Column="2" Orientation="Horizontal" HorizontalScrollBarVisibility="Never">
+                    <HorizontalStackLayout VerticalOptions="Center" Spacing="6">
+                        <Button
+                            x:Name="UndoButton"
+                            AutomationId="toolbar-undo"
+                            Clicked="OnUndoClicked"
+                            SemanticProperties.Description="Undo the last change"
+                            Style="{StaticResource ToolbarButton}"
+                            Text="Undo" />
+                        <Button
+                            x:Name="RedoButton"
+                            AutomationId="toolbar-redo"
+                            Clicked="OnRedoClicked"
+                            SemanticProperties.Description="Redo the last undone change"
+                            Style="{StaticResource ToolbarButton}"
+                            Text="Redo" />
+                        <BoxView Margin="3,7" WidthRequest="1" BackgroundColor="{StaticResource Border}" />
+                        <Button AutomationId="toolbar-cut" Clicked="OnCutClicked" SemanticProperties.Description="Cut the selected control" Style="{StaticResource ToolbarButton}" Text="Cut" />
+                        <Button AutomationId="toolbar-copy" Clicked="OnCopyClicked" SemanticProperties.Description="Copy the selected control" Style="{StaticResource ToolbarButton}" Text="Copy" />
+                        <Button AutomationId="toolbar-paste" Clicked="OnPasteClicked" SemanticProperties.Description="Paste controls from the clipboard" Style="{StaticResource ToolbarButton}" Text="Paste" />
+                        <Button AutomationId="toolbar-duplicate" Clicked="OnDuplicateClicked" SemanticProperties.Description="Duplicate the selected control" Style="{StaticResource ToolbarButton}" Text="Duplicate" />
+                        <Button AutomationId="toolbar-delete" Clicked="OnDeleteClicked" SemanticProperties.Description="Delete the selected control" Style="{StaticResource ToolbarButton}" Text="Delete" />
+                        <BoxView Margin="3,7" WidthRequest="1" BackgroundColor="{StaticResource Border}" />
+                        <Button AutomationId="toolbar-load-controls" Clicked="OnLoadControlsClicked" SemanticProperties.Description="Load controls from an assembly" Style="{StaticResource ToolbarButton}" Text="Load controls" />
+                        <Button AutomationId="toolbar-xaml" Clicked="OnToggleXamlClicked" SemanticProperties.Description="Show or hide the live XAML editor" Style="{StaticResource ToolbarButton}" Text="XAML" />
+                        <Button AutomationId="toolbar-run-preview" Clicked="OnRunPreviewClicked" SemanticProperties.Description="Run the current design in a preview window" Style="{StaticResource ToolbarPrimaryButton}" Text="Run preview" />
+                    </HorizontalStackLayout>
+                </ScrollView>
             </Grid>
         </Border>
 
@@ -54,94 +70,50 @@
             x:Name="DesignerBody"
             Grid.Row="1"
             ColumnDefinitions="260,1,*,1,320"
-            BackgroundColor="#0F1117"
+            BackgroundColor="{StaticResource SurfaceSubtle}"
             IsClippedToBounds="True">
-            <Grid Grid.Column="0" Padding="14" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="10">
+            <Grid Grid.Column="0" Padding="16,15" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="11" BackgroundColor="{StaticResource Surface}">
                 <Grid ColumnDefinitions="*,Auto">
-                    <VerticalStackLayout>
-                        <Label FontAttributes="Bold" FontSize="14" Text="Toolbox" TextColor="#F5F7FF" />
-                        <Label FontSize="11" Text="Reflected from loaded assemblies" TextColor="#798196" />
+                    <VerticalStackLayout Spacing="2">
+                        <Label FontAttributes="Bold" FontSize="15" Text="Elements" TextColor="{StaticResource TextPrimary}" />
+                        <Label FontSize="10" Text="Build and navigate your page" TextColor="{StaticResource TextMuted}" />
                     </VerticalStackLayout>
                     <Border
                         Grid.Column="1"
-                        Padding="7,3"
-                        BackgroundColor="#242033"
-                        Stroke="#5946A3"
-                        StrokeShape="RoundRectangle 8">
-                        <Label x:Name="ControlCountLabel" FontSize="10" TextColor="#BFAFFF" />
+                        Padding="8,3"
+                        VerticalOptions="Center"
+                        BackgroundColor="{StaticResource AccentSoft}"
+                        Stroke="{StaticResource AccentBorder}"
+                        StrokeShape="RoundRectangle 9">
+                        <Label x:Name="ControlCountLabel" FontAttributes="Bold" FontSize="10" TextColor="{StaticResource Primary}" />
                     </Border>
                 </Grid>
-                <Grid Grid.Row="1" ColumnDefinitions="*,*" ColumnSpacing="6">
+                <Grid Grid.Row="1" ColumnDefinitions="*,*" ColumnSpacing="7">
                     <Button
                         x:Name="ToolboxTabButton"
                         AutomationId="tab-toolbox"
                         Clicked="OnToolboxTabClicked"
-                        FontSize="11"
-                        HeightRequest="32"
+                        SemanticProperties.Description="Show the grouped control toolbox"
+                        Style="{StaticResource TabButton}"
                         Text="Toolbox" />
                     <Button
                         x:Name="HierarchyTabButton"
                         Grid.Column="1"
                         AutomationId="tab-hierarchy"
                         Clicked="OnHierarchyTabClicked"
-                        FontSize="11"
-                        HeightRequest="32"
+                        SemanticProperties.Description="Show the visual hierarchy"
+                        Style="{StaticResource TabButton}"
                         Text="Hierarchy" />
                 </Grid>
                 <SearchBar
                     x:Name="ToolboxSearch"
                     Grid.Row="2"
                     AutomationId="toolbox-search"
-                    HeightRequest="38"
-                    Placeholder="Search controls..."
+                    Placeholder="Search controls"
+                    SemanticProperties.Description="Search available controls"
                     TextChanged="OnToolboxSearchChanged" />
-                <ScrollView
-                    x:Name="ToolboxList"
-                    Grid.Row="3">
-                    <VerticalStackLayout x:Name="ToolboxItemsHost">
-                        <BindableLayout.ItemTemplate>
-                            <DataTemplate x:DataType="catalog:ControlDescriptor">
-                                <controls:ToolboxItemView
-                                    AutomationId="{Binding AutomationId}"
-                                    Descriptor="{Binding .}"
-                                    ItemDragUpdated="OnToolboxDragUpdated"
-                                    ItemTapped="OnToolboxItemTapped"
-                                    Margin="0,0,0,7"
-                                    Padding="10,8"
-                                    BackgroundColor="#171A23"
-                                    Stroke="#292E3D"
-                                    StrokeShape="RoundRectangle 8">
-                                    <Grid ColumnDefinitions="34,*" RowDefinitions="Auto,Auto">
-                                        <Border
-                                            Grid.RowSpan="2"
-                                            WidthRequest="28"
-                                            HeightRequest="28"
-                                            BackgroundColor="#242033"
-                                            StrokeThickness="0"
-                                            StrokeShape="RoundRectangle 7">
-                                            <Label
-                                                HorizontalOptions="Center"
-                                                VerticalOptions="Center"
-                                                FontAttributes="Bold"
-                                                Text="+"
-                                                TextColor="#A994FF" />
-                                        </Border>
-                                        <Label
-                                            Grid.Column="1"
-                                            FontSize="12"
-                                            Text="{Binding DisplayName}"
-                                            TextColor="#E7EAF4" />
-                                        <Label
-                                            Grid.Row="1"
-                                            Grid.Column="1"
-                                            FontSize="9"
-                                            Text="{Binding Category}"
-                                            TextColor="#747D92" />
-                                    </Grid>
-                                </controls:ToolboxItemView>
-                            </DataTemplate>
-                        </BindableLayout.ItemTemplate>
-                    </VerticalStackLayout>
+                <ScrollView x:Name="ToolboxList" Grid.Row="3">
+                    <VerticalStackLayout x:Name="ToolboxItemsHost" Spacing="6" />
                 </ScrollView>
                 <CollectionView
                     x:Name="HierarchyList"
@@ -149,78 +121,68 @@
                     Grid.RowSpan="2"
                     AutomationId="hierarchy-list"
                     IsVisible="False"
-                    SelectionChanged="OnHierarchySelectionChanged"
-                    SelectionMode="Single">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="workspace:HierarchyItem">
-                            <Border
-                                Margin="{Binding Indent}"
-                                Padding="10,8"
-                                BackgroundColor="#171A23"
-                                Stroke="#292E3D"
-                                StrokeShape="RoundRectangle 7">
-                                <VerticalStackLayout Spacing="1">
-                                    <Label FontSize="11" Text="{Binding DisplayName}" TextColor="#E7EAF4" />
-                                    <Label FontSize="9" Text="{Binding Identity}" TextColor="#747D92" />
-                                </VerticalStackLayout>
-                            </Border>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
+                    ItemSizingStrategy="MeasureFirstItem">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="0" />
+                    </CollectionView.ItemsLayout>
                 </CollectionView>
             </Grid>
 
-            <BoxView Grid.Column="1" BackgroundColor="#292E3D" />
+            <BoxView Grid.Column="1" BackgroundColor="{StaticResource Border}" />
 
             <Grid Grid.Column="2" RowDefinitions="88,*">
                 <Border
-                    Padding="14,0"
-                    BackgroundColor="#131620"
-                    Stroke="#292E3D"
+                    Padding="16,0"
+                    BackgroundColor="{StaticResource Surface}"
+                    Stroke="{StaticResource Border}"
                     StrokeThickness="1">
-                    <Grid RowDefinitions="Auto,Auto" RowSpacing="4">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
-                            <Label VerticalOptions="Center" FontSize="11" Text="DESIGN SURFACE" TextColor="#8D94A8" />
-                            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" Spacing="6">
+                    <Grid RowDefinitions="Auto,Auto" RowSpacing="5">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+                            <VerticalStackLayout VerticalOptions="Center" Spacing="0">
+                                <Label FontAttributes="Bold" FontSize="11" Text="DESIGN SURFACE" TextColor="{StaticResource TextSecondary}" />
+                                <Label FontSize="9" Text="Interactive canvas" TextColor="{StaticResource TextMuted}" />
+                            </VerticalStackLayout>
+                            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="6">
                                 <Picker
                                     x:Name="DevicePicker"
                                     AutomationId="canvas-device"
-                                    WidthRequest="145"
-                                    FontSize="10"
-                                    SelectedIndexChanged="OnDeviceChanged"
-                                    TextColor="#D8DCE8" />
-                                <Button AutomationId="canvas-zoom-out" Clicked="OnZoomOutClicked" Style="{StaticResource ToolbarButton}" Text="-" />
+                                    WidthRequest="154"
+                                    SelectedIndexChanged="OnDeviceChanged" />
+                                <Button AutomationId="canvas-zoom-out" Clicked="OnZoomOutClicked" SemanticProperties.Description="Zoom out" Style="{StaticResource CompactToolbarButton}" Text="−" />
                                 <Label
                                     x:Name="ZoomLabel"
                                     AutomationId="canvas-zoom-value"
-                                    WidthRequest="44"
+                                    WidthRequest="46"
                                     HorizontalTextAlignment="Center"
                                     VerticalTextAlignment="Center"
+                                    FontAttributes="Bold"
                                     FontSize="10"
-                                    TextColor="#B9C0D3" />
-                                <Button AutomationId="canvas-zoom-in" Clicked="OnZoomInClicked" Style="{StaticResource ToolbarButton}" Text="+" />
-                                <Button AutomationId="canvas-zoom-fit" Clicked="OnZoomFitClicked" Style="{StaticResource ToolbarButton}" Text="Fit" />
-                                <Button AutomationId="canvas-zoom-reset" Clicked="OnZoomResetClicked" Style="{StaticResource ToolbarButton}" Text="1:1" />
+                                    TextColor="{StaticResource TextSecondary}" />
+                                <Button AutomationId="canvas-zoom-in" Clicked="OnZoomInClicked" SemanticProperties.Description="Zoom in" Style="{StaticResource CompactToolbarButton}" Text="+" />
+                                <Button AutomationId="canvas-zoom-fit" Clicked="OnZoomFitClicked" SemanticProperties.Description="Fit the design to the available canvas" Style="{StaticResource ToolbarButton}" Text="Fit" />
+                                <Button AutomationId="canvas-zoom-reset" Clicked="OnZoomResetClicked" SemanticProperties.Description="Reset zoom to one hundred percent" Style="{StaticResource ToolbarButton}" Text="1:1" />
                             </HorizontalStackLayout>
                         </Grid>
-                        <HorizontalStackLayout Grid.Row="1" HorizontalOptions="End" Spacing="6">
-                                <Button x:Name="ThemeButton" AutomationId="canvas-theme" Clicked="OnThemeClicked" Style="{StaticResource ToolbarButton}" Text="Dark" />
-                                <Button x:Name="SnapButton" AutomationId="canvas-snap" Clicked="OnSnapClicked" Style="{StaticResource ToolbarButton}" Text="Snap" />
-                                <Button x:Name="GridButton" AutomationId="canvas-grid" Clicked="OnGridClicked" Style="{StaticResource ToolbarButton}" Text="Grid" />
-                                <Button x:Name="RulersButton" AutomationId="canvas-rulers" Clicked="OnRulersClicked" Style="{StaticResource ToolbarButton}" Text="Rulers" />
-                                <Label VerticalOptions="Center" FontSize="9" Text="Grid size" TextColor="#8D94A8" />
-                                <Stepper
-                                    x:Name="GridSizeStepper"
-                                    AutomationId="canvas-grid-size"
-                                    Increment="2"
-                                    Maximum="64"
-                                    Minimum="2"
-                                    ValueChanged="OnGridSizeChanged" />
-                                <Label
-                                    x:Name="GridSizeLabel"
-                                    WidthRequest="22"
-                                    VerticalTextAlignment="Center"
-                                    FontSize="9"
-                                    TextColor="#B9C0D3" />
+                        <HorizontalStackLayout Grid.Row="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="6">
+                            <Button x:Name="SnapButton" AutomationId="canvas-snap" Clicked="OnSnapClicked" SemanticProperties.Description="Toggle snapping" Style="{StaticResource ToolbarButton}" Text="Snap" />
+                            <Button x:Name="GridButton" AutomationId="canvas-grid" Clicked="OnGridClicked" SemanticProperties.Description="Toggle the canvas grid" Style="{StaticResource ToolbarButton}" Text="Grid" />
+                            <Button x:Name="RulersButton" AutomationId="canvas-rulers" Clicked="OnRulersClicked" SemanticProperties.Description="Toggle canvas rulers" Style="{StaticResource ToolbarButton}" Text="Rulers" />
+                            <Label Margin="6,0,0,0" VerticalOptions="Center" FontSize="10" Text="Grid size" TextColor="{StaticResource TextSecondary}" />
+                            <Stepper
+                                x:Name="GridSizeStepper"
+                                AutomationId="canvas-grid-size"
+                                Increment="2"
+                                Maximum="64"
+                                Minimum="2"
+                                SemanticProperties.Description="Change the canvas grid size"
+                                ValueChanged="OnGridSizeChanged" />
+                            <Label
+                                x:Name="GridSizeLabel"
+                                WidthRequest="24"
+                                VerticalTextAlignment="Center"
+                                FontAttributes="Bold"
+                                FontSize="10"
+                                TextColor="{StaticResource TextSecondary}" />
                         </HorizontalStackLayout>
                     </Grid>
                 </Border>
@@ -228,7 +190,7 @@
                     x:Name="CanvasViewport"
                     Grid.Row="1"
                     AutomationId="canvas-viewport"
-                    BackgroundColor="#0B0D12"
+                    BackgroundColor="{StaticResource CanvasBackdrop}"
                     IsClippedToBounds="True"
                     PanRequested="OnCanvasPanRequested"
                     SizeChanged="OnCanvasViewportSizeChanged"
@@ -246,59 +208,50 @@
                             HorizontalOptions="Start"
                             VerticalOptions="Start"
                             BackgroundColor="White"
-                            Stroke="#343A4E"
+                            Stroke="{StaticResource BorderStrong}"
                             StrokeShape="RoundRectangle 12"
-                            Shadow="{Shadow Brush=Black, Opacity=0.4, Radius=24, Offset='0,10'}">
+                            Shadow="{Shadow Brush=#475569, Opacity=0.22, Radius=24, Offset='0,10'}">
                             <Grid>
-                                <GraphicsView
-                                    x:Name="CanvasGridOverlay"
-                                    InputTransparent="True" />
-                                <ContentView
-                                    x:Name="CanvasHost"
-                                    AutomationId="designer-canvas" />
+                                <GraphicsView x:Name="CanvasGridOverlay" InputTransparent="True" />
+                                <ContentView x:Name="CanvasHost" AutomationId="designer-canvas" />
                             </Grid>
                         </Border>
                     </Grid>
-                    <GraphicsView
-                        x:Name="CanvasRulerOverlay"
-                        InputTransparent="True" />
+                    <GraphicsView x:Name="CanvasRulerOverlay" InputTransparent="True" />
                     <Border
-                        Margin="12"
-                        Padding="9,5"
+                        Margin="14"
+                        Padding="10,6"
                         HorizontalOptions="Start"
                         VerticalOptions="End"
-                        BackgroundColor="#CC171A23"
-                        Stroke="#343A4E"
+                        BackgroundColor="#F2FFFFFF"
+                        Stroke="{StaticResource BorderStrong}"
                         StrokeShape="RoundRectangle 7">
-                        <Label
-                            FontSize="9"
-                            Text="Middle-drag or Space+drag to pan | Ctrl+wheel to zoom"
-                            TextColor="#9CA3B8" />
+                        <Label FontSize="9" Text="Middle-drag or Space+drag to pan  •  Ctrl+wheel to zoom" TextColor="{StaticResource TextSecondary}" />
                     </Border>
                 </controls:CanvasViewportView>
             </Grid>
 
-            <BoxView Grid.Column="3" BackgroundColor="#292E3D" />
+            <BoxView Grid.Column="3" BackgroundColor="{StaticResource Border}" />
 
-            <Grid Grid.Column="4" Padding="14" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12">
-                <VerticalStackLayout>
-                    <Label FontAttributes="Bold" FontSize="14" Text="Properties" TextColor="#F5F7FF" />
-                    <Label x:Name="SelectionLabel" AutomationId="selection-label" FontSize="11" TextColor="#798196" />
+            <Grid Grid.Column="4" Padding="16,15" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12" BackgroundColor="{StaticResource Surface}">
+                <VerticalStackLayout Spacing="2">
+                    <Label FontAttributes="Bold" FontSize="15" Text="Properties" TextColor="{StaticResource TextPrimary}" />
+                    <Label x:Name="SelectionLabel" AutomationId="selection-label" FontSize="10" TextColor="{StaticResource TextMuted}" />
                 </VerticalStackLayout>
                 <Border
                     Grid.Row="1"
-                    Padding="10,7"
-                    BackgroundColor="#171A23"
-                    Stroke="#292E3D"
+                    Padding="10,8"
+                    BackgroundColor="{StaticResource SurfaceSubtle}"
+                    Stroke="{StaticResource Border}"
                     StrokeShape="RoundRectangle 8">
-                    <Label FontSize="10" Text="Changes commit when an editor loses focus or Enter is pressed." TextColor="#858DA2" />
+                    <Label FontSize="10" LineBreakMode="WordWrap" Text="Changes save when an editor loses focus or you press Enter." TextColor="{StaticResource TextSecondary}" />
                 </Border>
                 <SearchBar
                     x:Name="PropertySearch"
                     Grid.Row="2"
                     AutomationId="property-search"
-                    HeightRequest="38"
-                    Placeholder="Search properties..."
+                    Placeholder="Search properties"
+                    SemanticProperties.Description="Search properties for the selected control"
                     TextChanged="OnPropertySearchChanged" />
                 <ScrollView Grid.Row="3">
                     <VerticalStackLayout x:Name="PropertyPanel" Spacing="8" />
@@ -309,31 +262,74 @@
         <Border
             x:Name="XamlPanel"
             Grid.Row="2"
-            HeightRequest="220"
+            HeightRequest="228"
             IsVisible="False"
-            Padding="14,10"
-            BackgroundColor="#131620"
-            Stroke="#292E3D"
+            Padding="16,11"
+            BackgroundColor="{StaticResource Surface}"
+            Stroke="{StaticResource Border}"
             StrokeThickness="1">
-            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,*" ColumnSpacing="10" RowSpacing="8">
-                <HorizontalStackLayout Spacing="10">
-                    <Label FontAttributes="Bold" FontSize="12" Text="XAML" TextColor="#F5F7FF" />
-                    <Label x:Name="XamlStatusLabel" FontSize="10" TextColor="#858DA2" />
-                </HorizontalStackLayout>
-                <HorizontalStackLayout Grid.Column="1" Spacing="7">
-                    <Button AutomationId="xaml-refresh" Clicked="OnRefreshXamlClicked" Style="{StaticResource ToolbarButton}" Text="Refresh" />
-                    <Button AutomationId="xaml-apply" Clicked="OnApplyXamlClicked" Style="{StaticResource ToolbarButton}" Text="Apply" />
-                </HorizontalStackLayout>
-                <Editor
-                    x:Name="XamlEditor"
-                    Grid.Row="1"
-                    Grid.ColumnSpan="2"
-                    AutomationId="xaml-editor"
-                    BackgroundColor="#0B0D12"
-                    FontSize="11"
-                    TextChanged="OnXamlTextChanged"
-                    TextColor="#DCE2F2" />
+            <Grid RowDefinitions="Auto,*" RowSpacing="9">
+                <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="9">
+                    <Label VerticalOptions="Center" FontAttributes="Bold" FontSize="12" Text="XAML" TextColor="{StaticResource TextPrimary}" />
+                    <ActivityIndicator
+                        x:Name="XamlBusyIndicator"
+                        Grid.Column="1"
+                        WidthRequest="18"
+                        HeightRequest="18"
+                        IsRunning="False"
+                        IsVisible="False"
+                        SemanticProperties.Description="Synchronizing XAML" />
+                    <HorizontalStackLayout Grid.Column="2" HorizontalOptions="End" Spacing="8">
+                        <Label VerticalOptions="Center" FontSize="10" Text="Changes sync live after a short pause" TextColor="{StaticResource TextMuted}" />
+                        <Border Padding="8,3" BackgroundColor="{StaticResource AccentSoft}" Stroke="{StaticResource AccentBorder}" StrokeShape="RoundRectangle 8">
+                            <Label x:Name="XamlStatusLabel" FontAttributes="Bold" FontSize="10" TextColor="{StaticResource TextSecondary}" />
+                        </Border>
+                    </HorizontalStackLayout>
+                </Grid>
+                <Border Grid.Row="1" BackgroundColor="{StaticResource SurfaceSubtle}" Stroke="{StaticResource BorderStrong}" StrokeShape="RoundRectangle 8">
+                    <Editor
+                        x:Name="XamlEditor"
+                        AutomationId="xaml-editor"
+                        Margin="1"
+                        BackgroundColor="Transparent"
+                        FontFamily="Consolas"
+                        FontSize="12"
+                        TextChanged="OnXamlTextChanged"
+                        TextColor="{StaticResource TextPrimary}" />
+                </Border>
             </Grid>
         </Border>
+
+        <Grid
+            x:Name="BusyOverlay"
+            Grid.RowSpan="3"
+            AutomationId="busy-overlay"
+            BackgroundColor="#66F8FAFC"
+            InputTransparent="False"
+            IsVisible="False">
+            <Border
+                Padding="28,22"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                BackgroundColor="{StaticResource Surface}"
+                Stroke="{StaticResource BorderStrong}"
+                StrokeShape="RoundRectangle 12"
+                Shadow="{Shadow Brush=#475569, Opacity=0.2, Radius=22, Offset='0,8'}">
+                <VerticalStackLayout MinimumWidthRequest="220" Spacing="12">
+                    <ActivityIndicator
+                        x:Name="BusyIndicator"
+                        HorizontalOptions="Center"
+                        IsRunning="False"
+                        SemanticProperties.Description="Designer operation in progress" />
+                    <Label
+                        x:Name="BusyLabel"
+                        HorizontalTextAlignment="Center"
+                        FontAttributes="Bold"
+                        FontSize="12"
+                        Text="Working…"
+                        TextColor="{StaticResource TextPrimary}" />
+                </VerticalStackLayout>
+            </Border>
+        </Grid>
     </Grid>
 </ContentPage>

--- a/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.App.Controls;
 using MAUIDesigner.Fresh.App.PropertyEditing;
+using MAUIDesigner.Fresh.App.Preview;
 using MAUIDesigner.Fresh.App.Rendering;
 using MAUIDesigner.Fresh.App.Workspace;
 using MAUIDesigner.Fresh.App.Xaml;
@@ -22,11 +24,25 @@ public partial class MainPage : ContentPage
     private readonly DesignerViewportState _viewport;
     private readonly CanvasGridDrawable _gridDrawable;
     private readonly CanvasRulerDrawable _rulerDrawable;
-    private readonly ObservableCollection<ControlDescriptor> _toolboxItems = [];
-    private readonly ObservableCollection<HierarchyItem> _hierarchyItems = [];
+    private readonly IRuntimePreviewService _runtimePreview;
     private bool _updatingXaml;
     private bool _xamlDirty;
+    private string _lastSerializedXaml = string.Empty;
     private bool _viewportInitialized;
+    private bool _nextDocumentChangeIsIncremental;
+    private bool _applyingLiveXaml;
+    private bool _renderScheduled;
+    private bool _pendingDocumentChange;
+    private bool _pendingFullRebuild;
+    private bool _pendingSelectionRefresh;
+    private bool _pendingSuppressXamlWriteback;
+    private bool _hierarchyDirty = true;
+    private int _xamlRevision;
+    private int _busyOperations;
+    private CancellationTokenSource? _xamlSyncCancellation;
+#if WINDOWS
+    private Microsoft.UI.Xaml.FrameworkElement? _platformRoot;
+#endif
 
     public MainPage(
         IControlCatalog catalog,
@@ -35,9 +51,21 @@ public partial class MainPage : ContentPage
         PropertyEditorRegistry propertyEditors,
         AssemblyExtensionLoader extensionLoader,
         XamlWorkspace xamlWorkspace,
-        DesignerViewportState viewport)
+        DesignerViewportState viewport,
+        IRuntimePreviewService runtimePreview)
     {
         InitializeComponent();
+        HierarchyList.ItemTemplate = new DataTemplate(() =>
+        {
+            var host = new ContentView();
+            host.BindingContextChanged += (_, _) =>
+            {
+                host.Content = host.BindingContext is HierarchyItem item
+                    ? CreateHierarchyRow(item.Node, item.Depth, item.IsLast)
+                    : null;
+            };
+            return host;
+        });
         _catalog = catalog;
         _workspace = workspace;
         _materializer = materializer;
@@ -45,6 +73,7 @@ public partial class MainPage : ContentPage
         _extensionLoader = extensionLoader;
         _xamlWorkspace = xamlWorkspace;
         _viewport = viewport;
+        _runtimePreview = runtimePreview;
         _gridDrawable = new CanvasGridDrawable(viewport);
         _rulerDrawable = new CanvasRulerDrawable(viewport);
         CanvasGridOverlay.Drawable = _gridDrawable;
@@ -53,8 +82,6 @@ public partial class MainPage : ContentPage
         DevicePicker.ItemsSource = _viewport.Devices.ToList();
         DevicePicker.SelectedItem = _viewport.SelectedDevice;
         GridSizeStepper.Value = _viewport.GridSize;
-        BindableLayout.SetItemsSource(ToolboxItemsHost, _toolboxItems);
-        HierarchyList.ItemsSource = _hierarchyItems;
         _workspace.Session.Changed += OnDocumentChanged;
         _workspace.SelectionChanged += OnSelectionChanged;
         _workspace.InteractionChanged += OnInteractionChanged;
@@ -64,6 +91,29 @@ public partial class MainPage : ContentPage
         RebuildDesigner();
         RefreshXaml();
         UpdateViewportVisuals();
+    }
+
+    protected override void OnHandlerChanged()
+    {
+#if WINDOWS
+        if (_platformRoot is not null)
+        {
+            _platformRoot.RemoveHandler(
+                Microsoft.UI.Xaml.UIElement.KeyDownEvent,
+                new Microsoft.UI.Xaml.Input.KeyEventHandler(OnNativeKeyDown));
+        }
+#endif
+        base.OnHandlerChanged();
+#if WINDOWS
+        if (Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement root)
+        {
+            _platformRoot = root;
+            root.AddHandler(
+                Microsoft.UI.Xaml.UIElement.KeyDownEvent,
+                new Microsoft.UI.Xaml.Input.KeyEventHandler(OnNativeKeyDown),
+                true);
+        }
+#endif
     }
 
     private void OnDeviceChanged(object? sender, EventArgs e)
@@ -93,13 +143,6 @@ public partial class MainPage : ContentPage
     private void OnZoomResetClicked(object? sender, EventArgs e)
     {
         _viewport.Reset(CanvasViewport.Width, CanvasViewport.Height);
-        UpdateViewportVisuals();
-    }
-
-    private void OnThemeClicked(object? sender, EventArgs e)
-    {
-        _viewport.ToggleTheme();
-        RebuildDesigner();
         UpdateViewportVisuals();
     }
 
@@ -168,14 +211,9 @@ public partial class MainPage : ContentPage
         CanvasTransformHost.TranslationY = _viewport.PanY;
         CanvasFrame.WidthRequest = _viewport.DesignWidth;
         CanvasFrame.HeightRequest = _viewport.DesignHeight;
-        CanvasFrame.BackgroundColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#111827")
-            : Colors.White;
-        CanvasViewport.BackgroundColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#080D17")
-            : Color.FromArgb("#0B0D12");
+        CanvasFrame.BackgroundColor = Colors.White;
+        CanvasViewport.BackgroundColor = Color.FromArgb("#EEF2F7");
         ZoomLabel.Text = $"{Math.Round(_viewport.Zoom * 100)}%";
-        ThemeButton.Text = _viewport.IsDarkPreview ? "Light" : "Dark";
         GridButton.BackgroundColor = _viewport.ShowGrid
             ? Color.FromArgb("#5946A3")
             : Color.FromArgb("#202431");
@@ -189,6 +227,7 @@ public partial class MainPage : ContentPage
             System.Globalization.CultureInfo.InvariantCulture);
         CanvasGridOverlay.Invalidate();
         CanvasRulerOverlay.Invalidate();
+        _materializer.RefreshGridTrackOverlays();
     }
 
     private void OnToolboxSearchChanged(object? sender, TextChangedEventArgs e) =>
@@ -241,27 +280,45 @@ public partial class MainPage : ContentPage
 
     private void OnHierarchyTabClicked(object? sender, EventArgs e) => ShowToolbox(show: false);
 
-    private void OnHierarchySelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (e.CurrentSelection.FirstOrDefault() is HierarchyItem item)
-        {
-            _workspace.Select(item.ElementId);
-        }
-
-        HierarchyList.SelectedItem = null;
-    }
-
     private void OnUndoClicked(object? sender, EventArgs e) => _workspace.Session.Undo();
 
     private void OnRedoClicked(object? sender, EventArgs e) => _workspace.Session.Redo();
 
     private void OnDeleteClicked(object? sender, EventArgs e) => _workspace.DeleteSelection();
 
+    private void OnCutClicked(object? sender, EventArgs e) => _workspace.CutSelection();
+
+    private void OnCopyClicked(object? sender, EventArgs e) => _workspace.CopySelection();
+
+    private void OnPasteClicked(object? sender, EventArgs e) => _ = _workspace.Paste();
+
+    private void OnDuplicateClicked(object? sender, EventArgs e) =>
+        _ = _workspace.DuplicateSelection();
+
+    private async void OnRunPreviewClicked(object? sender, EventArgs e)
+    {
+        SetBusy(true, "Opening preview...");
+        try
+        {
+            DevicePreset device = _viewport.SelectedDevice;
+            await _runtimePreview.OpenAsync(
+                _workspace.Session.Current,
+                new RuntimePreviewOptions(device.Name, device.Width, device.Height));
+        }
+        catch (InvalidOperationException exception)
+        {
+            ShowPropertyError(exception.Message);
+        }
+        finally
+        {
+            SetBusy(false);
+        }
+    }
+
     private void OnToggleXamlClicked(object? sender, EventArgs e)
     {
         bool opening = !XamlPanel.IsVisible;
         XamlPanel.IsVisible = opening;
-        DesignerBody.InputTransparent = opening;
         if (opening && !_xamlDirty)
         {
             RefreshXaml();
@@ -279,23 +336,89 @@ public partial class MainPage : ContentPage
             XamlStatusLabel.Text = diagnostic.Line is null
                 ? diagnostic.Message
                 : $"Line {diagnostic.Line}, column {diagnostic.Column}: {diagnostic.Message}";
-            XamlStatusLabel.TextColor = Color.FromArgb("#F87171");
+            XamlStatusLabel.TextColor = Color.FromArgb("#DC2626");
             return;
         }
 
         _workspace.ReplaceDocument(result.Document);
         _xamlDirty = false;
         XamlStatusLabel.Text = "Applied";
-        XamlStatusLabel.TextColor = Color.FromArgb("#86EFAC");
+        XamlStatusLabel.TextColor = Color.FromArgb("#16A34A");
     }
 
-    private void OnXamlTextChanged(object? sender, TextChangedEventArgs e)
+    private async void OnXamlTextChanged(object? sender, TextChangedEventArgs e)
     {
-        if (!_updatingXaml)
+        if (_updatingXaml ||
+            string.Equals(
+                XamlTextIdentity.Normalize(e.NewTextValue),
+                _lastSerializedXaml,
+                StringComparison.Ordinal))
         {
-            _xamlDirty = true;
-            XamlStatusLabel.Text = "Modified";
-            XamlStatusLabel.TextColor = Color.FromArgb("#FDE68A");
+            return;
+        }
+
+        _xamlDirty = true;
+        DesignerDocument sourceDocument = _workspace.Session.Current;
+        int revision = Interlocked.Increment(ref _xamlRevision);
+        _xamlSyncCancellation?.Cancel();
+        _xamlSyncCancellation?.Dispose();
+        _xamlSyncCancellation = new CancellationTokenSource();
+        CancellationToken cancellationToken = _xamlSyncCancellation.Token;
+        XamlStatusLabel.Text = "Waiting for valid XAML...";
+        XamlStatusLabel.TextColor = Color.FromArgb("#64748B");
+        XamlBusyIndicator.IsRunning = true;
+        XamlBusyIndicator.IsVisible = true;
+        try
+        {
+            await Task.Delay(300, cancellationToken);
+            var parseStopwatch = Stopwatch.StartNew();
+            string source = XamlEditor.Text ?? string.Empty;
+            XamlReadResult result = await Task.Run(
+                () => _xamlWorkspace.Parse(source),
+                cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (revision != _xamlRevision)
+            {
+                return;
+            }
+
+            if (!ReferenceEquals(sourceDocument, _workspace.Session.Current))
+            {
+                _xamlDirty = false;
+                RefreshXaml();
+                XamlStatusLabel.Text = "Canvas change kept";
+                return;
+            }
+
+            if (!result.Success || result.Document is null)
+            {
+                XamlDiagnostic diagnostic = result.Diagnostics.First();
+                XamlStatusLabel.Text = diagnostic.Line is null
+                    ? diagnostic.Message
+                    : $"Line {diagnostic.Line}, column {diagnostic.Column}: {diagnostic.Message}";
+                XamlStatusLabel.TextColor = Color.FromArgb("#DC2626");
+                return;
+            }
+
+            _applyingLiveXaml = true;
+            _workspace.ReplaceDocument(result.Document);
+            parseStopwatch.Stop();
+            ReportPerformance("live-xaml-parse-and-command", parseStopwatch.Elapsed, 100);
+            _xamlDirty = false;
+            XamlStatusLabel.Text = "Live";
+            XamlStatusLabel.TextColor = Color.FromArgb("#16A34A");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            if (revision == _xamlRevision)
+            {
+                _applyingLiveXaml = false;
+                XamlBusyIndicator.IsRunning = false;
+                XamlBusyIndicator.IsVisible = false;
+            }
         }
     }
 
@@ -314,7 +437,7 @@ public partial class MainPage : ContentPage
         {
             ExtensionLoadResult loaded = _extensionLoader.Load(result.FullPath);
             SelectionLabel.Text = $"{loaded.AssemblyName}: {loaded.ControlsAdded} controls added";
-            SelectionLabel.TextColor = Color.FromArgb("#86EFAC");
+            SelectionLabel.TextColor = Color.FromArgb("#16A34A");
         }
         catch (FileNotFoundException exception)
         {
@@ -330,11 +453,24 @@ public partial class MainPage : ContentPage
         }
     }
 
-    private void OnDocumentChanged(object? sender, DocumentChangedEventArgs e) =>
-        MainThread.BeginInvokeOnMainThread(RebuildDesigner);
+    private void OnDocumentChanged(object? sender, DocumentChangedEventArgs e)
+    {
+        bool incremental = _nextDocumentChangeIsIncremental;
+        bool suppressXamlWriteback = _applyingLiveXaml;
+        _nextDocumentChangeIsIncremental = false;
+        _pendingDocumentChange = true;
+        _pendingFullRebuild |= !incremental;
+        _pendingSuppressXamlWriteback |= suppressXamlWriteback;
+        if (_busyOperations == 0)
+        {
+            SetBusy(true, incremental ? "Applying property..." : "Rendering design...");
+        }
+
+        ScheduleRender();
+    }
 
     private void OnSelectionChanged(object? sender, EventArgs e) =>
-        MainThread.BeginInvokeOnMainThread(RebuildDesigner);
+        ScheduleSelectionRefresh();
 
     private void OnInteractionChanged(object? sender, EventArgs e) =>
         MainThread.BeginInvokeOnMainThread(_materializer.UpdateInteraction);
@@ -352,68 +488,442 @@ public partial class MainPage : ContentPage
                 descriptor.RuntimeType.FullName?.Contains(search, StringComparison.OrdinalIgnoreCase) == true);
         }
 
-        _toolboxItems.Clear();
-        foreach (ControlDescriptor descriptor in matches)
+        ControlDescriptor[] visible = matches.ToArray();
+        ToolboxItemsHost.Clear();
+        foreach (IGrouping<string, ControlDescriptor> category in visible
+                     .GroupBy(descriptor => descriptor.Category)
+                     .OrderBy(group => CategoryOrder(group.Key))
+                     .ThenBy(group => group.Key, StringComparer.Ordinal))
         {
-            _toolboxItems.Add(descriptor);
+            ToolboxItemsHost.Add(new Label
+            {
+                Text = category.Key.ToUpperInvariant(),
+                FontSize = 10,
+                FontAttributes = FontAttributes.Bold,
+                TextColor = Color.FromArgb("#6D5BD0"),
+                Margin = new Thickness(4, 12, 4, 4)
+            });
+            foreach (ControlDescriptor descriptor in category)
+            {
+                ToolboxItemsHost.Add(CreateToolboxItem(descriptor));
+            }
         }
 
-        ControlCountLabel.Text = _toolboxItems.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        ControlCountLabel.Text = visible.Length.ToString(
+            System.Globalization.CultureInfo.InvariantCulture);
     }
 
-    private void RebuildDesigner()
+    private void RebuildDesigner(bool suppressXamlWriteback = false)
     {
+        var stopwatch = Stopwatch.StartNew();
         CanvasHost.Content = _materializer.Materialize(_workspace.Session.Current);
         UndoButton.IsEnabled = _workspace.Session.CanUndo;
         RedoButton.IsEnabled = _workspace.Session.CanRedo;
-        RebuildHierarchy();
+        _hierarchyDirty = true;
+        if (HierarchyList.IsVisible)
+        {
+            RebuildHierarchy();
+        }
         RebuildPropertyPanel();
-        if (!_xamlDirty)
+        if (!_xamlDirty && !suppressXamlWriteback)
         {
             RefreshXaml();
+        }
+
+        stopwatch.Stop();
+        ReportPerformance("structural-rematerialization", stopwatch.Elapsed, 50);
+        if (stopwatch.ElapsedMilliseconds >= 100)
+        {
+            SelectionLabel.Text = $"Rendered in {stopwatch.ElapsedMilliseconds} ms";
         }
     }
 
     private void RefreshXaml()
     {
+        string xaml = _xamlWorkspace.Write(_workspace.Session.Current);
+        _lastSerializedXaml = XamlTextIdentity.Normalize(xaml);
         _updatingXaml = true;
-        XamlEditor.Text = _xamlWorkspace.Write(_workspace.Session.Current);
-        _updatingXaml = false;
+        XamlEditor.Text = xaml;
+        Dispatcher.Dispatch(() => _updatingXaml = false);
         _xamlDirty = false;
         XamlStatusLabel.Text = "Synchronized";
-        XamlStatusLabel.TextColor = Color.FromArgb("#858DA2");
+        XamlStatusLabel.TextColor = Color.FromArgb("#64748B");
     }
 
     private void RebuildHierarchy()
     {
-        _hierarchyItems.Clear();
-        AddHierarchyNode(_workspace.Session.Current.Root, 0);
+        _hierarchyDirty = false;
+        var items = new List<HierarchyItem>();
+        AddHierarchyItems(_workspace.Session.Current.Root, 0, isLast: true, items);
+        HierarchyList.ItemsSource = items;
     }
 
-    private void AddHierarchyNode(DesignerNode node, int depth)
+    private static void AddHierarchyItems(
+        DesignerNode node,
+        int depth,
+        bool isLast,
+        List<HierarchyItem> items)
+    {
+        items.Add(new HierarchyItem(node, depth, isLast));
+        for (int index = 0; index < node.Children.Length; index++)
+        {
+            AddHierarchyItems(
+                node.Children[index],
+                depth + 1,
+                index == node.Children.Length - 1,
+                items);
+        }
+    }
+
+    private Border CreateHierarchyRow(DesignerNode node, int depth, bool isLast)
     {
         string displayName = _catalog.TryGet(node.ControlType, out ControlDescriptor? descriptor)
             ? descriptor?.DisplayName ?? node.ControlType.XamlName
             : node.ControlType.XamlName;
-        _hierarchyItems.Add(new HierarchyItem(
-            node.Id,
-            displayName,
-            node.Id.Value,
-            new Thickness(depth * 14, 0, 0, 6),
-            node.Id == _workspace.SelectedId));
+
+        bool selected = node.Id == _workspace.SelectedId;
+        var row = new Border
+        {
+            AutomationId = $"hierarchy-{node.Id.Value}",
+            Margin = new Thickness(depth * 16, 0, 0, 5),
+            Padding = new Thickness(8, 6),
+            BackgroundColor = selected
+                ? Color.FromArgb("#EDE9FE")
+                : Colors.White,
+            Stroke = selected
+                ? Color.FromArgb("#6D5BD0")
+                : Color.FromArgb("#DDE3EC"),
+            StrokeThickness = selected ? 2 : 1,
+            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
+            {
+                CornerRadius = new CornerRadius(7)
+            }
+        };
+        var content = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(new GridLength(18)),
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(new GridLength(28)),
+                new ColumnDefinition(new GridLength(28)),
+                new ColumnDefinition(new GridLength(28))
+            },
+            ColumnSpacing = 3
+        };
+        content.Add(new Label
+        {
+            Text = depth == 0 ? "◆" : isLast ? "└" : "├",
+            FontSize = 10,
+            TextColor = Color.FromArgb("#6D5BD0"),
+            VerticalTextAlignment = TextAlignment.Center
+        });
+        var labels = new VerticalStackLayout { Spacing = 0 };
+        labels.Add(new Label
+        {
+            Text = displayName,
+            FontSize = 11,
+            FontAttributes = selected ? FontAttributes.Bold : FontAttributes.None,
+            TextColor = Color.FromArgb("#172033")
+        });
+        labels.Add(new Label
+        {
+            Text = $"{node.Id.Value}  ·  {node.Children.Length} children",
+            FontSize = 9,
+            TextColor = Color.FromArgb("#64748B")
+        });
+        content.Add(labels, 1);
+        content.Add(CreateHierarchyAction("↑", "Move up", 2, () =>
+        {
+            _workspace.Select(node.Id);
+            _ = _workspace.MoveSelection(-1);
+        }));
+        content.Add(CreateHierarchyAction("↓", "Move down", 3, () =>
+        {
+            _workspace.Select(node.Id);
+            _ = _workspace.MoveSelection(1);
+        }));
+        content.Add(CreateHierarchyAction("×", "Delete", 4, () =>
+        {
+            _workspace.Select(node.Id);
+            _workspace.DeleteSelection();
+        }, destructive: true));
+        row.Content = content;
+        var select = new TapGestureRecognizer();
+        select.Tapped += (_, _) =>
+        {
+            _workspace.Select(node.Id);
+            FocusCanvasElement(node.Id);
+        };
+        row.GestureRecognizers.Add(select);
+        AttachHierarchyDragDrop(row, node);
+        AttachContextMenu(row, node.Id);
+        return row;
+    }
+
+    private void AttachHierarchyDragDrop(View row, DesignerNode node)
+    {
+        if (node.Id != _workspace.Session.Current.Root.Id)
+        {
+            var drag = new DragGestureRecognizer();
+            drag.DragStarting += (_, args) =>
+            {
+                _workspace.Select(node.Id);
+                args.Data.Properties["DesignerElementId"] = node.Id.Value;
+            };
+            row.GestureRecognizers.Add(drag);
+        }
+
+        var drop = new DropGestureRecognizer { AllowDrop = true };
+        Color restingColor = node.Id == _workspace.SelectedId
+            ? Color.FromArgb("#EDE9FE")
+            : Colors.White;
+        drop.DragOver += (_, args) =>
+        {
+            if (TryGetDraggedElement(args.Data, out ElementId sourceId) &&
+                sourceId != node.Id)
+            {
+                args.AcceptedOperation = DataPackageOperation.Copy;
+                row.BackgroundColor = Color.FromArgb("#DDD6FE");
+                _workspace.SetDropTarget(node.Id);
+            }
+        };
+        drop.DragLeave += (_, _) =>
+        {
+            row.BackgroundColor = restingColor;
+            _workspace.ClearDropTarget();
+        };
+        drop.Drop += (_, args) =>
+        {
+            try
+            {
+                if (TryGetDraggedElement(args.Data, out ElementId sourceId) &&
+                    sourceId != node.Id)
+                {
+                    ReparentFromHierarchy(sourceId, node);
+                }
+            }
+            catch (InvalidOperationException exception)
+            {
+                ShowPropertyError(exception.Message);
+            }
+            finally
+            {
+                row.BackgroundColor = restingColor;
+                _workspace.ClearDropTarget();
+            }
+        };
+        row.GestureRecognizers.Add(drop);
+    }
+
+    private void ReparentFromHierarchy(ElementId sourceId, DesignerNode target)
+    {
+        if (_catalog.TryGet(target.ControlType, out ControlDescriptor? descriptor) &&
+            descriptor?.AcceptsChildren == true)
+        {
+            _workspace.Reparent(
+                sourceId,
+                target.Id,
+                new LayoutPlacement(target.Children.Length));
+            return;
+        }
+
+        DesignerNode? parent = FindParent(_workspace.Session.Current.Root, target.Id);
+        if (parent is null)
+        {
+            return;
+        }
+
+        int destinationIndex = parent.Children.IndexOf(target);
+        DesignerNode? sourceParent = FindParent(_workspace.Session.Current.Root, sourceId);
+        if (sourceParent?.Id == parent.Id &&
+            IndexOfChild(sourceParent, sourceId) < destinationIndex)
+        {
+            destinationIndex--;
+        }
+
+        _workspace.Reparent(
+            sourceId,
+            parent.Id,
+            new LayoutPlacement(destinationIndex));
+    }
+
+    private static DesignerNode? FindParent(DesignerNode node, ElementId childId)
+    {
         foreach (DesignerNode child in node.Children)
         {
-            AddHierarchyNode(child, depth + 1);
+            if (child.Id == childId)
+            {
+                return node;
+            }
+
+            DesignerNode? descendantParent = FindParent(child, childId);
+            if (descendantParent is not null)
+            {
+                return descendantParent;
+            }
         }
+
+        return null;
     }
+
+    private static int IndexOfChild(DesignerNode parent, ElementId childId)
+    {
+        for (int index = 0; index < parent.Children.Length; index++)
+        {
+            if (parent.Children[index].Id == childId)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TryGetDraggedElement(
+        DataPackage data,
+        out ElementId elementId)
+    {
+        data.Properties.TryGetValue("DesignerElementId", out object? raw);
+        return TryCreateElementId(raw, out elementId);
+    }
+
+    private static bool TryGetDraggedElement(
+        DataPackageView data,
+        out ElementId elementId)
+    {
+        data.Properties.TryGetValue("DesignerElementId", out object? raw);
+        return TryCreateElementId(raw, out elementId);
+    }
+
+    private static bool TryCreateElementId(object? raw, out ElementId elementId)
+    {
+        bool valid = raw is string value && !string.IsNullOrWhiteSpace(value);
+        elementId = valid ? new ElementId((string)raw!) : default;
+        return valid;
+    }
+
+    private static Button CreateHierarchyAction(
+        string text,
+        string description,
+        int column,
+        Action action,
+        bool destructive = false)
+    {
+        var button = new Button
+        {
+            Text = text,
+            FontSize = 11,
+            WidthRequest = 26,
+            HeightRequest = 26,
+            Padding = 0,
+            CornerRadius = 6,
+            BackgroundColor = destructive
+                ? Color.FromArgb("#FEF2F2")
+                : Color.FromArgb("#F1F5F9"),
+            TextColor = destructive
+                ? Color.FromArgb("#DC2626")
+                : Color.FromArgb("#475569")
+        };
+        SemanticProperties.SetDescription(button, description);
+        button.Clicked += (_, _) => action();
+        Grid.SetColumn(button, column);
+        return button;
+    }
+
+    private void FocusCanvasElement(ElementId elementId)
+    {
+        DesignerNode? node = _workspace.Session.Current.Find(elementId);
+        if (node?.Bounds is { } bounds)
+        {
+            _viewport.CenterOn(
+                bounds.X + bounds.Width / 2,
+                bounds.Y + bounds.Height / 2,
+                CanvasViewport.Width,
+                CanvasViewport.Height);
+            UpdateViewportVisuals();
+        }
+
+        _materializer.UpdateInteraction();
+    }
+
+    private void AttachContextMenu(View target, ElementId elementId)
+    {
+#if WINDOWS
+        target.HandlerChanged += (_, _) =>
+        {
+            if (target.Handler?.PlatformView is not Microsoft.UI.Xaml.FrameworkElement native ||
+                native.ContextFlyout is not null)
+            {
+                return;
+            }
+
+            var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
+            AddContextMenuItem(menu, "Cut", () =>
+            {
+                _workspace.Select(elementId);
+                _workspace.CutSelection();
+            });
+            AddContextMenuItem(menu, "Copy", () =>
+            {
+                _workspace.Select(elementId);
+                _workspace.CopySelection();
+            });
+            AddContextMenuItem(menu, "Paste", () =>
+            {
+                _workspace.Select(elementId);
+                _ = _workspace.Paste();
+            });
+            AddContextMenuItem(menu, "Duplicate", () =>
+            {
+                _workspace.Select(elementId);
+                _ = _workspace.DuplicateSelection();
+            });
+            AddContextMenuItem(menu, "Move up", () =>
+            {
+                _workspace.Select(elementId);
+                _ = _workspace.MoveSelection(-1);
+            });
+            AddContextMenuItem(menu, "Move down", () =>
+            {
+                _workspace.Select(elementId);
+                _ = _workspace.MoveSelection(1);
+            });
+            AddContextMenuItem(menu, "Delete", () =>
+            {
+                _workspace.Select(elementId);
+                _workspace.DeleteSelection();
+            });
+            native.ContextFlyout = menu;
+        };
+#endif
+    }
+
+#if WINDOWS
+    private static void AddContextMenuItem(
+        Microsoft.UI.Xaml.Controls.MenuFlyout menu,
+        string text,
+        Action action)
+    {
+        var item = new Microsoft.UI.Xaml.Controls.MenuFlyoutItem { Text = text };
+        item.Click += (_, _) => action();
+        menu.Items.Add(item);
+    }
+#endif
 
     private void ShowToolbox(bool show)
     {
         ToolboxSearch.IsVisible = show;
         ToolboxList.IsVisible = show;
         HierarchyList.IsVisible = !show;
-        ToolboxTabButton.BackgroundColor = show ? Color.FromArgb("#7C5CFF") : Color.FromArgb("#202431");
-        HierarchyTabButton.BackgroundColor = show ? Color.FromArgb("#202431") : Color.FromArgb("#7C5CFF");
+        ToolboxTabButton.BackgroundColor = show ? Color.FromArgb("#6D5BD0") : Color.FromArgb("#EEF1F6");
+        ToolboxTabButton.TextColor = show ? Colors.White : Color.FromArgb("#475569");
+        HierarchyTabButton.BackgroundColor = show ? Color.FromArgb("#EEF1F6") : Color.FromArgb("#6D5BD0");
+        HierarchyTabButton.TextColor = show ? Color.FromArgb("#475569") : Colors.White;
+        if (!show && _hierarchyDirty)
+        {
+            RebuildHierarchy();
+        }
     }
 
     private void RebuildPropertyPanel()
@@ -444,7 +954,7 @@ public partial class MainPage : ContentPage
                 Text = group.Key.ToUpperInvariant(),
                 FontSize = 9,
                 FontAttributes = FontAttributes.Bold,
-                TextColor = Color.FromArgb("#7C5CFF"),
+                TextColor = Color.FromArgb("#6D5BD0"),
                 Margin = new Thickness(0, 6, 0, 0)
             });
             foreach (PropertyDescriptor property in group)
@@ -455,7 +965,7 @@ public partial class MainPage : ContentPage
                 var context = new PropertyEditorContext(
                     property,
                     value,
-                    newValue => CommitProperty(property, newValue),
+                    newValue => CommitProperty(selected.Id, property, newValue),
                     ShowPropertyError);
                 if (!_propertyEditors.TryCreate(context, out View? editor) || editor is null)
                 {
@@ -471,7 +981,7 @@ public partial class MainPage : ContentPage
                         {
                             Text = property.Name,
                             FontSize = 10,
-                            TextColor = Color.FromArgb("#AEB5C7")
+                            TextColor = Color.FromArgb("#475569")
                         },
                         editor
                     }
@@ -483,12 +993,15 @@ public partial class MainPage : ContentPage
     private void ShowPropertyError(string message)
     {
         SelectionLabel.Text = message;
-        SelectionLabel.TextColor = Color.FromArgb("#F87171");
+        SelectionLabel.TextColor = Color.FromArgb("#DC2626");
     }
 
-    private void CommitProperty(PropertyDescriptor property, string? text)
+    private void CommitProperty(
+        ElementId elementId,
+        PropertyDescriptor property,
+        string? text)
     {
-        DesignerNode? selected = _workspace.Session.Current.Find(_workspace.SelectedId);
+        DesignerNode? selected = _workspace.Session.Current.Find(elementId);
         if (selected is null)
         {
             return;
@@ -505,13 +1018,258 @@ public partial class MainPage : ContentPage
             !DesignerValueConverter.TryConvert(newValue.Text, property.ValueType, out _))
         {
             SelectionLabel.Text = $"{property.Name}: invalid {property.ValueType.Name}";
-            SelectionLabel.TextColor = Color.FromArgb("#F87171");
+            SelectionLabel.TextColor = Color.FromArgb("#DC2626");
             return;
         }
 
-        SelectionLabel.TextColor = Color.FromArgb("#798196");
+        SelectionLabel.TextColor = Color.FromArgb("#64748B");
+        var stopwatch = Stopwatch.StartNew();
+        bool incremental = newValue is not null &&
+            _materializer.TryApplyProperty(selected.Id, property.Name, newValue);
+        _nextDocumentChangeIsIncremental = incremental;
         _workspace.Session.Execute(new SetPropertyCommand(selected.Id, property.Name, newValue));
+        stopwatch.Stop();
+        ReportPerformance("literal-property-commit", stopwatch.Elapsed, 16);
+        SelectionLabel.Text = $"{property.Name} updated";
+        SelectionLabel.TextColor = Color.FromArgb("#16A34A");
     }
+
+    private ToolboxItemView CreateToolboxItem(ControlDescriptor descriptor)
+    {
+        var item = new ToolboxItemView
+        {
+            AutomationId = descriptor.AutomationId,
+            Descriptor = descriptor,
+            Margin = new Thickness(0, 0, 0, 6),
+            Padding = new Thickness(10, 8),
+            BackgroundColor = Colors.White,
+            Stroke = Color.FromArgb("#DDE3EC"),
+            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
+            {
+                CornerRadius = new CornerRadius(8)
+            },
+            Content = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(new GridLength(32)),
+                    new ColumnDefinition(GridLength.Star)
+                },
+                Children =
+                {
+                    new Border
+                    {
+                        WidthRequest = 26,
+                        HeightRequest = 26,
+                        BackgroundColor = Color.FromArgb("#EEF0FF"),
+                        StrokeThickness = 0,
+                        StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
+                        {
+                            CornerRadius = new CornerRadius(7)
+                        },
+                        Content = new Label
+                        {
+                            Text = "+",
+                            TextColor = Color.FromArgb("#6554C0"),
+                            FontAttributes = FontAttributes.Bold,
+                            HorizontalTextAlignment = TextAlignment.Center,
+                            VerticalTextAlignment = TextAlignment.Center
+                        }
+                    },
+                    new Label
+                    {
+                        Text = descriptor.DisplayName,
+                        TextColor = Color.FromArgb("#172033"),
+                        FontSize = 12,
+                        VerticalTextAlignment = TextAlignment.Center,
+                        Margin = new Thickness(8, 0, 0, 0)
+                    }
+                }
+            }
+        };
+        ((BindableObject)((Microsoft.Maui.Controls.Grid)item.Content).Children[1])
+            .SetValue(Microsoft.Maui.Controls.Grid.ColumnProperty, 1);
+        item.ItemDragUpdated += OnToolboxDragUpdated;
+        item.ItemTapped += OnToolboxItemTapped;
+        return item;
+    }
+
+    private static int CategoryOrder(string category) =>
+        category switch
+        {
+            "Layouts" => 0,
+            "Input" => 1,
+            "Display" => 2,
+            "Data and collections" => 3,
+            _ => 10
+        };
+
+    private void ScheduleSelectionRefresh()
+    {
+        _pendingSelectionRefresh = true;
+        ScheduleRender();
+    }
+
+    private void ScheduleRender()
+    {
+        if (_renderScheduled)
+        {
+            return;
+        }
+
+        _renderScheduled = true;
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            _renderScheduled = false;
+            bool documentChanged = _pendingDocumentChange;
+            bool fullRebuild = _pendingFullRebuild;
+            bool selectionChanged = _pendingSelectionRefresh;
+            bool suppressXamlWriteback = _pendingSuppressXamlWriteback;
+            _pendingDocumentChange = false;
+            _pendingFullRebuild = false;
+            _pendingSelectionRefresh = false;
+            _pendingSuppressXamlWriteback = false;
+            try
+            {
+                UndoButton.IsEnabled = _workspace.Session.CanUndo;
+                RedoButton.IsEnabled = _workspace.Session.CanRedo;
+                if (fullRebuild)
+                {
+                    RebuildDesigner(suppressXamlWriteback);
+                }
+                else
+                {
+                    if (documentChanged && !_xamlDirty && !suppressXamlWriteback)
+                    {
+                        RefreshXaml();
+                    }
+
+                    if (selectionChanged)
+                    {
+                        var stopwatch = Stopwatch.StartNew();
+                        _materializer.UpdateInteraction();
+                        stopwatch.Stop();
+                        ReportPerformance("selection-chrome", stopwatch.Elapsed, 5);
+                        _hierarchyDirty = true;
+                        if (HierarchyList.IsVisible)
+                        {
+                            RebuildHierarchy();
+                        }
+                        SetBusy(true, "Loading properties...");
+                        Dispatcher.DispatchDelayed(
+                            TimeSpan.FromMilliseconds(1),
+                            () =>
+                            {
+                                try
+                                {
+                                    RebuildPropertyPanel();
+                                }
+                                finally
+                                {
+                                    SetBusy(false);
+                                }
+                            });
+                    }
+                }
+            }
+            finally
+            {
+                if (documentChanged)
+                {
+                    SetBusy(false);
+                }
+            }
+        });
+    }
+
+    private void SetBusy(bool busy, string? message = null)
+    {
+        _busyOperations = Math.Max(0, _busyOperations + (busy ? 1 : -1));
+        bool visible = _busyOperations > 0;
+        BusyOverlay.IsVisible = visible;
+        BusyIndicator.IsRunning = visible;
+        if (message is not null)
+        {
+            BusyLabel.Text = message;
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void ReportPerformance(
+        string operation,
+        TimeSpan elapsed,
+        int budgetMilliseconds)
+    {
+        string outcome = elapsed.TotalMilliseconds <= budgetMilliseconds ? "PASS" : "MISS";
+        Console.WriteLine(
+            $"[DesignerPerformance] {outcome} {operation} " +
+            $"{elapsed.TotalMilliseconds:F2} ms / {budgetMilliseconds} ms");
+    }
+
+    private sealed record HierarchyItem(
+        DesignerNode Node,
+        int Depth,
+        bool IsLast);
+
+#if WINDOWS
+    private void OnNativeKeyDown(
+        object sender,
+        Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (_platformRoot?.XamlRoot is null ||
+            Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(_platformRoot.XamlRoot) is
+                Microsoft.UI.Xaml.Controls.TextBox or
+                Microsoft.UI.Xaml.Controls.RichEditBox or
+                Microsoft.UI.Xaml.Controls.PasswordBox)
+        {
+            return;
+        }
+
+        bool control = Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+        bool alt = Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Menu)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+
+        if (control)
+        {
+            switch (e.Key)
+            {
+                case Windows.System.VirtualKey.C:
+                    _workspace.CopySelection();
+                    e.Handled = true;
+                    return;
+                case Windows.System.VirtualKey.X:
+                    _workspace.CutSelection();
+                    e.Handled = true;
+                    return;
+                case Windows.System.VirtualKey.V:
+                    _ = _workspace.Paste();
+                    e.Handled = true;
+                    return;
+                case Windows.System.VirtualKey.D:
+                    _ = _workspace.DuplicateSelection();
+                    e.Handled = true;
+                    return;
+            }
+        }
+
+        if (alt && e.Key is Windows.System.VirtualKey.Up or Windows.System.VirtualKey.Down)
+        {
+            _ = _workspace.MoveSelection(
+                e.Key == Windows.System.VirtualKey.Up ? -1 : 1);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Windows.System.VirtualKey.Delete)
+        {
+            _workspace.DeleteSelection();
+            e.Handled = true;
+        }
+    }
+#endif
 
     private static bool IsEditableProperty(PropertyDescriptor property)
     {

--- a/maui-designer-native/MAUIDesigner.Fresh.App/MauiProgram.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/MauiProgram.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Maui;
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.App.PropertyEditing;
+using MAUIDesigner.Fresh.App.Preview;
 using MAUIDesigner.Fresh.App.Rendering;
 using MAUIDesigner.Fresh.App.Workspace;
 using MAUIDesigner.Fresh.App.Xaml;
@@ -52,6 +53,10 @@ public static class MauiProgram
 		builder.Services.AddSingleton<ControlMaterializer>();
 		builder.Services.AddSingleton<DesignerViewportState>();
 		builder.Services.AddSingleton<PropertyEditorRegistry>();
+		builder.Services.AddSingleton<PreviewDocumentRenderer>();
+		builder.Services.AddSingleton<IPreviewDispatcher, MainThreadPreviewDispatcher>();
+		builder.Services.AddSingleton<IPreviewWindowHost, MauiPreviewWindowHost>();
+		builder.Services.AddSingleton<IRuntimePreviewService, RuntimePreviewService>();
 		builder.Services.AddSingleton<MainPage>();
 
 		return builder.Build();

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Preview/IRuntimePreviewService.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Preview/IRuntimePreviewService.cs
@@ -1,0 +1,25 @@
+using MAUIDesigner.Fresh.Core.Documents;
+
+namespace MAUIDesigner.Fresh.App.Preview;
+
+public interface IRuntimePreviewService
+{
+    Task<Window> OpenAsync(
+        DesignerDocument document,
+        RuntimePreviewOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record RuntimePreviewOptions(
+    string DeviceName,
+    double Width,
+    double Height)
+{
+    public static RuntimePreviewOptions Responsive { get; } =
+        new("Responsive", 0, 0);
+
+    public string DisplayText =>
+        Width > 0 && Height > 0
+            ? $"{DeviceName} · {Width:0} × {Height:0}"
+            : DeviceName;
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Preview/PreviewDocumentRenderer.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Preview/PreviewDocumentRenderer.cs
@@ -1,0 +1,218 @@
+using System.Reflection;
+using MAUIDesigner.Fresh.App.Catalog;
+using MAUIDesigner.Fresh.App.Rendering;
+using MAUIDesigner.Fresh.Core.Documents;
+
+namespace MAUIDesigner.Fresh.App.Preview;
+
+public sealed class PreviewDocumentRenderer
+{
+    private readonly IControlCatalog _catalog;
+    private readonly LayoutAdapterRegistry _layoutAdapters = new();
+
+    public PreviewDocumentRenderer(IControlCatalog catalog)
+    {
+        _catalog = catalog;
+    }
+
+    public View Materialize(DesignerDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        document.Validate();
+        return Build(document.Root);
+    }
+
+    private View Build(DesignerNode node)
+    {
+        if (!_catalog.TryGet(node.ControlType, out ControlDescriptor? descriptor) ||
+            descriptor is null)
+        {
+            return CreatePlaceholder(
+                node,
+                $"Control type '{node.ControlType.XamlName}' is not registered.");
+        }
+
+        View view;
+        try
+        {
+            view = _catalog.Create(node.ControlType);
+            ApplyProperties(view, descriptor, node);
+            view.AutomationId = $"preview-{node.Id.Value}";
+        }
+        catch (Exception exception) when (IsRecoverable(exception))
+        {
+            return CreatePlaceholder(node, GetReason(exception));
+        }
+
+        ILayoutAdapter? adapter;
+        try
+        {
+            adapter = descriptor.AcceptsChildren
+                ? _layoutAdapters.Resolve(descriptor)
+                : null;
+        }
+        catch (Exception exception) when (IsRecoverable(exception))
+        {
+            return CreatePlaceholder(node, GetReason(exception));
+        }
+
+        foreach (DesignerNode childNode in node.Children)
+        {
+            View child = Build(childNode);
+            try
+            {
+                if (childNode.ParentPropertyName is string propertyName)
+                {
+                    SetVisualProperty(view, propertyName, child);
+                }
+                else if (adapter is not null)
+                {
+                    adapter.AddChild(view, child, childNode);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"'{node.ControlType.XamlName}' does not accept visual children.");
+                }
+            }
+            catch (Exception exception) when (IsRecoverable(exception))
+            {
+                TryAddAttachmentPlaceholder(
+                    view,
+                    adapter,
+                    childNode,
+                    CreatePlaceholder(childNode, GetReason(exception)));
+            }
+        }
+
+        return view;
+    }
+
+    private static void ApplyProperties(
+        View view,
+        ControlDescriptor descriptor,
+        DesignerNode node)
+    {
+        foreach ((string name, DesignerValue designerValue) in node.Properties)
+        {
+            if (!TryGetPreviewText(designerValue, out string text))
+            {
+                continue;
+            }
+
+            PropertyDescriptor? propertyDescriptor = descriptor.Properties.FirstOrDefault(
+                property =>
+                    string.Equals(property.Name, name, StringComparison.Ordinal) &&
+                    !property.IsReadOnly);
+            if (propertyDescriptor is null ||
+                !DesignerValueConverter.TryConvert(
+                    text,
+                    propertyDescriptor.ValueType,
+                    out object? value))
+            {
+                continue;
+            }
+
+            if (GetWritableProperties(descriptor.RuntimeType)
+                .TryGetValue(name, out PropertyInfo? property))
+            {
+                property.SetValue(view, value);
+            }
+        }
+    }
+
+    private static IReadOnlyDictionary<string, PropertyInfo> GetWritableProperties(Type type) =>
+        RuntimePropertyCache.GetWritableProperties(type);
+
+    private static bool TryGetPreviewText(DesignerValue value, out string text)
+    {
+        if (value.Kind == DesignerValueKind.Literal)
+        {
+            text = value.Text;
+            return true;
+        }
+
+        if (value.Kind == DesignerValueKind.MarkupExtension &&
+            DesignerMarkupPreview.TryGetLiteral(value.Text, out string preview))
+        {
+            text = preview;
+            return true;
+        }
+
+        text = string.Empty;
+        return false;
+    }
+
+    private static void SetVisualProperty(View parent, string propertyName, View child)
+    {
+        PropertyInfo property = VisualContentProperty.FindAll(parent.GetType())
+            .FirstOrDefault(candidate =>
+                string.Equals(candidate.Name, propertyName, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"Visual property '{propertyName}' is unavailable on '{parent.GetType().FullName}'.");
+        property.SetValue(parent, child);
+    }
+
+    private static void TryAddAttachmentPlaceholder(
+        View parent,
+        ILayoutAdapter? adapter,
+        DesignerNode childNode,
+        View placeholder)
+    {
+        try
+        {
+            if (childNode.ParentPropertyName is string propertyName)
+            {
+                SetVisualProperty(parent, propertyName, placeholder);
+            }
+            else
+            {
+                adapter?.AddChild(parent, placeholder, childNode);
+            }
+        }
+        catch (Exception exception) when (IsRecoverable(exception))
+        {
+        }
+    }
+
+    private static Border CreatePlaceholder(DesignerNode node, string reason) =>
+        new()
+        {
+            AutomationId = $"preview-error-{node.Id.Value}",
+            Padding = 12,
+            Margin = 4,
+            BackgroundColor = Color.FromArgb("#FFF1F2"),
+            Stroke = Color.FromArgb("#E11D48"),
+            StrokeThickness = 1,
+            Content = new VerticalStackLayout
+            {
+                Spacing = 4,
+                Children =
+                {
+                    new Label
+                    {
+                        Text = $"Could not render {node.ControlType.XamlName}",
+                        FontAttributes = FontAttributes.Bold,
+                        TextColor = Color.FromArgb("#9F1239")
+                    },
+                    new Label
+                    {
+                        Text = reason,
+                        FontSize = 12,
+                        TextColor = Color.FromArgb("#881337"),
+                        LineBreakMode = LineBreakMode.WordWrap
+                    }
+                }
+            }
+        };
+
+    private static string GetReason(Exception exception) =>
+        exception.InnerException?.Message ?? exception.Message;
+
+    private static bool IsRecoverable(Exception exception) =>
+        exception is not OutOfMemoryException and
+        not StackOverflowException and
+        not AccessViolationException and
+        not AppDomainUnloadedException and
+        not BadImageFormatException;
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Preview/RuntimePreviewService.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Preview/RuntimePreviewService.cs
@@ -1,0 +1,153 @@
+using MAUIDesigner.Fresh.Core.Documents;
+
+namespace MAUIDesigner.Fresh.App.Preview;
+
+public sealed class RuntimePreviewService : IRuntimePreviewService
+{
+    public const string WindowTitle = "MAUI Designer Preview";
+
+    private readonly PreviewDocumentRenderer _renderer;
+    private readonly IPreviewDispatcher _dispatcher;
+    private readonly IPreviewWindowHost _windowHost;
+
+    public RuntimePreviewService(
+        PreviewDocumentRenderer renderer,
+        IPreviewDispatcher dispatcher,
+        IPreviewWindowHost windowHost)
+    {
+        _renderer = renderer;
+        _dispatcher = dispatcher;
+        _windowHost = windowHost;
+    }
+
+    public Task<Window> OpenAsync(
+        DesignerDocument document,
+        RuntimePreviewOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        cancellationToken.ThrowIfCancellationRequested();
+        options ??= RuntimePreviewOptions.Responsive;
+
+        return _dispatcher.InvokeAsync(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            View renderedContent = _renderer.Materialize(document);
+            Window? window = null;
+            var closeButton = new Button
+            {
+                Text = "Close",
+                AutomationId = "preview-close",
+                Padding = new Thickness(14, 6),
+                Command = new Command(() =>
+                {
+                    if (window is not null)
+                    {
+                        _windowHost.Close(window);
+                    }
+                })
+            };
+            var header = new Grid
+            {
+                AutomationId = "preview-header",
+                Padding = new Thickness(16, 10),
+                BackgroundColor = Color.FromArgb("#F8FAFC"),
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(GridLength.Star),
+                    new ColumnDefinition(GridLength.Auto)
+                }
+            };
+            header.Add(new Label
+            {
+                Text = options.DisplayText,
+                AutomationId = "preview-device-info",
+                FontAttributes = FontAttributes.Bold,
+                TextColor = Color.FromArgb("#334155"),
+                VerticalTextAlignment = TextAlignment.Center
+            });
+            header.Add(closeButton, 1);
+
+            var deviceSurface = new Border
+            {
+                AutomationId = "preview-device-surface",
+                BackgroundColor = Colors.White,
+                Stroke = Color.FromArgb("#CBD5E1"),
+                StrokeThickness = 1,
+                Content = renderedContent,
+                WidthRequest = options.Width > 0 ? options.Width : -1,
+                HeightRequest = options.Height > 0 ? options.Height : -1,
+                HorizontalOptions = options.Width > 0
+                    ? LayoutOptions.Center
+                    : LayoutOptions.Fill,
+                VerticalOptions = options.Height > 0
+                    ? LayoutOptions.Start
+                    : LayoutOptions.Fill
+            };
+            var pageLayout = new Grid
+            {
+                BackgroundColor = Color.FromArgb("#E2E8F0"),
+                RowDefinitions =
+                {
+                    new RowDefinition(GridLength.Auto),
+                    new RowDefinition(GridLength.Star)
+                }
+            };
+            pageLayout.Add(header);
+            pageLayout.Add(new ScrollView
+            {
+                AutomationId = "preview-scroll",
+                Orientation = ScrollOrientation.Both,
+                Padding = 20,
+                Content = deviceSurface
+            }, 0, 1);
+
+            window = new Window(new ContentPage
+            {
+                BackgroundColor = Color.FromArgb("#E2E8F0"),
+                Content = pageLayout
+            })
+            {
+                Title = WindowTitle
+            };
+            _windowHost.Open(window);
+            return window;
+        });
+    }
+}
+
+public interface IPreviewDispatcher
+{
+    Task<T> InvokeAsync<T>(Func<T> action);
+}
+
+public sealed class MainThreadPreviewDispatcher : IPreviewDispatcher
+{
+    public Task<T> InvokeAsync<T>(Func<T> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return MainThread.IsMainThread
+            ? Task.FromResult(action())
+            : MainThread.InvokeOnMainThreadAsync(action);
+    }
+}
+
+public interface IPreviewWindowHost
+{
+    void Open(Window window);
+
+    void Close(Window window);
+}
+
+public sealed class MauiPreviewWindowHost : IPreviewWindowHost
+{
+    public void Open(Window window) =>
+        GetApplication().OpenWindow(window);
+
+    public void Close(Window window) =>
+        GetApplication().CloseWindow(window);
+
+    private static Application GetApplication() =>
+        Application.Current
+        ?? throw new InvalidOperationException("The MAUI application is not available.");
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/PropertyEditing/GridDefinitionsPropertyEditor.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/PropertyEditing/GridDefinitionsPropertyEditor.cs
@@ -1,0 +1,324 @@
+using System.Globalization;
+using MAUIDesigner.Fresh.App.Catalog;
+
+namespace MAUIDesigner.Fresh.App.PropertyEditing;
+
+public enum GridTrackUnitType
+{
+    Auto,
+    Star,
+    Absolute
+}
+
+public readonly record struct GridTrackDefinition(GridTrackUnitType UnitType, double Value)
+{
+    public static GridTrackDefinition Auto => new(GridTrackUnitType.Auto, 1);
+}
+
+public static class GridDefinitionSerializer
+{
+    public static bool TryParse(string? text, out GridTrackDefinition[] definitions)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            definitions = [];
+            return true;
+        }
+
+        string[] parts = text.Split(',', StringSplitOptions.TrimEntries);
+        definitions = new GridTrackDefinition[parts.Length];
+        for (int index = 0; index < parts.Length; index++)
+        {
+            if (!TryParseTrack(parts[index], out definitions[index]))
+            {
+                definitions = [];
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static string Serialize(IEnumerable<GridTrackDefinition> definitions) =>
+        string.Join(",", definitions.Select(Serialize));
+
+    public static string Serialize(GridTrackDefinition definition) =>
+        definition.UnitType switch
+        {
+            GridTrackUnitType.Auto => "Auto",
+            GridTrackUnitType.Star when definition.Value == 1 => "*",
+            GridTrackUnitType.Star =>
+                $"{definition.Value.ToString("G", CultureInfo.InvariantCulture)}*",
+            GridTrackUnitType.Absolute =>
+                definition.Value.ToString("G", CultureInfo.InvariantCulture),
+            _ => throw new ArgumentOutOfRangeException(nameof(definition))
+        };
+
+    private static bool TryParseTrack(string text, out GridTrackDefinition definition)
+    {
+        if (text.Equals("Auto", StringComparison.OrdinalIgnoreCase))
+        {
+            definition = GridTrackDefinition.Auto;
+            return true;
+        }
+
+        bool isStar = text.EndsWith('*');
+        ReadOnlySpan<char> numeric = isStar ? text.AsSpan(0, text.Length - 1) : text.AsSpan();
+        double value;
+        if (isStar && numeric.IsEmpty)
+        {
+            value = 1;
+        }
+        else if (!double.TryParse(
+                     numeric,
+                     NumberStyles.Float,
+                     CultureInfo.InvariantCulture,
+                     out value) ||
+                 !double.IsFinite(value) ||
+                 value < 0)
+        {
+            definition = default;
+            return false;
+        }
+
+        definition = new GridTrackDefinition(
+            isStar ? GridTrackUnitType.Star : GridTrackUnitType.Absolute,
+            value);
+        return true;
+    }
+}
+
+public sealed class GridDefinitionCollectionModel
+{
+    private readonly List<GridTrackDefinition> _definitions;
+
+    public GridDefinitionCollectionModel(string? value)
+    {
+        if (!GridDefinitionSerializer.TryParse(value, out GridTrackDefinition[] definitions))
+        {
+            throw new FormatException("The Grid definition contains an invalid length.");
+        }
+
+        _definitions = [.. definitions];
+    }
+
+    public IReadOnlyList<GridTrackDefinition> Definitions => _definitions;
+
+    public string? Add()
+    {
+        _definitions.Add(new GridTrackDefinition(GridTrackUnitType.Star, 1));
+        return Serialize();
+    }
+
+    public string? RemoveAt(int index)
+    {
+        if ((uint)index >= (uint)_definitions.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        _definitions.RemoveAt(index);
+        return Serialize();
+    }
+
+    public string? Replace(int index, GridTrackDefinition definition)
+    {
+        if ((uint)index >= (uint)_definitions.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        _definitions[index] = definition;
+        return Serialize();
+    }
+
+    private string? Serialize() =>
+        _definitions.Count == 0 ? null : GridDefinitionSerializer.Serialize(_definitions);
+}
+
+public sealed class GridDefinitionsPropertyEditor : IPropertyEditor
+{
+    public bool CanEdit(PropertyDescriptor property)
+    {
+        Type type = Nullable.GetUnderlyingType(property.ValueType) ?? property.ValueType;
+        return type == typeof(RowDefinitionCollection) ||
+            type == typeof(ColumnDefinitionCollection);
+    }
+
+    public View Create(PropertyEditorContext context)
+    {
+        bool rows = (Nullable.GetUnderlyingType(context.Property.ValueType) ??
+            context.Property.ValueType) == typeof(RowDefinitionCollection);
+        return new GridDefinitionCollectionEditor(context, rows);
+    }
+}
+
+public sealed class GridDefinitionCollectionEditor : ContentView
+{
+    private static readonly string[] UnitNames = ["Auto", "Star", "Absolute"];
+    private readonly PropertyEditorContext _context;
+    private readonly bool _rows;
+    private readonly List<GridTrackDefinition> _definitions;
+    private readonly VerticalStackLayout _trackList;
+
+    public GridDefinitionCollectionEditor(PropertyEditorContext context, bool rows)
+    {
+        _context = context;
+        _rows = rows;
+        if (!GridDefinitionSerializer.TryParse(context.Value, out GridTrackDefinition[] parsed))
+        {
+            parsed = [];
+            context.ShowError($"{context.Property.Name} contains an invalid Grid length.");
+        }
+
+        _definitions = [.. parsed];
+        _trackList = new VerticalStackLayout { Spacing = 5 };
+        var addButton = new Button
+        {
+            AutomationId = $"{EditorAutomationId}-add",
+            FontSize = 11,
+            HeightRequest = 32,
+            HorizontalOptions = LayoutOptions.Start,
+            Text = rows ? "+ Add row" : "+ Add column"
+        };
+        addButton.Clicked += (_, _) => AddTrack();
+
+        Content = new VerticalStackLayout
+        {
+            Spacing = 6,
+            Children = { _trackList, addButton }
+        };
+        RebuildRows();
+    }
+
+    public string EditorAutomationId => $"property-{_context.Property.Name}";
+
+    public IReadOnlyList<GridTrackDefinition> Definitions => _definitions;
+
+    public void AddTrack()
+    {
+        _definitions.Add(new GridTrackDefinition(GridTrackUnitType.Star, 1));
+        RebuildRows();
+        Commit();
+    }
+
+    public void RemoveTrack(int index)
+    {
+        if ((uint)index >= (uint)_definitions.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        _definitions.RemoveAt(index);
+        RebuildRows();
+        Commit();
+    }
+
+    private void RebuildRows()
+    {
+        _trackList.Children.Clear();
+        for (int index = 0; index < _definitions.Count; index++)
+        {
+            int trackIndex = index;
+            GridTrackDefinition definition = _definitions[index];
+            var row = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(new GridLength(54)),
+                    new ColumnDefinition(new GridLength(88)),
+                    new ColumnDefinition(GridLength.Star),
+                    new ColumnDefinition(new GridLength(34))
+                },
+                ColumnSpacing = 5
+            };
+            row.Add(new Label
+            {
+                FontSize = 10,
+                Text = $"{(_rows ? "Row" : "Column")} {index + 1}",
+                VerticalTextAlignment = TextAlignment.Center
+            });
+
+            var unitPicker = new Picker
+            {
+                AutomationId = $"{EditorAutomationId}-{index}-type",
+                FontSize = 10,
+                HeightRequest = 34,
+                ItemsSource = UnitNames,
+                SelectedIndex = (int)definition.UnitType
+            };
+            row.Add(unitPicker, 1);
+
+            var valueEntry = new Entry
+            {
+                AutomationId = $"{EditorAutomationId}-{index}-value",
+                FontSize = 10,
+                HeightRequest = 34,
+                IsEnabled = definition.UnitType != GridTrackUnitType.Auto,
+                Keyboard = Keyboard.Numeric,
+                Placeholder = definition.UnitType == GridTrackUnitType.Star ? "Weight" : "Pixels",
+                Text = definition.Value.ToString("G", CultureInfo.InvariantCulture)
+            };
+            row.Add(valueEntry, 2);
+
+            var removeButton = new Button
+            {
+                AutomationId = $"{EditorAutomationId}-{index}-remove",
+                FontSize = 13,
+                HeightRequest = 32,
+                Padding = 0,
+                Text = "−"
+            };
+            row.Add(removeButton, 3);
+
+            unitPicker.SelectedIndexChanged += (_, _) =>
+            {
+                if (unitPicker.SelectedIndex < 0)
+                {
+                    return;
+                }
+
+                GridTrackUnitType unit = (GridTrackUnitType)unitPicker.SelectedIndex;
+                double value = unit == GridTrackUnitType.Auto
+                    ? 1
+                    : _definitions[trackIndex].Value;
+                if (unit != GridTrackUnitType.Auto && value <= 0)
+                {
+                    value = 1;
+                }
+
+                _definitions[trackIndex] = new GridTrackDefinition(unit, value);
+                RebuildRows();
+                Commit();
+            };
+            void CommitValue()
+            {
+                if (!double.TryParse(
+                        valueEntry.Text,
+                        NumberStyles.Float,
+                        CultureInfo.InvariantCulture,
+                        out double value) ||
+                    !double.IsFinite(value) ||
+                    value < 0)
+                {
+                    _context.ShowError(
+                        $"{_context.Property.Name} values must be non-negative numbers.");
+                    return;
+                }
+
+                _definitions[trackIndex] = _definitions[trackIndex] with { Value = value };
+                Commit();
+            }
+
+            valueEntry.Completed += (_, _) => CommitValue();
+            valueEntry.Unfocused += (_, _) => CommitValue();
+            removeButton.Clicked += (_, _) => RemoveTrack(trackIndex);
+            _trackList.Children.Add(row);
+        }
+    }
+
+    private void Commit() =>
+        _context.Commit(_definitions.Count == 0
+            ? null
+            : GridDefinitionSerializer.Serialize(_definitions));
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/PropertyEditing/PropertyEditorRegistry.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/PropertyEditing/PropertyEditorRegistry.cs
@@ -172,19 +172,6 @@ public sealed class PropertyEditorRegistry
             CreateEntry(context, "Auto, *, 2*, or pixels", Keyboard.Default);
     }
 
-    private sealed class GridDefinitionsPropertyEditor : IPropertyEditor
-    {
-        public bool CanEdit(PropertyDescriptor property)
-        {
-            Type type = Nullable.GetUnderlyingType(property.ValueType) ?? property.ValueType;
-            return type == typeof(RowDefinitionCollection) ||
-                type == typeof(ColumnDefinitionCollection);
-        }
-
-        public View Create(PropertyEditorContext context) =>
-            CreateEntry(context, "Comma-separated: Auto, *, 2*, 120", Keyboard.Default);
-    }
-
     private sealed class ColorPropertyEditor : IPropertyEditor
     {
         public bool CanEdit(PropertyDescriptor property)

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/CanvasOverlayDrawables.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/CanvasOverlayDrawables.cs
@@ -19,9 +19,7 @@ public sealed class CanvasGridDrawable : IDrawable
             return;
         }
 
-        canvas.StrokeColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#263247")
-            : Color.FromArgb("#E5E7EB");
+        canvas.StrokeColor = Color.FromArgb("#D9DEE8");
         canvas.StrokeSize = (float)(1 / _viewport.Zoom);
         for (double x = 0; x <= _viewport.DesignWidth; x += _viewport.GridSize)
         {
@@ -32,6 +30,214 @@ public sealed class CanvasGridDrawable : IDrawable
         {
             canvas.DrawLine(0, (float)y, (float)_viewport.DesignWidth, (float)y);
         }
+    }
+}
+
+public readonly record struct GridTrackLine(float X1, float Y1, float X2, float Y2);
+
+public sealed class GridTrackOverlayDrawable : IDrawable
+{
+    private static readonly Color TrackColor = Color.FromArgb("#8B5CF6");
+    private GridTrackLine[] _lines = [];
+    private readonly float[] _dashPattern = new float[2];
+    private int _lineCount;
+    private float _strokeSize = 1;
+
+    public int LineCount => _lineCount;
+
+    public GridTrackLine GetLine(int index)
+    {
+        if ((uint)index >= (uint)_lineCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        return _lines[index];
+    }
+
+    public void Update(Grid grid, RectF bounds, double deviceZoom)
+    {
+        ArgumentNullException.ThrowIfNull(grid);
+        int rowCount = grid.RowDefinitions.Count;
+        int columnCount = grid.ColumnDefinitions.Count;
+        EnsureCapacity(Math.Max(0, rowCount - 1) + Math.Max(0, columnCount - 1));
+
+        _lineCount = 0;
+        double rowStarUnit = ResolveStarUnit(grid, rows: true);
+        float y = bounds.Top;
+        for (int index = 0; index < rowCount - 1; index++)
+        {
+            y += (float)ResolveRowHeight(grid, index, rowStarUnit);
+            float lineY = y + (float)(Math.Max(0, grid.RowSpacing) / 2);
+            _lines[_lineCount++] = new GridTrackLine(
+                bounds.Left,
+                lineY,
+                bounds.Right,
+                lineY);
+            y += (float)Math.Max(0, grid.RowSpacing);
+        }
+
+        double columnStarUnit = ResolveStarUnit(grid, rows: false);
+        float x = bounds.Left;
+        for (int index = 0; index < columnCount - 1; index++)
+        {
+            x += (float)ResolveColumnWidth(grid, index, columnStarUnit);
+            float lineX = x + (float)(Math.Max(0, grid.ColumnSpacing) / 2);
+            _lines[_lineCount++] = new GridTrackLine(
+                lineX,
+                bounds.Top,
+                lineX,
+                bounds.Bottom);
+            x += (float)Math.Max(0, grid.ColumnSpacing);
+        }
+
+        SetZoom(deviceZoom);
+    }
+
+    public void UpdateActualTracks(
+        ReadOnlySpan<double> rowHeights,
+        ReadOnlySpan<double> columnWidths,
+        RectF bounds,
+        double rowSpacing,
+        double columnSpacing,
+        double deviceZoom)
+    {
+        EnsureCapacity(Math.Max(0, rowHeights.Length - 1) +
+            Math.Max(0, columnWidths.Length - 1));
+        _lineCount = 0;
+
+        float y = bounds.Top;
+        for (int index = 0; index < rowHeights.Length - 1; index++)
+        {
+            y += (float)Math.Max(0, rowHeights[index]);
+            float lineY = y + (float)(Math.Max(0, rowSpacing) / 2);
+            _lines[_lineCount++] = new GridTrackLine(
+                bounds.Left,
+                lineY,
+                bounds.Right,
+                lineY);
+            y += (float)Math.Max(0, rowSpacing);
+        }
+
+        float x = bounds.Left;
+        for (int index = 0; index < columnWidths.Length - 1; index++)
+        {
+            x += (float)Math.Max(0, columnWidths[index]);
+            float lineX = x + (float)(Math.Max(0, columnSpacing) / 2);
+            _lines[_lineCount++] = new GridTrackLine(
+                lineX,
+                bounds.Top,
+                lineX,
+                bounds.Bottom);
+            x += (float)Math.Max(0, columnSpacing);
+        }
+
+        SetZoom(deviceZoom);
+    }
+
+    public void Clear() => _lineCount = 0;
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        if (_lineCount == 0)
+        {
+            return;
+        }
+
+        canvas.StrokeColor = TrackColor;
+        canvas.StrokeSize = _strokeSize;
+        canvas.StrokeDashPattern = _dashPattern;
+        canvas.StrokeLineCap = LineCap.Round;
+        for (int index = 0; index < _lineCount; index++)
+        {
+            GridTrackLine line = _lines[index];
+            canvas.DrawLine(line.X1, line.Y1, line.X2, line.Y2);
+        }
+    }
+
+    private void EnsureCapacity(int required)
+    {
+        if (_lines.Length >= required)
+        {
+            return;
+        }
+
+        Array.Resize(ref _lines, Math.Max(required, _lines.Length == 0 ? 4 : _lines.Length * 2));
+    }
+
+    private void SetZoom(double deviceZoom)
+    {
+        double safeZoom = double.IsFinite(deviceZoom) && deviceZoom > 0 ? deviceZoom : 1;
+        _strokeSize = (float)(1 / safeZoom);
+        _dashPattern[0] = (float)(1.5 / safeZoom);
+        _dashPattern[1] = (float)(3 / safeZoom);
+    }
+
+    private static double ResolveStarUnit(Grid grid, bool rows)
+    {
+        int count = rows ? grid.RowDefinitions.Count : grid.ColumnDefinitions.Count;
+        double spacing = Math.Max(0, rows ? grid.RowSpacing : grid.ColumnSpacing);
+        double available = Math.Max(0, rows ? grid.Height : grid.Width) -
+            Math.Max(0, count - 1) * spacing;
+        double consumed = 0;
+        double starWeight = 0;
+        for (int index = 0; index < count; index++)
+        {
+            GridLength length = rows
+                ? grid.RowDefinitions[index].Height
+                : grid.ColumnDefinitions[index].Width;
+            if (length.IsAbsolute)
+            {
+                consumed += Math.Max(0, length.Value);
+            }
+            else if (length.IsAuto)
+            {
+                consumed += ResolveAutoSize(grid, rows, index);
+            }
+            else
+            {
+                starWeight += Math.Max(0, length.Value);
+            }
+        }
+
+        return starWeight == 0 ? 0 : Math.Max(0, available - consumed) / starWeight;
+    }
+
+    private static double ResolveRowHeight(Grid grid, int index, double starUnit)
+    {
+        GridLength length = grid.RowDefinitions[index].Height;
+        return length.IsAbsolute
+            ? Math.Max(0, length.Value)
+            : length.IsAuto
+                ? ResolveAutoSize(grid, rows: true, index)
+                : Math.Max(0, length.Value) * starUnit;
+    }
+
+    private static double ResolveColumnWidth(Grid grid, int index, double starUnit)
+    {
+        GridLength length = grid.ColumnDefinitions[index].Width;
+        return length.IsAbsolute
+            ? Math.Max(0, length.Value)
+            : length.IsAuto
+                ? ResolveAutoSize(grid, rows: false, index)
+                : Math.Max(0, length.Value) * starUnit;
+    }
+
+    private static double ResolveAutoSize(Grid grid, bool rows, int index)
+    {
+        double size = 0;
+        foreach (IView child in grid.Children)
+        {
+            var bindable = (BindableObject)child;
+            int childIndex = rows ? Grid.GetRow(bindable) : Grid.GetColumn(bindable);
+            int span = rows ? Grid.GetRowSpan(bindable) : Grid.GetColumnSpan(bindable);
+            if (childIndex == index && span == 1)
+            {
+                size = Math.Max(size, rows ? child.Frame.Height : child.Frame.Width);
+            }
+        }
+
+        return size;
     }
 }
 
@@ -52,17 +258,11 @@ public sealed class CanvasRulerDrawable : IDrawable
             return;
         }
 
-        canvas.FillColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#1E293B")
-            : Color.FromArgb("#F8FAFC");
+        canvas.FillColor = Color.FromArgb("#F8FAFC");
         canvas.FillRectangle(0, 0, dirtyRect.Width, RulerSize);
         canvas.FillRectangle(0, 0, RulerSize, dirtyRect.Height);
-        canvas.StrokeColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#475569")
-            : Color.FromArgb("#CBD5E1");
-        canvas.FontColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#CBD5E1")
-            : Color.FromArgb("#475569");
+        canvas.StrokeColor = Color.FromArgb("#CBD5E1");
+        canvas.FontColor = Color.FromArgb("#475569");
         canvas.FontSize = 8;
 
         double step = Math.Max(_viewport.GridSize * 5, 40);
@@ -104,9 +304,7 @@ public sealed class CanvasRulerDrawable : IDrawable
                 VerticalAlignment.Top);
         }
 
-        canvas.FillColor = _viewport.IsDarkPreview
-            ? Color.FromArgb("#172033")
-            : Color.FromArgb("#EEF2F7");
+        canvas.FillColor = Color.FromArgb("#EEF2F7");
         canvas.FillRectangle(0, 0, RulerSize, RulerSize);
     }
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/ControlMaterializer.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/ControlMaterializer.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.App.Workspace;
 using MAUIDesigner.Fresh.App.Viewport;
@@ -11,7 +12,14 @@ public sealed class ControlMaterializer
 {
     private readonly IControlCatalog _catalog;
     private readonly Dictionary<ElementId, Border> _outlines = [];
+    private readonly Dictionary<ElementId, View> _views = [];
+    private readonly Dictionary<ElementId, Grid> _chromes = [];
+    private readonly Dictionary<ElementId, View> _moveHandles = [];
+    private readonly Dictionary<ElementId, View> _resizeHandles = [];
     private readonly Dictionary<ElementId, (View View, ILayoutAdapter Adapter)> _targets = [];
+    private readonly List<Action> _gridTrackUpdates = [];
+    private readonly ConditionalWeakTable<Microsoft.UI.Xaml.FrameworkElement, object>
+        _contextMenuTargets = new();
     private readonly LayoutAdapterRegistry _layoutAdapters = new();
     private readonly DesignerWorkspace _workspace;
     private readonly DesignerViewportState _viewport;
@@ -31,18 +39,50 @@ public sealed class ControlMaterializer
     public View Materialize(DesignerDocument document)
     {
         _outlines.Clear();
+        _views.Clear();
+        _chromes.Clear();
+        _moveHandles.Clear();
+        _resizeHandles.Clear();
         _targets.Clear();
+        _gridTrackUpdates.Clear();
         _activeDropPreview = null;
         _manualDrag = null;
         return Build(document.Root, isRoot: true);
     }
 
+    public void RefreshGridTrackOverlays()
+    {
+        foreach (Action update in _gridTrackUpdates)
+        {
+            update();
+        }
+    }
+
     public void UpdateInteraction()
     {
         RemoveActiveDropPreview();
-        foreach ((ElementId id, Border outline) in _outlines)
+        foreach ((ElementId id, Grid chrome) in _chromes)
         {
-            UpdateOutline(outline, id);
+            bool selected = id == _workspace.SelectedId;
+            bool highlighted = selected || id == _workspace.DropTargetId;
+            if (highlighted)
+            {
+                Border outline = EnsureOutline(chrome, id);
+                UpdateOutline(outline, id);
+            }
+            else if (_outlines.Remove(id, out Border? outline))
+            {
+                chrome.Remove(outline);
+            }
+
+            if (selected)
+            {
+                EnsureSelectionHandles(chrome, id);
+            }
+            else
+            {
+                RemoveSelectionHandles(chrome, id);
+            }
         }
 
         if (_workspace.DropTargetId is not ElementId targetId ||
@@ -53,6 +93,36 @@ public sealed class ControlMaterializer
         }
 
         _activeDropPreview = target.Adapter.AddDropPreview(target.View, placement);
+    }
+
+    public bool TryApplyProperty(
+        ElementId elementId,
+        string propertyName,
+        DesignerValue? designerValue)
+    {
+        if (designerValue is null ||
+            !_views.TryGetValue(elementId, out View? view) ||
+            propertyName is nameof(Grid.RowDefinitions) or nameof(Grid.ColumnDefinitions))
+        {
+            return false;
+        }
+
+        DesignerNode? node = _workspace.Session.Current.Find(elementId);
+        if (node is null ||
+            !_catalog.TryGet(node.ControlType, out ControlDescriptor? descriptor) ||
+            descriptor is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return TryApplyPropertyValue(view, descriptor, propertyName, designerValue);
+        }
+        catch (Exception exception) when (IsRecoverableMaterializationFailure(exception))
+        {
+            return false;
+        }
     }
 
     public void BeginManualDrag(View source, ElementId? movingId)
@@ -152,6 +222,7 @@ public sealed class ControlMaterializer
             View view = _catalog.Create(node.ControlType);
             ApplyProperties(view, descriptor, node);
             view.AutomationId = $"designer-{node.Id.Value}";
+            _views[node.Id] = view;
             ILayoutAdapter? layoutAdapter = descriptor.AcceptsChildren
                 ? _layoutAdapters.Resolve(descriptor)
                 : null;
@@ -176,7 +247,9 @@ public sealed class ControlMaterializer
 
             if (isRoot)
             {
-                return view;
+                return view is Grid rootGrid
+                    ? CreateGridTrackSurface(rootGrid)
+                    : view;
             }
 
             return CreateChrome(view, node);
@@ -195,23 +268,17 @@ public sealed class ControlMaterializer
             MinimumHeightRequest = 24,
             AutomationId = $"chrome-{node.Id.Value}"
         };
+        _chromes[node.Id] = chrome;
         chrome.Add(content);
-
-        var outline = new Border
+        if (content is Grid gridContent)
         {
-            InputTransparent = true,
-            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
-            {
-                CornerRadius = new CornerRadius(4)
-            }
-        };
-        UpdateOutline(outline, node.Id);
-        _outlines[node.Id] = outline;
-        chrome.Add(outline);
+            AddGridTrackOverlay(chrome, gridContent);
+        }
 
         var tap = new TapGestureRecognizer();
         tap.Tapped += (_, _) => _workspace.Select(node.Id);
         chrome.GestureRecognizers.Add(tap);
+        AttachContextMenu(chrome, node.Id);
 
         var reparent = new PanGestureRecognizer();
         reparent.PanUpdated += (_, args) =>
@@ -246,14 +313,155 @@ public sealed class ControlMaterializer
 
         if (node.Id == _workspace.SelectedId)
         {
-            AddMoveHandle(chrome, node);
-            AddResizeHandle(chrome, node);
+            _ = EnsureOutline(chrome, node.Id);
+            EnsureSelectionHandles(chrome, node.Id);
         }
 
         return chrome;
     }
 
-    private void AddMoveHandle(Grid chrome, DesignerNode node)
+    private Border EnsureOutline(Grid chrome, ElementId id)
+    {
+        if (_outlines.TryGetValue(id, out Border? existing))
+        {
+            return existing;
+        }
+
+        var outline = new Border
+        {
+            InputTransparent = true,
+            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
+            {
+                CornerRadius = new CornerRadius(4)
+            }
+        };
+        UpdateOutline(outline, id);
+        _outlines[id] = outline;
+        chrome.Add(outline);
+        return outline;
+    }
+
+    private void EnsureSelectionHandles(Grid chrome, ElementId id)
+    {
+        if (_moveHandles.ContainsKey(id) || _resizeHandles.ContainsKey(id))
+        {
+            return;
+        }
+
+        DesignerNode? node = _workspace.Session.Current.Find(id);
+        if (node is null)
+        {
+            return;
+        }
+
+        _moveHandles[id] = AddMoveHandle(chrome, node);
+        _resizeHandles[id] = AddResizeHandle(chrome, node);
+    }
+
+    private void RemoveSelectionHandles(Grid chrome, ElementId id)
+    {
+        if (_moveHandles.Remove(id, out View? moveHandle))
+        {
+            chrome.Remove(moveHandle);
+        }
+
+        if (_resizeHandles.Remove(id, out View? resizeHandle))
+        {
+            chrome.Remove(resizeHandle);
+        }
+    }
+
+    private Grid CreateGridTrackSurface(Grid content)
+    {
+        var surface = new Grid();
+        surface.Add(content);
+        AddGridTrackOverlay(surface, content);
+        return surface;
+    }
+
+    private void AddGridTrackOverlay(Grid surface, Grid content)
+    {
+        var drawable = new GridTrackOverlayDrawable();
+        var overlay = new GraphicsView
+        {
+            InputTransparent = true,
+            Drawable = drawable
+        };
+        void UpdateTracks()
+        {
+            drawable.Update(
+                content,
+                new RectF(0, 0, (float)content.Width, (float)content.Height),
+                _viewport.Zoom);
+            overlay.Invalidate();
+        }
+
+        content.SizeChanged += (_, _) => UpdateTracks();
+        overlay.Loaded += (_, _) => UpdateTracks();
+        _gridTrackUpdates.Add(UpdateTracks);
+        surface.Add(overlay);
+    }
+
+    private void AttachContextMenu(View target, ElementId elementId)
+    {
+#if WINDOWS
+        target.HandlerChanged += (_, _) =>
+        {
+            if (target.Handler?.PlatformView is not Microsoft.UI.Xaml.FrameworkElement native ||
+                _contextMenuTargets.TryGetValue(native, out _))
+            {
+                return;
+            }
+
+            _contextMenuTargets.Add(native, new object());
+            native.ContextRequested += (_, args) =>
+            {
+                var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
+                AddContextMenuItem(menu, "Cut", () =>
+                {
+                    _workspace.Select(elementId);
+                    _workspace.CutSelection();
+                });
+                AddContextMenuItem(menu, "Copy", () =>
+                {
+                    _workspace.Select(elementId);
+                    _workspace.CopySelection();
+                });
+                AddContextMenuItem(menu, "Paste", () =>
+                {
+                    _workspace.Select(elementId);
+                    _workspace.Paste();
+                });
+                AddContextMenuItem(menu, "Duplicate", () =>
+                {
+                    _workspace.Select(elementId);
+                    _workspace.DuplicateSelection();
+                });
+                AddContextMenuItem(menu, "Delete", () =>
+                {
+                    _workspace.Select(elementId);
+                    _workspace.DeleteSelection();
+                });
+                menu.ShowAt(native);
+                args.Handled = true;
+            };
+        };
+#endif
+    }
+
+#if WINDOWS
+    private static void AddContextMenuItem(
+        Microsoft.UI.Xaml.Controls.MenuFlyout menu,
+        string text,
+        Action action)
+    {
+        var item = new Microsoft.UI.Xaml.Controls.MenuFlyoutItem { Text = text };
+        item.Click += (_, _) => action();
+        menu.Items.Add(item);
+    }
+#endif
+
+    private View AddMoveHandle(Grid chrome, DesignerNode node)
     {
         var handle = new Border
         {
@@ -313,9 +521,10 @@ public sealed class ControlMaterializer
         };
         handle.GestureRecognizers.Add(pan);
         chrome.Add(handle);
+        return handle;
     }
 
-    private void AddResizeHandle(Grid chrome, DesignerNode node)
+    private View AddResizeHandle(Grid chrome, DesignerNode node)
     {
         var handle = new Border
         {
@@ -371,6 +580,7 @@ public sealed class ControlMaterializer
         };
         handle.GestureRecognizers.Add(pan);
         chrome.Add(handle);
+        return handle;
     }
 
     private static bool TryGetWindowBounds(View view, out RectD bounds)
@@ -428,36 +638,10 @@ public sealed class ControlMaterializer
     {
         foreach ((string name, DesignerValue designerValue) in node.Properties)
         {
-            string text;
-            if (designerValue.Kind == DesignerValueKind.Literal)
-            {
-                text = designerValue.Text;
-            }
-            else if (designerValue.Kind == DesignerValueKind.MarkupExtension &&
-                     DesignerMarkupPreview.TryGetLiteral(designerValue.Text, out string preview))
-            {
-                text = preview;
-            }
-            else
-            {
-                continue;
-            }
-
-            PropertyDescriptor? propertyDescriptor = descriptor.Properties
-                .FirstOrDefault(property => property.Name == name && !property.IsReadOnly);
-            PropertyInfo? property = propertyDescriptor is null
-                ? null
-                : descriptor.RuntimeType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
-            if (property is null ||
-                !DesignerValueConverter.TryConvert(text, property.PropertyType, out object? value))
-            {
-                continue;
-            }
-
-            property.SetValue(view, value);
+            _ = TryApplyPropertyValue(view, descriptor, name, designerValue);
         }
 
-        PropertyInfo? textProperty = descriptor.RuntimeType.GetProperty("Text", BindingFlags.Public | BindingFlags.Instance);
+        GetWritableProperties(descriptor).TryGetValue("Text", out PropertyInfo? textProperty);
         if (!node.Properties.ContainsKey("Text") && textProperty?.CanWrite == true && textProperty.PropertyType == typeof(string))
         {
             textProperty.SetValue(view, descriptor.DisplayName);
@@ -465,6 +649,41 @@ public sealed class ControlMaterializer
 
         ApplyPreviewTextContrast(view, descriptor, node);
     }
+
+    private static bool TryApplyPropertyValue(
+        View view,
+        ControlDescriptor descriptor,
+        string propertyName,
+        DesignerValue designerValue)
+    {
+        string text;
+        if (designerValue.Kind == DesignerValueKind.Literal)
+        {
+            text = designerValue.Text;
+        }
+        else if (designerValue.Kind == DesignerValueKind.MarkupExtension &&
+                 DesignerMarkupPreview.TryGetLiteral(designerValue.Text, out string preview))
+        {
+            text = preview;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!GetWritableProperties(descriptor).TryGetValue(propertyName, out PropertyInfo? property) ||
+            !DesignerValueConverter.TryConvert(text, property.PropertyType, out object? value))
+        {
+            return false;
+        }
+
+        property.SetValue(view, value);
+        return true;
+    }
+
+    private static IReadOnlyDictionary<string, PropertyInfo> GetWritableProperties(
+        ControlDescriptor descriptor) =>
+        RuntimePropertyCache.GetWritableProperties(descriptor.RuntimeType);
 
     private void ApplyPreviewTextContrast(
         View view,
@@ -482,14 +701,16 @@ public sealed class ControlMaterializer
                 property.Name == "TextColor" &&
                 !property.IsReadOnly &&
                 property.ValueType == typeof(Color));
-        PropertyInfo? textColorProperty = textColorDescriptor is null
-            ? null
-            : descriptor.RuntimeType.GetProperty(
+        PropertyInfo? textColorProperty = null;
+        if (textColorDescriptor is not null)
+        {
+            GetWritableProperties(descriptor).TryGetValue(
                 textColorDescriptor.Name,
-                BindingFlags.Public | BindingFlags.Instance);
+                out textColorProperty);
+        }
         textColorProperty?.SetValue(
             view,
-            _viewport.IsDarkPreview ? Colors.White : Colors.Black);
+            Colors.Black);
     }
 
     private static void EnsureDesignSize(View view, ControlDescriptor descriptor)

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Resources/Styles/Colors.xaml
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Resources/Styles/Colors.xaml
@@ -1,44 +1,42 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
-    <!-- Note: For Android please see also Platforms\Android\Resources\values\colors.xml -->
+    <Color x:Key="Primary">#6554C0</Color>
+    <Color x:Key="PrimaryHover">#5746B1</Color>
+    <Color x:Key="PrimaryPressed">#493A9D</Color>
+    <Color x:Key="AccentBlue">#2563EB</Color>
+    <Color x:Key="AccentSoft">#F0EDFF</Color>
+    <Color x:Key="AccentBorder">#CFC7F7</Color>
 
-    <Color x:Key="Primary">#512BD4</Color>
-    <Color x:Key="PrimaryDark">#ac99ea</Color>
-    <Color x:Key="PrimaryDarkText">#242424</Color>
-    <Color x:Key="Secondary">#DFD8F7</Color>
-    <Color x:Key="SecondaryDarkText">#9880e5</Color>
-    <Color x:Key="Tertiary">#2B0B98</Color>
+    <Color x:Key="White">#FFFFFF</Color>
+    <Color x:Key="Black">#0F172A</Color>
+    <Color x:Key="Surface">#FFFFFF</Color>
+    <Color x:Key="SurfaceSubtle">#F8FAFC</Color>
+    <Color x:Key="SurfaceMuted">#F1F5F9</Color>
+    <Color x:Key="CanvasBackdrop">#E9EEF5</Color>
+    <Color x:Key="Border">#D8E0EA</Color>
+    <Color x:Key="BorderStrong">#B8C3D1</Color>
+    <Color x:Key="TextPrimary">#172033</Color>
+    <Color x:Key="TextSecondary">#536176</Color>
+    <Color x:Key="TextMuted">#718096</Color>
+    <Color x:Key="Danger">#C9364B</Color>
+    <Color x:Key="DangerSoft">#FFF1F2</Color>
+    <Color x:Key="Success">#16835A</Color>
 
-    <Color x:Key="White">White</Color>
-    <Color x:Key="Black">Black</Color>
-    <Color x:Key="Magenta">#D600AA</Color>
-    <Color x:Key="MidnightBlue">#190649</Color>
-    <Color x:Key="OffBlack">#1f1f1f</Color>
+    <Color x:Key="Gray100">#F1F5F9</Color>
+    <Color x:Key="Gray200">#E2E8F0</Color>
+    <Color x:Key="Gray300">#CBD5E1</Color>
+    <Color x:Key="Gray400">#94A3B8</Color>
+    <Color x:Key="Gray500">#64748B</Color>
+    <Color x:Key="Gray600">#475569</Color>
+    <Color x:Key="Gray900">#0F172A</Color>
+    <Color x:Key="Gray950">#020617</Color>
 
-    <Color x:Key="Gray100">#E1E1E1</Color>
-    <Color x:Key="Gray200">#C8C8C8</Color>
-    <Color x:Key="Gray300">#ACACAC</Color>
-    <Color x:Key="Gray400">#919191</Color>
-    <Color x:Key="Gray500">#6E6E6E</Color>
-    <Color x:Key="Gray600">#404040</Color>
-    <Color x:Key="Gray900">#212121</Color>
-    <Color x:Key="Gray950">#141414</Color>
-
-    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
-    <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}"/>
-    <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource Tertiary}"/>
-    <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}"/>
-    <SolidColorBrush x:Key="BlackBrush" Color="{StaticResource Black}"/>
-
-    <SolidColorBrush x:Key="Gray100Brush" Color="{StaticResource Gray100}"/>
-    <SolidColorBrush x:Key="Gray200Brush" Color="{StaticResource Gray200}"/>
-    <SolidColorBrush x:Key="Gray300Brush" Color="{StaticResource Gray300}"/>
-    <SolidColorBrush x:Key="Gray400Brush" Color="{StaticResource Gray400}"/>
-    <SolidColorBrush x:Key="Gray500Brush" Color="{StaticResource Gray500}"/>
-    <SolidColorBrush x:Key="Gray600Brush" Color="{StaticResource Gray600}"/>
-    <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}"/>
-    <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}"/>
+    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}" />
+    <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}" />
+    <SolidColorBrush x:Key="BlackBrush" Color="{StaticResource Black}" />
+    <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource Surface}" />
+    <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource Border}" />
 </ResourceDictionary>

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Resources/Styles/Styles.xaml
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Resources/Styles/Styles.xaml
@@ -1,170 +1,67 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
-    <Style TargetType="ActivityIndicator">
-        <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-    </Style>
-
-    <Style TargetType="IndicatorView">
-        <Setter Property="IndicatorColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}"/>
-        <Setter Property="SelectedIndicatorColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray100}}"/>
-    </Style>
-
-    <Style TargetType="Border">
-        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
-        <Setter Property="StrokeShape" Value="Rectangle"/>
-        <Setter Property="StrokeThickness" Value="1"/>
-    </Style>
-
-    <Style TargetType="BoxView">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
-    </Style>
-
-    <Style TargetType="Button">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource PrimaryDarkText}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14"/>
-        <Setter Property="BorderWidth" Value="0"/>
-        <Setter Property="CornerRadius" Value="8"/>
-        <Setter Property="Padding" Value="14,10"/>
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="PointerOver" />
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="CheckBox">
-        <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="DatePicker">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14"/>
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="Editor">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="Entry">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="ImageButton">
-        <Setter Property="Opacity" Value="1" />
-        <Setter Property="BorderColor" Value="Transparent"/>
-        <Setter Property="BorderWidth" Value="0"/>
-        <Setter Property="CornerRadius" Value="0"/>
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="Opacity" Value="0.5" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="PointerOver" />
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+    <Style TargetType="Page" ApplyToDerivedTypes="True">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BackgroundColor" Value="{StaticResource SurfaceSubtle}" />
     </Style>
 
     <Style TargetType="Label">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
-        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
+    </Style>
+
+    <Style TargetType="Border">
+        <Setter Property="Stroke" Value="{StaticResource Border}" />
+        <Setter Property="StrokeThickness" Value="1" />
+    </Style>
+
+    <Style TargetType="ActivityIndicator">
+        <Setter Property="Color" Value="{StaticResource Primary}" />
+    </Style>
+
+    <Style x:Key="BaseButton" TargetType="Button">
+        <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+        <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="CornerRadius" Value="7" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="HeightRequest" Value="36" />
+        <Setter Property="MinimumHeightRequest" Value="32" />
+        <Setter Property="MinimumWidthRequest" Value="36" />
+        <Setter Property="Padding" Value="14,0" />
+        <Setter Property="TextColor" Value="{StaticResource White}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal" />
+                    <VisualState x:Name="PointerOver">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="{StaticResource PrimaryHover}" />
+                            <Setter Property="BorderColor" Value="{StaticResource PrimaryHover}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Pressed">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="{StaticResource PrimaryPressed}" />
+                            <Setter Property="BorderColor" Value="{StaticResource PrimaryPressed}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Focused">
+                        <VisualState.Setters>
+                            <Setter Property="BorderColor" Value="{StaticResource AccentBlue}" />
+                            <Setter Property="BorderWidth" Value="2" />
+                        </VisualState.Setters>
+                    </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            <Setter Property="BackgroundColor" Value="{StaticResource Gray200}" />
+                            <Setter Property="BorderColor" Value="{StaticResource Gray200}" />
+                            <Setter Property="TextColor" Value="{StaticResource Gray500}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -172,36 +69,48 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Label" x:Key="Headline">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
-        <Setter Property="FontSize" Value="32" />
-        <Setter Property="HorizontalOptions" Value="Center" />
-        <Setter Property="HorizontalTextAlignment" Value="Center" />
-    </Style>
+    <Style TargetType="Button" BasedOn="{StaticResource BaseButton}" />
 
-    <Style TargetType="Label" x:Key="SubHeadline">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
-        <Setter Property="FontSize" Value="24" />
-        <Setter Property="HorizontalOptions" Value="Center" />
-        <Setter Property="HorizontalTextAlignment" Value="Center" />
-    </Style>
-
-    <Style TargetType="Picker">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
+    <Style x:Key="ToolbarButton" TargetType="Button">
+        <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="BorderColor" Value="{StaticResource Border}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="CornerRadius" Value="7" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="HeightRequest" Value="32" />
+        <Setter Property="MinimumHeightRequest" Value="32" />
+        <Setter Property="MinimumWidthRequest" Value="34" />
+        <Setter Property="Padding" Value="11,0" />
+        <Setter Property="TextColor" Value="{StaticResource TextSecondary}" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal" />
+                    <VisualState x:Name="PointerOver">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="{StaticResource AccentSoft}" />
+                            <Setter Property="BorderColor" Value="{StaticResource AccentBorder}" />
+                            <Setter Property="TextColor" Value="{StaticResource PrimaryPressed}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Pressed">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="#E5DFFD" />
+                            <Setter Property="BorderColor" Value="{StaticResource Primary}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Focused">
+                        <VisualState.Setters>
+                            <Setter Property="BorderColor" Value="{StaticResource AccentBlue}" />
+                            <Setter Property="BorderWidth" Value="2" />
+                        </VisualState.Setters>
+                    </VisualState>
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                            <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            <Setter Property="BackgroundColor" Value="{StaticResource SurfaceMuted}" />
+                            <Setter Property="BorderColor" Value="{StaticResource Border}" />
+                            <Setter Property="TextColor" Value="{StaticResource Gray400}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -209,226 +118,98 @@
         </Setter>
     </Style>
 
-    <Style TargetType="ProgressBar">
-        <Setter Property="ProgressColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="ProgressColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+    <Style x:Key="ToolbarPrimaryButton" TargetType="Button" BasedOn="{StaticResource BaseButton}">
+        <Setter Property="HeightRequest" Value="34" />
+        <Setter Property="Padding" Value="14,0" />
     </Style>
 
-    <Style TargetType="RadioButton">
-        <Setter Property="BackgroundColor" Value="Transparent"/>
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14"/>
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+    <Style x:Key="CompactToolbarButton" TargetType="Button" BasedOn="{StaticResource ToolbarButton}">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="Padding" Value="8,0" />
+        <Setter Property="MinimumWidthRequest" Value="34" />
     </Style>
 
-    <Style TargetType="RefreshView">
-        <Setter Property="RefreshColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+    <Style x:Key="TabButton" TargetType="Button" BasedOn="{StaticResource ToolbarButton}">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="HeightRequest" Value="36" />
+        <Setter Property="HorizontalOptions" Value="Fill" />
+    </Style>
+
+    <Style TargetType="Entry">
+        <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="PlaceholderColor" Value="{StaticResource TextMuted}" />
+        <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="MinimumHeightRequest" Value="36" />
+    </Style>
+
+    <Style TargetType="Editor">
+        <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="PlaceholderColor" Value="{StaticResource TextMuted}" />
+        <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="MinimumHeightRequest" Value="44" />
     </Style>
 
     <Style TargetType="SearchBar">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
-        <Setter Property="CancelButtonColor" Value="{StaticResource Gray500}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="CancelButtonColor" Value="{StaticResource Primary}" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                            <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="HeightRequest" Value="38" />
+        <Setter Property="MinimumHeightRequest" Value="38" />
+        <Setter Property="PlaceholderColor" Value="{StaticResource TextMuted}" />
+        <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
     </Style>
 
-    <Style TargetType="SearchHandler">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
-        <Setter Property="BackgroundColor" Value="Transparent" />
+    <Style TargetType="Picker">
+        <Setter Property="BackgroundColor" Value="{StaticResource Surface}" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                            <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="HeightRequest" Value="34" />
+        <Setter Property="MinimumHeightRequest" Value="34" />
+        <Setter Property="TextColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="TitleColor" Value="{StaticResource TextSecondary}" />
     </Style>
 
-    <Style TargetType="Shadow">
-        <Setter Property="Radius" Value="15" />
-        <Setter Property="Opacity" Value="0.5" />
-        <Setter Property="Brush" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
-        <Setter Property="Offset" Value="10,10" />
-    </Style>
-
-    <Style TargetType="Slider">
-        <Setter Property="MinimumTrackColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-        <Setter Property="MaximumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
-        <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="MinimumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
-                            <Setter Property="MaximumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
-                            <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-
-    <Style TargetType="SwipeItem">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+    <Style TargetType="CheckBox">
+        <Setter Property="Color" Value="{StaticResource Primary}" />
     </Style>
 
     <Style TargetType="Switch">
-        <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+        <Setter Property="OnColor" Value="{StaticResource Primary}" />
         <Setter Property="ThumbColor" Value="{StaticResource White}" />
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                            <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="On">
-                        <VisualState.Setters>
-                            <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Secondary}, Dark={StaticResource Gray200}}" />
-                            <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="Off">
-                        <VisualState.Setters>
-                            <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
     </Style>
 
-    <Style TargetType="TimePicker">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="BackgroundColor" Value="Transparent"/>
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
-        <Setter Property="FontSize" Value="14"/>
-        <Setter Property="MinimumHeightRequest" Value="44"/>
-        <Setter Property="MinimumWidthRequest" Value="44"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="Disabled">
-                        <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
+    <Style TargetType="Slider">
+        <Setter Property="MinimumTrackColor" Value="{StaticResource Primary}" />
+        <Setter Property="MaximumTrackColor" Value="{StaticResource Gray300}" />
+        <Setter Property="ThumbColor" Value="{StaticResource Primary}" />
     </Style>
-  
-    <!--
-    <Style TargetType="TitleBar">
-        <Setter Property="MinimumHeightRequest" Value="32"/>
-        <Setter Property="VisualStateManager.VisualStateGroups">
-            <VisualStateGroupList>
-                <VisualStateGroup x:Name="TitleActiveStates">
-                    <VisualState x:Name="TitleBarTitleActive">
-                        <VisualState.Setters>
-                            <Setter Property="BackgroundColor" Value="Transparent" />
-                            <Setter Property="ForegroundColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="TitleBarTitleInactive">
-                        <VisualState.Setters>
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-                            <Setter Property="ForegroundColor" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateGroupList>
-        </Setter>
-    </Style>
-    -->
 
-    <Style TargetType="Page" ApplyToDerivedTypes="True">
-        <Setter Property="Padding" Value="0"/>
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource OffBlack}}" />
+    <Style TargetType="ProgressBar">
+        <Setter Property="ProgressColor" Value="{StaticResource Primary}" />
     </Style>
 
     <Style TargetType="Shell" ApplyToDerivedTypes="True">
-        <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource OffBlack}}" />
-        <Setter Property="Shell.ForegroundColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource SecondaryDarkText}}" />
-        <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource SecondaryDarkText}}" />
-        <Setter Property="Shell.DisabledColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="Shell.UnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray200}}" />
+        <Setter Property="Shell.BackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="Shell.ForegroundColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="Shell.TitleColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="Shell.DisabledColor" Value="{StaticResource Gray400}" />
+        <Setter Property="Shell.UnselectedColor" Value="{StaticResource TextSecondary}" />
         <Setter Property="Shell.NavBarHasShadow" Value="False" />
-        <Setter Property="Shell.TabBarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-        <Setter Property="Shell.TabBarForegroundColor" Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
-        <Setter Property="Shell.TabBarTitleColor" Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
-        <Setter Property="Shell.TabBarUnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+        <Setter Property="Shell.TabBarBackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="Shell.TabBarForegroundColor" Value="{StaticResource Primary}" />
+        <Setter Property="Shell.TabBarTitleColor" Value="{StaticResource Primary}" />
+        <Setter Property="Shell.TabBarUnselectedColor" Value="{StaticResource TextSecondary}" />
     </Style>
 
     <Style TargetType="NavigationPage">
-        <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource OffBlack}}" />
-        <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
-        <Setter Property="IconColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+        <Setter Property="BarBackgroundColor" Value="{StaticResource Surface}" />
+        <Setter Property="BarTextColor" Value="{StaticResource TextPrimary}" />
+        <Setter Property="IconColor" Value="{StaticResource TextSecondary}" />
     </Style>
-
-    <Style TargetType="TabbedPage">
-        <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}" />
-        <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
-        <Setter Property="UnselectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="SelectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
-    </Style>
-
 </ResourceDictionary>

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Viewport/DesignerViewportState.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Viewport/DesignerViewportState.cs
@@ -32,8 +32,6 @@ public sealed class DesignerViewportState
 
     public bool SnapToGrid { get; private set; } = true;
 
-    public bool IsDarkPreview { get; private set; }
-
     public DevicePreset SelectedDevice { get; private set; }
 
     public DesignerViewportState()
@@ -86,6 +84,16 @@ public sealed class DesignerViewportState
         Center(viewportWidth, viewportHeight);
     }
 
+    public void CenterOn(
+        double designX,
+        double designY,
+        double viewportWidth,
+        double viewportHeight)
+    {
+        PanX = viewportWidth / 2 - designX * Zoom;
+        PanY = viewportHeight / 2 - designY * Zoom;
+    }
+
     public double ToDesignDelta(double viewportDelta) => viewportDelta / Zoom;
 
     public double Snap(double value) =>
@@ -101,8 +109,6 @@ public sealed class DesignerViewportState
     public void ToggleRulers() => ShowRulers = !ShowRulers;
 
     public void ToggleSnap() => SnapToGrid = !SnapToGrid;
-
-    public void ToggleTheme() => IsDarkPreview = !IsDarkPreview;
 
     private static double ClampZoom(double zoom) =>
         Math.Round(Math.Clamp(zoom, MinimumZoom, MaximumZoom), 2);

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Workspace/DesignerWorkspace.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Workspace/DesignerWorkspace.cs
@@ -7,8 +7,11 @@ namespace MAUIDesigner.Fresh.App.Workspace;
 
 public sealed class DesignerWorkspace
 {
+    private const double PasteOffset = 16;
     private readonly IControlCatalog _catalog;
     private long _nextId;
+    private DesignerNode? _clipboard;
+    private int _pasteCount;
 
     public DesignerWorkspace(IControlCatalog catalog)
     {
@@ -29,6 +32,24 @@ public sealed class DesignerWorkspace
     public ElementId? DropTargetId { get; private set; }
 
     public LayoutPlacement? DropPlacement { get; private set; }
+
+    public bool CanCopy => SelectedId != Session.Current.Root.Id &&
+        Session.Current.Find(SelectedId) is not null;
+
+    public bool CanCut => SelectedId != Session.Current.Root.Id &&
+        Session.Current.Find(SelectedId) is not null;
+
+    public bool CanPaste => _clipboard is not null && TryResolveInsertionParent(out _);
+
+    public bool CanDuplicate => TryGetSelectedSiblingPosition(out DesignerNode? parent, out _) &&
+        CanAcceptChild(parent!.Id);
+
+    public bool CanMoveSelectionUp =>
+        TryGetSelectedSiblingPosition(out _, out int index) && index > 0;
+
+    public bool CanMoveSelectionDown =>
+        TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index) &&
+        index < parent!.Children.Length - 1;
 
     public void Select(ElementId id)
     {
@@ -125,8 +146,90 @@ public sealed class DesignerWorkspace
             return;
         }
 
-        Session.Execute(new RemoveElementCommand(SelectedId));
-        Select(Session.Current.Root.Id);
+        ElementId removedId = SelectedId;
+        DesignerNode parent = FindParent(Session.Current.Root, removedId)
+            ?? throw new InvalidOperationException($"Element '{removedId}' has no parent.");
+        Session.Execute(new RemoveElementCommand(removedId));
+        Select(parent.Id);
+    }
+
+    public void CopySelection()
+    {
+        if (!CanCopy)
+        {
+            return;
+        }
+
+        _clipboard = Session.Current.Find(SelectedId)
+            ?? throw new KeyNotFoundException($"Element '{SelectedId}' was not found.");
+        _pasteCount = 0;
+        InteractionChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void CutSelection()
+    {
+        if (!CanCut)
+        {
+            return;
+        }
+
+        CopySelection();
+        DeleteSelection();
+    }
+
+    public ElementId? Paste()
+    {
+        if (_clipboard is null || !TryResolveInsertionParent(out ElementId parentId))
+        {
+            return null;
+        }
+
+        _pasteCount++;
+        DesignerNode clone = PrepareCloneForParent(_clipboard, parentId, _pasteCount);
+        Session.Execute(new AddElementCommand(parentId, clone));
+        Select(clone.Id);
+        return clone.Id;
+    }
+
+    public ElementId? DuplicateSelection()
+    {
+        if (!TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index) ||
+            !CanAcceptChild(parent!.Id))
+        {
+            return null;
+        }
+
+        DesignerNode source = Session.Current.Find(SelectedId)!;
+        DesignerNode clone = PrepareCloneForParent(source, parent.Id, 1);
+        Session.Execute(new AddElementCommand(parent.Id, clone, index + 1));
+        Select(clone.Id);
+        return clone.Id;
+    }
+
+    public bool MoveSelectionUp() => MoveSelection(-1);
+
+    public bool MoveSelectionDown() => MoveSelection(1);
+
+    public bool MoveSelection(int direction)
+    {
+        if (direction is not (-1 or 1))
+        {
+            throw new ArgumentOutOfRangeException(nameof(direction), "Direction must be -1 or 1.");
+        }
+
+        if (!TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index))
+        {
+            return false;
+        }
+
+        int destinationIndex = index + direction;
+        if (destinationIndex < 0 || destinationIndex >= parent!.Children.Length)
+        {
+            return false;
+        }
+
+        Session.Execute(new ReorderElementCommand(SelectedId, destinationIndex));
+        return true;
     }
 
     public void ReplaceDocument(DesignerDocument document)
@@ -139,18 +242,30 @@ public sealed class DesignerWorkspace
 
     private ElementId ResolveInsertionParent()
     {
+        if (TryResolveInsertionParent(out ElementId parentId))
+        {
+            return parentId;
+        }
+
+        throw new InvalidOperationException("The document has no container that can accept another child control.");
+    }
+
+    private bool TryResolveInsertionParent(out ElementId parentId)
+    {
         DesignerNode? candidate = Session.Current.Find(SelectedId) ?? Session.Current.Root;
         while (candidate is not null)
         {
             if (CanAcceptChild(candidate.Id))
             {
-                return candidate.Id;
+                parentId = candidate.Id;
+                return true;
             }
 
             candidate = FindParent(Session.Current.Root, candidate.Id);
         }
 
-        throw new InvalidOperationException("The document has no container that can accept another child control.");
+        parentId = default;
+        return false;
     }
 
     public bool CanAcceptChild(ElementId parentId, ElementId? movingId = null)
@@ -214,6 +329,57 @@ public sealed class DesignerWorkspace
         return node is not null &&
             _catalog.TryGet(node.ControlType, out ControlDescriptor? descriptor) &&
             descriptor?.RuntimeType == typeof(AbsoluteLayout);
+    }
+
+    private DesignerNode PrepareCloneForParent(DesignerNode source, ElementId parentId, int offsetMultiplier)
+    {
+        DesignerNode clone = DesignerNodeCloner.CloneSubtree(source);
+        RectD? bounds = null;
+        if (IsAbsoluteLayout(parentId))
+        {
+            RectD sourceBounds = source.Bounds ?? CreateDefaultBounds(source);
+            double offset = PasteOffset * offsetMultiplier;
+            bounds = sourceBounds with
+            {
+                X = sourceBounds.X + offset,
+                Y = sourceBounds.Y + offset
+            };
+        }
+
+        return clone with
+        {
+            ParentPropertyName = null,
+            Bounds = bounds,
+            Properties = clone.Properties
+                .Remove("AbsoluteLayout.LayoutBounds")
+                .Remove("AbsoluteLayout.LayoutFlags")
+        };
+    }
+
+    private RectD CreateDefaultBounds(DesignerNode node)
+    {
+        bool acceptsChildren = _catalog.TryGet(node.ControlType, out ControlDescriptor? descriptor) &&
+            descriptor?.AcceptsChildren == true;
+        return new RectD(24, 24, acceptsChildren ? 280 : 160, acceptsChildren ? 180 : 48);
+    }
+
+    private bool TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index)
+    {
+        parent = FindParent(Session.Current.Root, SelectedId);
+        index = -1;
+        if (parent is not null)
+        {
+            for (int childIndex = 0; childIndex < parent.Children.Length; childIndex++)
+            {
+                if (parent.Children[childIndex].Id == SelectedId)
+                {
+                    index = childIndex;
+                    break;
+                }
+            }
+        }
+
+        return parent is not null && index >= 0;
     }
 
     private static DesignerNode? FindParent(DesignerNode parent, ElementId childId)

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Xaml/CatalogXamlTypeResolver.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Xaml/CatalogXamlTypeResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.Core.Documents;
 using MAUIDesigner.Fresh.Core.Xaml;
@@ -9,13 +10,36 @@ public sealed class CatalogXamlTypeResolver : MAUIDesigner.Fresh.Core.Xaml.IXaml
 {
     private const string MauiNamespace = "http://schemas.microsoft.com/dotnet/2021/maui";
     private readonly IControlCatalog _catalog;
+    private readonly ConcurrentDictionary<(string Namespace, string Name), XamlTypeResolution>
+        _cache = new();
 
     public CatalogXamlTypeResolver(IControlCatalog catalog)
     {
         _catalog = catalog;
+        _catalog.Changed += (_, _) => _cache.Clear();
     }
 
     public bool TryResolve(
+        string xamlNamespace,
+        string localName,
+        out XamlTypeResolution? resolution)
+    {
+        if (_cache.TryGetValue((xamlNamespace, localName), out resolution))
+        {
+            return true;
+        }
+
+        if (TryResolveCore(xamlNamespace, localName, out resolution) &&
+            resolution is not null)
+        {
+            _cache[(xamlNamespace, localName)] = resolution;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryResolveCore(
         string xamlNamespace,
         string localName,
         out XamlTypeResolution? resolution)

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Xaml/XamlTextIdentity.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Xaml/XamlTextIdentity.cs
@@ -1,0 +1,9 @@
+namespace MAUIDesigner.Fresh.App.Xaml;
+
+public static class XamlTextIdentity
+{
+    public static string Normalize(string? value) =>
+        (value ?? string.Empty)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.Core.Tests/DocumentSessionTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core.Tests/DocumentSessionTests.cs
@@ -133,4 +133,155 @@ public sealed class DocumentSessionTests
         Assert.Equal("None", restored.Properties["AbsoluteLayout.LayoutFlags"].Text);
         Assert.Equal("Header", restored.ParentPropertyName);
     }
+
+    [Fact]
+    public void Clone_subtree_regenerates_all_ids_and_preserves_content()
+    {
+        var child = new DesignerNode(
+            new ElementId("child"),
+            LabelType,
+            ImmutableDictionary<string, DesignerValue>.Empty
+                .Add("Text", DesignerValue.Literal("Preserved")),
+            bounds: new RectD(1, 2, 30, 40),
+            preservedContent: [new XamlSyntaxFragment("<Label.GestureRecognizers />")],
+            parentPropertyName: "Header");
+        var source = new DesignerNode(
+            new ElementId("source"),
+            GridType,
+            ImmutableDictionary<string, DesignerValue>.Empty
+                .Add("Padding", DesignerValue.Literal("8")),
+            [child],
+            new RectD(10, 20, 200, 100));
+
+        DesignerNode first = DesignerNodeCloner.CloneSubtree(source);
+        DesignerNode second = DesignerNodeCloner.CloneSubtree(source);
+
+        Assert.NotEqual(source.Id, first.Id);
+        Assert.NotEqual(child.Id, first.Children[0].Id);
+        Assert.NotEqual(first.Id, second.Id);
+        Assert.NotEqual(first.Children[0].Id, second.Children[0].Id);
+        Assert.Equal(source.ControlType, first.ControlType);
+        Assert.Equal(source.Properties, first.Properties);
+        Assert.Equal(source.Bounds, first.Bounds);
+        Assert.Equal(child.Properties, first.Children[0].Properties);
+        Assert.Equal(child.Bounds, first.Children[0].Bounds);
+        Assert.Equal(child.PreservedContent, first.Children[0].PreservedContent);
+        Assert.Equal("Header", first.Children[0].ParentPropertyName);
+        Assert.Equal(new ElementId("source"), source.Id);
+        Assert.Equal(new ElementId("child"), source.Children[0].Id);
+    }
+
+    [Fact]
+    public void Clone_subtree_rejects_duplicate_ids_from_factory()
+    {
+        var source = new DesignerNode(
+            new ElementId("source"),
+            GridType,
+            children: [new DesignerNode(new ElementId("child"), LabelType)]);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            DesignerNodeCloner.CloneSubtree(source, () => new ElementId("duplicate")));
+    }
+
+    [Fact]
+    public void Clone_subtree_regenerates_names_and_internal_references()
+    {
+        var source = new DesignerNode(
+            new ElementId("source"),
+            GridType,
+            ImmutableDictionary<string, DesignerValue>.Empty
+                .Add("x:Name", DesignerValue.Literal("Card"))
+                .Add(
+                    "IsVisible",
+                    new DesignerValue(
+                        "{Binding IsReady, Source={x:Reference Title}}",
+                        DesignerValueKind.MarkupExtension))
+                .Add(
+                    "BindingPath",
+                    new DesignerValue(
+                        "{Binding Title}",
+                        DesignerValueKind.MarkupExtension))
+                .Add(
+                    "Resource",
+                    new DesignerValue(
+                        "{StaticResource Title}",
+                        DesignerValueKind.MarkupExtension))
+                .Add(
+                    "ElementBinding",
+                    new DesignerValue(
+                        "{Binding Text, ElementName=Title}",
+                        DesignerValueKind.MarkupExtension)),
+            [
+                new DesignerNode(
+                    new ElementId("child"),
+                    LabelType,
+                    ImmutableDictionary<string, DesignerValue>.Empty
+                        .Add("x:Name", DesignerValue.Literal("Title"))
+                        .Add("Text", DesignerValue.Literal("Title")),
+                    preservedContent:
+                    [
+                        new XamlSyntaxFragment(
+                            "<Reference Target=\"{x:Reference Card}\" />"),
+                        new XamlSyntaxFragment(
+                            "<Setter Value=\"{Binding Source={x:Reference Name=&quot;Title&quot;}}\" />"),
+                        new XamlSyntaxFragment(
+                            "<x:String x:Key=\"Hint\">ElementName=Title}</x:String>")
+                    ])
+            ]);
+        var ids = new Queue<ElementId>(
+            [new ElementId("clone-root"), new ElementId("clone-title")]);
+
+        DesignerNode clone = DesignerNodeCloner.CloneSubtree(source, ids.Dequeue);
+
+        Assert.Equal("Card_Copy_clone_root", clone.Properties["x:Name"].Text);
+        Assert.Equal(
+            "{Binding IsReady, Source={x:Reference Title_Copy_clone_title}}",
+            clone.Properties["IsVisible"].Text);
+        Assert.Equal("{Binding Title}", clone.Properties["BindingPath"].Text);
+        Assert.Equal("{StaticResource Title}", clone.Properties["Resource"].Text);
+        Assert.Equal(
+            "{Binding Text, ElementName=Title_Copy_clone_title}",
+            clone.Properties["ElementBinding"].Text);
+        Assert.Equal("Title_Copy_clone_title", clone.Children[0].Properties["x:Name"].Text);
+        Assert.Equal("Title", clone.Children[0].Properties["Text"].Text);
+        Assert.Contains(
+            "Card_Copy_clone_root",
+            clone.Children[0].PreservedContent[0].Xml);
+        Assert.Contains(
+            "Title_Copy_clone_title",
+            clone.Children[0].PreservedContent[1].Xml);
+        Assert.Equal(
+            "<x:String x:Key=\"Hint\">ElementName=Title}</x:String>",
+            clone.Children[0].PreservedContent[2].Xml);
+    }
+
+    [Fact]
+    public void Reorder_preserves_node_data_and_undoes_atomically()
+    {
+        var session = new DocumentSession(DesignerDocument.Create(GridType));
+        var firstId = new ElementId("first");
+        var secondId = new ElementId("second");
+        var second = new DesignerNode(
+            secondId,
+            LabelType,
+            ImmutableDictionary<string, DesignerValue>.Empty
+                .Add("Text", DesignerValue.Literal("Second")),
+            bounds: new RectD(4, 8, 120, 32),
+            parentPropertyName: "Header");
+        session.Execute(new AddElementCommand(
+            new ElementId("root"),
+            new DesignerNode(firstId, LabelType)));
+        session.Execute(new AddElementCommand(new ElementId("root"), second));
+
+        session.Execute(new ReorderElementCommand(secondId, 0));
+
+        DesignerNode reordered = session.Current.Root.Children[0];
+        Assert.Same(second, reordered);
+        Assert.Equal("Header", reordered.ParentPropertyName);
+        Assert.Equal(new RectD(4, 8, 120, 32), reordered.Bounds);
+        Assert.True(session.Undo());
+        Assert.Equal(
+            new[] { firstId, secondId },
+            session.Current.Root.Children.Select(child => child.Id));
+    }
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DesignerNodeCloner.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DesignerNodeCloner.cs
@@ -1,0 +1,153 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace MAUIDesigner.Fresh.Core.Documents;
+
+public static class DesignerNodeCloner
+{
+    public static DesignerNode CloneSubtree(
+        DesignerNode source,
+        Func<ElementId>? createId = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        createId ??= ElementId.CreateUnique;
+
+        var generatedIds = new HashSet<ElementId>();
+        var ids = new Dictionary<ElementId, ElementId>();
+        var names = new Dictionary<string, string>(StringComparer.Ordinal);
+        BuildClonePlan(source, createId, generatedIds, ids, names);
+        return Clone(source, ids, names);
+    }
+
+    private static void BuildClonePlan(
+        DesignerNode source,
+        Func<ElementId> createId,
+        HashSet<ElementId> generatedIds,
+        Dictionary<ElementId, ElementId> ids,
+        Dictionary<string, string> names)
+    {
+        ElementId id = createId();
+        if (!generatedIds.Add(id))
+        {
+            throw new InvalidOperationException($"The clone id factory produced duplicate id '{id}'.");
+        }
+
+        ids.Add(source.Id, id);
+        if (source.Properties.TryGetValue("x:Name", out DesignerValue? name) &&
+            !string.IsNullOrWhiteSpace(name.Text))
+        {
+            names.TryAdd(name.Text, CreateCloneName(name.Text, id));
+        }
+
+        foreach (DesignerNode child in source.Children)
+        {
+            BuildClonePlan(child, createId, generatedIds, ids, names);
+        }
+    }
+
+    private static DesignerNode Clone(
+        DesignerNode source,
+        IReadOnlyDictionary<ElementId, ElementId> ids,
+        IReadOnlyDictionary<string, string> names)
+    {
+        ImmutableArray<DesignerNode>.Builder children =
+            ImmutableArray.CreateBuilder<DesignerNode>(source.Children.Length);
+        foreach (DesignerNode child in source.Children)
+        {
+            children.Add(Clone(child, ids, names));
+        }
+
+        ImmutableDictionary<string, DesignerValue> properties = names.Count == 0
+            ? source.Properties
+            : RewriteProperties(source.Properties, names);
+        ImmutableArray<XamlSyntaxFragment> preservedContent = names.Count == 0
+            ? source.PreservedContent
+            : source.PreservedContent
+                .Select(fragment => new XamlSyntaxFragment(
+                    RewritePreservedAttributes(fragment.Xml, names)))
+                .ToImmutableArray();
+        return source with
+        {
+            Id = ids[source.Id],
+            Properties = properties,
+            Children = children.MoveToImmutable(),
+            PreservedContent = preservedContent
+        };
+    }
+
+    private static ImmutableDictionary<string, DesignerValue> RewriteProperties(
+        ImmutableDictionary<string, DesignerValue> properties,
+        IReadOnlyDictionary<string, string> names)
+    {
+        var rewritten = properties.ToBuilder();
+        if (properties.TryGetValue("x:Name", out DesignerValue? name) &&
+            names.TryGetValue(name.Text, out string? cloneName))
+        {
+            rewritten["x:Name"] = name with { Text = cloneName };
+        }
+
+        foreach ((string propertyName, DesignerValue value) in properties)
+        {
+            if (propertyName == "x:Name" || value.Kind == DesignerValueKind.Literal)
+            {
+                continue;
+            }
+
+            rewritten[propertyName] = value with
+            {
+                Text = RewriteReferences(value.Text, names)
+            };
+        }
+
+        return rewritten.ToImmutable();
+    }
+
+    private static string RewriteReferences(
+        string value,
+        IReadOnlyDictionary<string, string> names)
+    {
+        string rewritten = value;
+        foreach ((string original, string replacement) in names)
+        {
+            rewritten = Regex.Replace(
+                rewritten,
+                $@"(?<prefix>\{{\s*x:Reference\s+(?:Name\s*=\s*)?)(?:(?<quote>[""']|&quot;|&apos;){Regex.Escape(original)}\k<quote>|{Regex.Escape(original)})(?=\s*[,}}])",
+                match => match.Groups["prefix"].Value +
+                    match.Groups["quote"].Value +
+                    replacement +
+                    match.Groups["quote"].Value,
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            rewritten = Regex.Replace(
+                rewritten,
+                $@"(?<prefix>\bElementName\s*=\s*)(?:(?<quote>[""']|&quot;|&apos;){Regex.Escape(original)}\k<quote>|{Regex.Escape(original)})(?=\s*[,}}])",
+                match => match.Groups["prefix"].Value +
+                    match.Groups["quote"].Value +
+                    replacement +
+                    match.Groups["quote"].Value,
+                RegexOptions.CultureInvariant);
+        }
+
+        return rewritten;
+    }
+
+    private static string RewritePreservedAttributes(
+        string xml,
+        IReadOnlyDictionary<string, string> names) =>
+        Regex.Replace(
+            xml,
+            @"(?<prefix>\s[^\s=<>/]+\s*=\s*)(?<quote>[""'])(?<value>.*?)\k<quote>",
+            match => match.Groups["prefix"].Value +
+                match.Groups["quote"].Value +
+                RewriteReferences(match.Groups["value"].Value, names) +
+                match.Groups["quote"].Value,
+            RegexOptions.CultureInvariant | RegexOptions.Singleline);
+
+    private static string CreateCloneName(string original, ElementId id)
+    {
+        string suffix = new(
+            id.Value.Select(character =>
+                    char.IsLetterOrDigit(character) ? character : '_')
+                .ToArray());
+        return $"{original}_Copy_{suffix}";
+    }
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentCommands.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentCommands.cs
@@ -50,6 +50,14 @@ public sealed record ReparentElementCommand(
         DocumentEditor.Reparent(document, ElementId, DestinationParentId, DestinationIndex, Bounds);
 }
 
+public sealed record ReorderElementCommand(ElementId ElementId, int DestinationIndex) : IDocumentCommand
+{
+    public string Description => $"Reorder {ElementId}";
+
+    public DesignerDocument Apply(DesignerDocument document) =>
+        DocumentEditor.Reorder(document, ElementId, DestinationIndex);
+}
+
 public sealed record PlaceElementCommand(
     ElementId ElementId,
     ElementId DestinationParentId,

--- a/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentEditor.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentEditor.cs
@@ -63,6 +63,34 @@ internal static class DocumentEditor
             destinationIndex);
     }
 
+    public static DesignerDocument Reorder(
+        DesignerDocument document,
+        ElementId id,
+        int destinationIndex)
+    {
+        if (document.Root.Id == id)
+        {
+            throw new InvalidOperationException("The document root cannot be reordered.");
+        }
+
+        DesignerNode parent = FindParent(document.Root, id) ?? throw Missing(id);
+        int sourceIndex = IndexOf(parent.Children, id);
+        int clampedIndex = Math.Clamp(destinationIndex, 0, parent.Children.Length - 1);
+        if (sourceIndex == clampedIndex)
+        {
+            return document;
+        }
+
+        DesignerNode child = parent.Children[sourceIndex];
+        ImmutableArray<DesignerNode> reordered = parent.Children
+            .RemoveAt(sourceIndex)
+            .Insert(clampedIndex, child);
+        return document with
+        {
+            Root = Rewrite(document.Root, parent.Id, node => node with { Children = reordered })
+        };
+    }
+
     public static DesignerDocument SetProperty(
         DesignerDocument document,
         ElementId id,
@@ -201,6 +229,38 @@ internal static class DocumentEditor
         {
             CollectIds(child, ids);
         }
+    }
+
+    private static DesignerNode? FindParent(DesignerNode parent, ElementId childId)
+    {
+        if (IndexOf(parent.Children, childId) >= 0)
+        {
+            return parent;
+        }
+
+        foreach (DesignerNode child in parent.Children)
+        {
+            DesignerNode? match = FindParent(child, childId);
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static int IndexOf(ImmutableArray<DesignerNode> children, ElementId id)
+    {
+        for (int index = 0; index < children.Length; index++)
+        {
+            if (children[index].Id == id)
+            {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     private static KeyNotFoundException Missing(ElementId id) =>

--- a/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/ElementId.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/ElementId.cs
@@ -10,5 +10,7 @@ public readonly record struct ElementId
 
     public string Value { get; }
 
+    public static ElementId CreateUnique() => new(Guid.NewGuid().ToString("N"));
+
     public override string ToString() => Value;
 }

--- a/maui-designer-native/PERFORMANCE.md
+++ b/maui-designer-native/PERFORMANCE.md
@@ -1,0 +1,86 @@
+# Native designer performance
+
+## Interaction budget
+
+The desktop target is 60 Hz, leaving 16.67 ms per frame. The designer reserves
+8 ms for MAUI layout/rendering and 3 ms for WinUI input dispatch, leaving a
+5 ms budget for designer work during pointer and selection interactions.
+
+Before measuring, the expected limits are:
+
+| Operation | Budget | Reason |
+| --- | ---: | --- |
+| Selection outline update | 5 ms | Must complete inside one pointer frame. |
+| Literal property preview | 16 ms | Should appear in the next rendered frame. |
+| XAML debounce after typing stops | 300 ms | Avoids parsing incomplete markup per keystroke. |
+| XAML parse and document swap | 100 ms for typical pages | Keeps feedback within the direct-manipulation threshold. |
+| Structural rematerialization | 50 ms up to 2,000 nodes | Structural edits are less frequent but must remain interactive. |
+
+## Audit findings
+
+The original event path rematerialized every native control, rebuilt the
+hierarchy and property inspector, and serialized all XAML for both selection
+changes and individual property changes. Property materialization also repeated
+reflection lookup for every node. This explains delayed focus and property
+updates such as `RotationX`.
+
+The optimized path:
+
+- updates selection outlines and handles without replacing the canvas tree;
+- applies convertible literal property values to the existing native control;
+- caches writable reflection metadata per runtime control type;
+- caches XAML type resolution by namespace and local name, invalidating the
+  cache whenever extension controls change;
+- creates selection handles, outlines, and native context menus only when they
+  are actually needed instead of for every document node;
+- coalesces document and selection notifications into one dispatcher turn;
+- reserves full rematerialization for structural changes, undo/redo, invalidated
+  property resets, and successful live-XAML document replacement;
+- parses live XAML off the UI thread after a 300 ms debounce;
+- displays explicit busy feedback while structural rendering is in progress;
+- defers hierarchy work while the toolbox is visible and virtualizes hierarchy
+  rows with `CollectionView` when the hierarchy is opened.
+
+## Measurements
+
+The fixed 2,000-node workload is one `VerticalStackLayout` containing 2,000
+native `Label` controls. Budgets were not changed after measurement.
+
+### Remaining misses
+
+| Operation | Before optimization | Current | Budget | Result |
+| --- | ---: | ---: | ---: | --- |
+| Structural rematerialization, 2,000 nodes | 23,757.33 ms | 1,246.96 ms | 50 ms | MISS |
+| Live-XAML parse, command, and synchronous projection | 51,966.71 ms | 1,269.75 ms | 100 ms | MISS |
+
+The current implementation is approximately 19 times faster for structural
+projection and 41 times faster end-to-end, but creating 2,001 real MAUI
+controls plus selectable wrappers still exceeds the fixed large-document
+budget. The miss is retained as an explicit scalability defect rather than
+hidden by changing the threshold. The process remained responsive with the
+full document rendered and used approximately 500 MB working set.
+
+Opening the hierarchy no longer creates 2,001 hierarchy rows eagerly. Native
+validation at the end of the same document found 34 realized rows near IDs
+1962-1995; the remaining rows stayed virtualized.
+
+### Representative interactive passes
+
+| Operation | Measurement | Budget | Result |
+| --- | ---: | ---: | --- |
+| Selection outline update | 0.58-1.52 ms | 5 ms | PASS |
+| Literal property preview | 4.94-6.45 ms | 16 ms | PASS |
+| Typical live-XAML parse and command | 46.47-98.07 ms | 100 ms | PASS |
+| Typical structural rematerialization | 27.50-48.87 ms | 50 ms | PASS |
+
+## Profiling
+
+Debug builds include the MAUI DevFlow profiler. For deeper Windows CPU and
+allocation analysis, capture a trace from the running designer:
+
+```powershell
+dotnet-trace collect --process-id <PID> --providers Microsoft-DotNETCore-SampleProfiler
+```
+
+Record native interaction measurements and any budget misses in
+`VALIDATION.md`; do not relax a budget to fit a measured result.

--- a/maui-designer-native/README.md
+++ b/maui-designer-native/README.md
@@ -10,13 +10,16 @@ and keeps edits in an immutable document model that supports undo and redo.
   `View` types without a per-control registry.
 - Uses assembly-qualified control identities so controls with the same short
   name do not collide.
-- Renders a searchable toolbox, hierarchy, native design surface, grouped
-  property inspector, and transactional XAML drawer.
+- Renders a categorized toolbox, virtualized recursive interactive hierarchy,
+  native design surface, grouped property inspector, and live XAML drawer.
 - Supports click-to-add, pointer-captured drag/drop with target previews,
-  selection, delete, move, resize, reparenting, and bounded undo/redo.
+  selection, delete, move, resize, reparenting, cut/copy/paste/duplicate,
+  hierarchy reordering, context menus, keyboard commands, and bounded undo/redo.
 - Matches the web designer's viewport workflow with device presets, 25%-300%
   focal-point zoom, fit/reset, Ctrl+wheel zoom, middle-button or Space+drag
-  panning, configurable snap/grid controls, rulers, and light/dark previews.
+  panning, configurable snap/grid controls, rulers, and a light-only workspace.
+- Provides specialized Grid row/column collection editors, dotted track
+  boundaries, and a separate real-MAUI runtime preview window.
 - Uses extensible layout adapters for `AbsoluteLayout`, measured Grid cells,
   stack insertion positions, generic layouts, and single-content containers.
 - Preserves resources, namespaces, markup extensions, attached properties,
@@ -67,10 +70,10 @@ Controls requiring constructor arguments can be registered through
 
 ## XAML workflow
 
-Open **XAML** to edit the current document. **Apply** parses into a temporary
-document and only replaces the active design when the entire input is valid.
-Errors include source locations and leave the current design unchanged.
-**Refresh** regenerates XAML from the current immutable document.
+Open **XAML** to edit the current document. Changes are parsed automatically
+after a 300 ms pause and replace the active design only when the entire input
+is valid. Errors include source locations and leave the current design
+unchanged. Canvas and property edits automatically serialize back to XAML.
 
 Runtime-only constructs such as live bindings, converters, commands, and
 behaviors are retained in XAML but are not executed by the designer. Literal

--- a/maui-designer-native/VALIDATION.md
+++ b/maui-designer-native/VALIDATION.md
@@ -172,7 +172,7 @@ Predictions written before measurement:
    design coordinates at non-100% zoom, while transformed target bounds must
    include the native scale.
 4. Native validation must demonstrate device switching, zoom in/out, fit,
-   reset, middle-button panning, grid and ruler toggles, dark preview, and
+   reset, middle-button panning, grid and ruler toggles, and
    selection/manipulation on a zoomed canvas.
 
 Observed results:
@@ -182,9 +182,7 @@ Observed results:
 2. A real middle-button drag shifted the surface and ruler origins while the
    viewport retained pointer capture.
 3. Switching to the 390 x 844 phone preset fitted and centered it at 45%.
-4. Grid, ruler, snap, and dark-preview controls remained visible in the
-   two-row toolbar; native screenshots confirmed both light and dark grid
-   rendering.
+4. Grid, ruler, and snap controls remained visible in the two-row toolbar.
 5. At 48% zoom, moving a Label by `(80,40)` viewport DIPs produced snapped
    design bounds `(192,104,160,48)`. Resizing by `(48,24)` produced
    `(192,104,264,96)`, confirming inverse-scale manipulation math.
@@ -203,3 +201,56 @@ Observed results:
    render a visible unavailable-control placeholder.
 10. Final validation passed 15 core tests and 12 Windows app tests; the signed
     Release host opened a responsive native `MAUI Designer` window.
+
+## Native UX parity validation
+
+Predictions written before measurement:
+
+1. Reflection metadata for every runtime control must contain one descriptor
+   per property name. Otherwise shadowed MAUI properties can throw
+   `AmbiguousMatchException` and replace valid controls with error placeholders.
+2. Copy, paste, and duplicate must regenerate every subtree ID, preserve
+   properties and children, offset absolute bounds, and undo atomically.
+3. Grid definition parsing must reject malformed lengths and serialize
+   Auto/Star/Absolute values canonically. Track overlays must precompute only
+   internal row and column boundaries and clear without stale lines.
+4. Valid XAML must replace the canvas automatically after the fixed 300 ms
+   debounce; invalid intermediate XAML must preserve the last valid canvas.
+5. Runtime preview must use the selected device dimensions, create a second
+   window without designer chrome, and keep individual render failures visible
+   without terminating the preview.
+6. Selection chrome should update within 5 ms, literal property previews within
+   16 ms, typical live-XAML parse/swap within 100 ms after debounce, and a
+   structural rematerialization of up to 2,000 nodes within 50 ms.
+
+Observed results, with misses reported first:
+
+1. The original 2,000-Label workload missed structural rematerialization at
+   23,757.33 ms and live-XAML parse/command at 51,966.71 ms.
+2. Cached XAML type resolution, lazy interaction chrome and context menus,
+   deferred hierarchy work, and hierarchy virtualization reduced the same
+   measurements to 1,246.96 ms and 1,269.75 ms. These remain explicit misses
+   against the unchanged 50 ms and 100 ms budgets.
+3. The rendered 2,000-control process remained responsive at approximately
+   500 MB working set. Scrolling the virtualized hierarchy near its end
+   realized 34 rows around IDs 1962-1995 rather than all 2,001 rows.
+4. Representative normal-document passes were 0.58-1.52 ms for selection,
+   4.94-6.45 ms for literal property commits, 46.47-98.07 ms for live XAML,
+   and 27.50-48.87 ms for structural rematerialization.
+5. Deliberately disabling inherited-property deduplication, clipboard offsets,
+   duplicate placement, Grid validation, stale-overlay clearing, subtree ID
+   regeneration, copied-name regeneration, and line-ending normalization made
+   their respective tests fail for the predicted reasons before restoration.
+   A final clone-reference mutation also proved the regression catches both
+   binding-path corruption and accidental rewriting of literal text inside
+   preserved XAML. The restored implementation rewrites only `x:Reference`
+   and binding `ElementName` arguments in property values and XML attributes.
+6. Native DevFlow validation confirmed automatic XAML rendering, canvas-to-XAML
+   property updates, recursive hierarchy selection, clipboard duplication,
+   Grid definition editing and dotted boundaries, and a second real-MAUI
+   preview window.
+7. Strict diagnostics reported 134 subpixel desired-size findings at 125%
+   scaling, 33 interaction-occlusion findings despite successful direct taps,
+   and eight offscreen ScrollView clipping findings. Screenshots showed no
+   corresponding visible truncation or overlap; these are recorded rather than
+   suppressed.


### PR DESCRIPTION
## Summary
- add automatic bidirectional XAML synchronization with invalid-input preservation
- add grouped controls, virtualized recursive hierarchy, Grid definition tooling, and dotted track overlays
- add clipboard/context-menu workflows, runtime MAUI preview, and polished light desktop shell
- cache reflection/XAML metadata and avoid eager interaction chrome for responsive editing

## Validation
- 19 core tests pass
- 35 Windows app tests pass
- self-contained win-x64 publish launches as MAUI Designer
- mutation checks proved reflection, clipboard, Grid, namescope/reference, preserved-XAML, and line-ending regressions fail for the intended reasons

## Performance
Typical interaction budgets pass. The fixed 2,000-node workload improved from 23.76 s to 1.25 s structural projection and from 51.97 s to 1.27 s end-to-end, but still misses the original 50/100 ms large-document budgets; this remains documented as an explicit scalability defect.