### PR TITLE
Harden MAUI Designer and automate VSIX publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [develop, main, master]
   pull_request:
 
 jobs:

--- a/.github/workflows/native-designer.yml
+++ b/.github/workflows/native-designer.yml
@@ -3,6 +3,7 @@ name: Native MAUI Designer
 on:
   push:
     branches:
+      - develop
       - main
     paths:
       - maui-designer-native/**

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -13,6 +13,17 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Require a commit from main
+        shell: pwsh
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $env:GITHUB_SHA origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Native releases must be tagged from a commit already merged into main.'
+          }
 
       - uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -28,6 +28,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a commit from main before publishing
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+        shell: pwsh
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $env:GITHUB_SHA origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw 'VSIX releases must be built from a commit already merged into main.'
+          }
 
       - uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -41,6 +41,16 @@ jobs:
             throw 'VSIX releases must be built from a commit already merged into main.'
           }
 
+      - name: Stamp the VSIX release version
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.tag != '' && inputs.tag || github.ref_name }}
+        run: |
+          $version = & .\extension\scripts\Set-VsixReleaseVersion.ps1 -Tag $env:RELEASE_TAG
+          "VSIX_VERSION=$version" | Out-File $env:GITHUB_ENV -Append
+          Write-Host "Building VSIX version $version from $env:RELEASE_TAG."
+
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
@@ -67,6 +77,27 @@ jobs:
           $zip = [System.IO.Compression.ZipFile]::OpenRead($vsix.FullName)
           try {
             $names = $zip.Entries | ForEach-Object { $_.FullName }
+            $manifestEntry = $zip.GetEntry('extension.vsixmanifest')
+            if (-not $manifestEntry) { throw 'The VSIX is missing extension.vsixmanifest.' }
+
+            $reader = [IO.StreamReader]::new($manifestEntry.Open())
+            try {
+              [xml] $manifest = $reader.ReadToEnd()
+            } finally {
+              $reader.Dispose()
+            }
+
+            $packageVersion = $manifest.PackageManifest.Metadata.Identity.Version
+            $assemblyEntry = $zip.GetEntry('MauiDesigner.Vsix.dll')
+            if (-not $assemblyEntry) { throw 'The VSIX is missing MauiDesigner.Vsix.dll.' }
+
+            $assemblyPath = Join-Path $env:RUNNER_TEMP 'MauiDesigner.Vsix.dll'
+            [IO.Compression.ZipFileExtensions]::ExtractToFile(
+              $assemblyEntry,
+              $assemblyPath,
+              $true)
+            $assemblyVersion = [Reflection.AssemblyName]::GetAssemblyName($assemblyPath).Version.ToString()
+            $fileVersion = [Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath).FileVersion
           } finally {
             $zip.Dispose()
           }
@@ -81,8 +112,14 @@ jobs:
           if (-not ($names -match '^native/MAUIDesigner\.exe$')) {
             throw 'The VSIX does not contain native/MAUIDesigner.exe.'
           }
+          if ($env:VSIX_VERSION -and $packageVersion -ne $env:VSIX_VERSION) {
+            throw "The VSIX contains version $packageVersion; expected $env:VSIX_VERSION from the release tag."
+          }
+          if ($assemblyVersion -ne $packageVersion -or $fileVersion -ne $packageVersion) {
+            throw "Version mismatch: manifest $packageVersion, assembly $assemblyVersion, file $fileVersion."
+          }
 
-          Write-Host "$($vsix.Name) contains $($names.Count) entries."
+          Write-Host "$($vsix.Name) version $packageVersion contains $($names.Count) entries."
           Copy-Item $vsix.FullName MauiDesigner.vsix
 
       - uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Branch and release flow
+
+1. Create feature branches from `develop` and merge completed work back into `develop`.
+2. Test the integrated `develop` branch.
+3. After explicit approval, open a pull request from `develop` to `main`.
+4. Merge the pull request only after its required checks pass.
+5. Create `native-v*` and `vsix-v*` release tags from the resulting `main` commit.
+
+Do not commit feature work directly to `main`, create a release tag from
+`develop`, or publish release artifacts before the `develop` changes have been
+approved and promoted through a pull request.
+
+Both release workflows verify that their tagged commit is reachable from
+`origin/main` before building or publishing an artifact.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A powerful web-based visual designer for creating MAUI (Microsoft App UI) layout
 
 **Live demo (web designer):** https://gmprakhar.github.io/MAUI-Designer/ (deployed to GitHub Pages from `main`)
 
+Development is integrated on `develop`. Changes are promoted to `main` through
+an explicitly approved pull request, and release tags are created only after
+that merge. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 > The web app is a **MAUI XAML-aware HTML/CSS designer**. It does not run the MAUI
 > renderers, so the canvas is an approximation. The Windows-native app in
 > [`maui-designer-native/`](maui-designer-native/README.md) hosts **real MAUI views**

--- a/extension/scripts/Set-VsixReleaseVersion.ps1
+++ b/extension/scripts/Set-VsixReleaseVersion.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $Tag,
+
+    [string] $ManifestPath = (
+        Join-Path $PSScriptRoot '..\src\MauiDesigner.Vsix\source.extension.vsixmanifest'),
+
+    [string] $AssemblyInfoPath = (
+        Join-Path $PSScriptRoot '..\src\MauiDesigner.Vsix\Properties\AssemblyInfo.cs')
+)
+
+$match = [regex]::Match(
+    $Tag,
+    '^vsix-v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-beta\.(?<revision>0|[1-9]\d*)$')
+if (-not $match.Success) {
+    throw "Release tag '$Tag' must use the format vsix-v<major>.<minor>.<patch>-beta.<number>."
+}
+
+$parts = @('major', 'minor', 'patch', 'revision') |
+    ForEach-Object { [int]::Parse($match.Groups[$_].Value) }
+if ($parts | Where-Object { $_ -gt 65534 }) {
+    throw "Release tag '$Tag' contains a version component greater than 65534."
+}
+
+$version = $parts -join '.'
+$utf8WithoutBom = [Text.UTF8Encoding]::new($false)
+
+function Replace-SingleMatch {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Content,
+
+        [Parameter(Mandatory)]
+        [string] $Pattern,
+
+        [Parameter(Mandatory)]
+        [string] $Description
+    )
+
+    $regex = [regex]::new($Pattern)
+    if ($regex.Matches($Content).Count -ne 1) {
+        throw "Expected exactly one $Description declaration."
+    }
+
+    return $regex.Replace(
+        $Content,
+        { param($value) $value.Groups[1].Value + $version + $value.Groups[2].Value },
+        1)
+}
+
+$manifest = [IO.File]::ReadAllText($ManifestPath)
+$manifest = Replace-SingleMatch `
+    -Content $manifest `
+    -Pattern '(<Identity\b[^>]*\bVersion=")[^"]+("[^>]*>)' `
+    -Description 'VSIX manifest version'
+[IO.File]::WriteAllText($ManifestPath, $manifest, $utf8WithoutBom)
+
+$assemblyInfo = [IO.File]::ReadAllText($AssemblyInfoPath)
+foreach ($attribute in @('AssemblyVersion', 'AssemblyFileVersion')) {
+    $assemblyInfo = Replace-SingleMatch `
+        -Content $assemblyInfo `
+        -Pattern ('(\[assembly:\s*' + $attribute + '\(")[^"]+("\)\])') `
+        -Description $attribute
+}
+[IO.File]::WriteAllText($AssemblyInfoPath, $assemblyInfo, $utf8WithoutBom)
+
+Write-Output $version

--- a/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
+++ b/extension/src/MauiDesigner.Core/Protocol/DesignerProtocol.cs
@@ -18,6 +18,7 @@ namespace MauiDesigner.Core.Protocol
         public const string ManifestsPush = "manifests.push";
         public const string DocumentSaved = "document.saved";
         public const string HostClose = "host.close";
+        public const string HostCommand = "host.command";
 
         // Designer -> host
         public const string DesignerReady = "designer.ready";
@@ -26,6 +27,7 @@ namespace MauiDesigner.Core.Protocol
         public const string ManifestsRequest = "manifests.request";
         public const string DesignerError = "designer.error";
         public const string DesignerClosed = "designer.closed";
+        public const string DesignerFocusChanged = "designer.focusChanged";
     }
 
     /// <summary>A single message in either direction.</summary>
@@ -53,6 +55,14 @@ namespace MauiDesigner.Core.Protocol
         [JsonPropertyName("requestId")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? RequestId { get; set; }
+
+        [JsonPropertyName("command")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Command { get; set; }
+
+        [JsonPropertyName("textInputFocused")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? TextInputFocused { get; set; }
 
         [JsonPropertyName("manifests")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -84,6 +94,16 @@ namespace MauiDesigner.Core.Protocol
 
         public static string HostClose(string requestId) =>
             Serialize(new DesignerMessage { Type = MessageTypes.HostClose, RequestId = requestId });
+
+        public static string HostCommand(string command) =>
+            Serialize(new DesignerMessage { Type = MessageTypes.HostCommand, Command = command });
+
+        public static string DesignerFocusChanged(bool textInputFocused) =>
+            Serialize(new DesignerMessage
+            {
+                Type = MessageTypes.DesignerFocusChanged,
+                TextInputFocused = textInputFocused
+            });
 
         public static bool IsCloseResponseFor(DesignerMessage? message, string requestId) =>
             message?.Type == MessageTypes.DesignerClosed &&

--- a/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/DesignerControl.cs
@@ -49,6 +49,7 @@ namespace MauiDesigner.Vsix
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center
             };
+            _nativeHost.ShortcutRequested += OnShortcutRequested;
 
             var root = new Grid();
             root.Children.Add(_nativeHost);
@@ -57,6 +58,9 @@ namespace MauiDesigner.Vsix
         }
 
         public event EventHandler<string>? MessageReceived;
+
+        private void OnShortcutRequested(object? sender, string command) =>
+            PostMessage(DesignerProtocol.HostCommand(command));
 
         public async Task InitializeAsync(string executablePath)
         {
@@ -217,6 +221,12 @@ namespace MauiDesigner.Vsix
                     }
 
                     DesignerMessage? message = DesignerProtocol.Parse(json);
+                    if (message?.Type == MessageTypes.DesignerFocusChanged)
+                    {
+                        _nativeHost.TextInputFocused = message.TextInputFocused == true;
+                        continue;
+                    }
+
                     if (message?.Type == MessageTypes.DesignerClosed)
                     {
                         lock (_closeGate)
@@ -389,6 +399,7 @@ namespace MauiDesigner.Vsix
             _writer?.Dispose();
             _pipe?.Dispose();
             DisposeProcess();
+            _nativeHost.ShortcutRequested -= OnShortcutRequested;
             _nativeHost.Dispose();
             _writeGate.Dispose();
         }

--- a/extension/src/MauiDesigner.Vsix/Editor/NativeDesignerHost.cs
+++ b/extension/src/MauiDesigner.Vsix/Editor/NativeDesignerHost.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Input;
 
 namespace MauiDesigner.Vsix
 {
@@ -22,6 +23,14 @@ namespace MauiDesigner.Vsix
             new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
         private IntPtr _hostHandle;
         private IntPtr _designerHandle;
+        private volatile bool _textInputFocused;
+
+        public event EventHandler<string>? ShortcutRequested;
+
+        public bool TextInputFocused
+        {
+            set => _textInputFocused = value;
+        }
 
         // BuildWindowCore is owned by WPF, so this completion source is the
         // bridge into that lifecycle rather than independently scheduled work.
@@ -89,6 +98,63 @@ namespace MauiDesigner.Vsix
         {
             base.OnWindowPositionChanged(rcBoundingBox);
             ResizeDesigner();
+        }
+
+        protected override bool TranslateAcceleratorCore(
+            ref MSG msg,
+            ModifierKeys modifiers)
+        {
+            const int WmKeyDown = 0x0100;
+            const int WmSysKeyDown = 0x0104;
+            if (msg.message is not (WmKeyDown or WmSysKeyDown) ||
+                _textInputFocused)
+            {
+                return base.TranslateAcceleratorCore(ref msg, modifiers);
+            }
+
+            string? command = ResolveShortcut((int)msg.wParam, modifiers);
+            if (command is null)
+            {
+                return base.TranslateAcceleratorCore(ref msg, modifiers);
+            }
+
+            bool isRepeat = (msg.lParam.ToInt64() & (1L << 30)) != 0;
+            if (!isRepeat)
+            {
+                ShortcutRequested?.Invoke(this, command);
+            }
+
+            return true;
+        }
+
+        private static string? ResolveShortcut(int key, ModifierKeys modifiers)
+        {
+            if ((modifiers & ModifierKeys.Control) != 0)
+            {
+                return key switch
+                {
+                    0x41 => "selectAll",
+                    0x43 => "copy",
+                    0x44 => "duplicate",
+                    0x56 => "paste",
+                    0x58 => "cut",
+                    0x59 => "redo",
+                    0x5A => "undo",
+                    _ => null
+                };
+            }
+
+            if ((modifiers & ModifierKeys.Alt) != 0)
+            {
+                return key switch
+                {
+                    0x26 => "moveUp",
+                    0x28 => "moveDown",
+                    _ => null
+                };
+            }
+
+            return key == 0x2E ? "delete" : null;
         }
 
         private void ResizeDesigner()

--- a/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
+++ b/extension/src/MauiDesigner.Vsix/Properties/AssemblyInfo.cs
@@ -4,6 +4,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("MAUI Designer for Visual Studio")]
 [assembly: AssemblyDescription("Out-of-process native designer for .NET MAUI XAML pages.")]
 [assembly: AssemblyProduct("MAUI Designer")]
-[assembly: AssemblyVersion("0.2.24.0")]
-[assembly: AssemblyFileVersion("0.2.24.0")]
+[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyFileVersion("1.0.0.7")]
 [assembly: ComVisible(false)]

--- a/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
+++ b/extension/src/MauiDesigner.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="0.2.24" Language="en-US" Publisher="GMPrakhar" />
+    <Identity Id="MauiDesigner.6e7b4b0d-8f5a-4a63-9f1e-4f2f7b0c6a11" Version="1.0.0.7" Language="en-US" Publisher="GMPrakhar" />
     <DisplayName>MAUI Designer</DisplayName>
     <Description xml:space="preserve">A native WYSIWYG designer for .NET MAUI XAML pages, hosted out of process for Visual Studio stability.</Description>
     <MoreInfo>https://github.com/GMPrakhar/MAUI-Designer</MoreInfo>

--- a/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/DesignerSessionTests.cs
@@ -85,6 +85,28 @@ namespace MauiDesigner.Core.Tests
         }
 
         [Fact]
+        public void Host_commands_include_their_designer_command()
+        {
+            DesignerMessage message = DesignerProtocol.Parse(
+                DesignerProtocol.HostCommand("duplicate"))!;
+
+            Assert.Equal(MessageTypes.HostCommand, message.Type);
+            Assert.Equal("duplicate", message.Command);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Designer_focus_messages_identify_text_input_focus(bool focused)
+        {
+            DesignerMessage message = DesignerProtocol.Parse(
+                DesignerProtocol.DesignerFocusChanged(focused))!;
+
+            Assert.Equal(MessageTypes.DesignerFocusChanged, message.Type);
+            Assert.Equal(focused, message.TextInputFocused);
+        }
+
+        [Fact]
         public void Close_responses_only_match_their_own_request()
         {
             var response = new DesignerMessage

--- a/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
+++ b/extension/tests/MauiDesigner.Core.Tests/RegistrationMetadataTests.cs
@@ -364,11 +364,7 @@ namespace MauiDesigner.Core.Tests
                 Assert.True(match.Success, $"AssemblyInfo.cs is missing [assembly: {attribute}].");
 
                 var declared = Version.Parse(match.Groups[1].Value);
-                Assert.True(
-                    declared.Major == manifestVersion.Major
-                        && declared.Minor == manifestVersion.Minor
-                        && declared.Build == manifestVersion.Build,
-                    $"{attribute} is {declared} but the manifest ships {manifestVersion}.");
+                Assert.Equal(manifestVersion, declared);
             }
         }
 

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerSurfacePolicyTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerSurfacePolicyTests.cs
@@ -1,6 +1,7 @@
 using MAUIDesigner.Fresh.App.Catalog;
 using MAUIDesigner.Fresh.App.Controls;
 using MAUIDesigner.Fresh.App.Rendering;
+using MAUIDesigner.Fresh.Core.Geometry;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MAUIDesigner.Fresh.App.Tests;
@@ -44,6 +45,27 @@ public sealed class DesignerSurfacePolicyTests
                 startingWidth,
                 horizontalChange,
                 resizeFromRightEdge));
+
+    [Theory]
+    [InlineData(0, 0, 100, 100, 10, 10, 20, 20, true)]
+    [InlineData(0, 0, 100, 100, -1, 10, 20, 20, false)]
+    [InlineData(0, 0, 100, 100, 90, 90, 20, 20, false)]
+    [InlineData(0, 0, 3, 100, 0, 0, 1, 1, false)]
+    public void Marquee_selection_requires_full_containment_and_a_real_drag(
+        double marqueeX,
+        double marqueeY,
+        double marqueeWidth,
+        double marqueeHeight,
+        double elementX,
+        double elementY,
+        double elementWidth,
+        double elementHeight,
+        bool expected) =>
+        Assert.Equal(
+            expected,
+            MarqueeSelectionPolicy.Contains(
+                new RectD(marqueeX, marqueeY, marqueeWidth, marqueeHeight),
+                new RectD(elementX, elementY, elementWidth, elementHeight)));
 
     private static ReflectionControlCatalog CreateCatalog()
     {

--- a/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerWorkspaceTests.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App.Tests/DesignerWorkspaceTests.cs
@@ -106,7 +106,7 @@ public sealed class DesignerWorkspaceTests
     }
 
     [Fact]
-    public void Cut_keeps_an_internal_snapshot_and_root_cannot_be_cut_or_deleted()
+    public void Cut_keeps_an_internal_snapshot_and_undoes()
     {
         ReflectionControlCatalog catalog = CreateCatalog();
         var workspace = new DesignerWorkspace(catalog);
@@ -124,15 +124,88 @@ public sealed class DesignerWorkspaceTests
         Assert.True(workspace.CanPaste);
         Assert.True(workspace.Session.Undo());
         Assert.NotNull(workspace.Session.Current.Find(labelId));
+    }
 
+    [Fact]
+    public void Deleting_the_root_resets_the_document_and_undo_restores_it()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor label = Find(catalog, typeof(Label));
+        ElementId labelId = workspace.Add(label);
         workspace.Select(workspace.Session.Current.Root.Id);
-        workspace.CopySelection();
-        workspace.CutSelection();
         workspace.DeleteSelection();
-        ElementId pastedId = Assert.IsType<ElementId>(workspace.Paste());
-        Assert.NotNull(workspace.Session.Current.Root);
-        Assert.Equal("Cut me", workspace.Session.Current.Find(labelId)!.Properties[nameof(Label.Text)].Text);
-        Assert.Equal(label.Id, workspace.Session.Current.Find(pastedId)!.ControlType);
+
+        Assert.Empty(workspace.Session.Current.Root.Children);
+        Assert.Equal(typeof(AbsoluteLayout).Name, workspace.Session.Current.Root.ControlType.XamlName);
+        Assert.True(workspace.Session.Undo());
+        Assert.NotNull(workspace.Session.Current.Find(labelId));
+    }
+
+    [Fact]
+    public void Multi_selection_deletes_as_one_undoable_change()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId firstId = workspace.Add(button);
+        ElementId secondId = workspace.Add(button);
+        workspace.SetSelection([firstId, secondId], additive: false);
+
+        workspace.DeleteSelection();
+
+        Assert.Null(workspace.Session.Current.Find(firstId));
+        Assert.Null(workspace.Session.Current.Find(secondId));
+        Assert.True(workspace.Session.Undo());
+        Assert.NotNull(workspace.Session.Current.Find(firstId));
+        Assert.NotNull(workspace.Session.Current.Find(secondId));
+    }
+
+    [Fact]
+    public void Multi_selection_copy_paste_and_duplicate_preserve_the_group()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId firstId = workspace.Add(button);
+        ElementId secondId = workspace.Add(button);
+        RectD firstBounds = workspace.Session.Current.Find(firstId)!.Bounds!.Value;
+        RectD secondBounds = workspace.Session.Current.Find(secondId)!.Bounds!.Value;
+        workspace.SetSelection([firstId, secondId], additive: false);
+        workspace.CopySelection();
+        workspace.Select(workspace.Session.Current.Root.Id);
+
+        Assert.NotNull(workspace.Paste());
+        Assert.Equal(2, workspace.SelectionCount);
+        Assert.Equal(4, workspace.Session.Current.Root.Children.Length);
+        DesignerNode[] pasted = workspace.Session.Current.Root.Children.Skip(2).ToArray();
+        Assert.Equal(firstBounds.X + 16, pasted[0].Bounds!.Value.X);
+        Assert.Equal(firstBounds.Y + 16, pasted[0].Bounds!.Value.Y);
+        Assert.Equal(secondBounds.X + 16, pasted[1].Bounds!.Value.X);
+        Assert.Equal(secondBounds.Y + 16, pasted[1].Bounds!.Value.Y);
+
+        Assert.NotNull(workspace.DuplicateSelection());
+        Assert.Equal(2, workspace.SelectionCount);
+        Assert.Equal(6, workspace.Session.Current.Root.Children.Length);
+    }
+
+    [Fact]
+    public void Toggle_selection_supports_control_click_semantics()
+    {
+        ReflectionControlCatalog catalog = CreateCatalog();
+        var workspace = new DesignerWorkspace(catalog);
+        ControlDescriptor button = Find(catalog, typeof(Button));
+        ElementId firstId = workspace.Add(button);
+        ElementId secondId = workspace.Add(button);
+
+        workspace.Select(firstId);
+        workspace.ToggleSelection(secondId);
+
+        Assert.Equal(2, workspace.SelectionCount);
+        Assert.Contains(firstId, workspace.SelectedIds);
+        Assert.Contains(secondId, workspace.SelectedIds);
+        workspace.ToggleSelection(secondId);
+        Assert.Equal([firstId], workspace.SelectedIds);
     }
 
     [Fact]

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Controls/CanvasViewportView.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Controls/CanvasViewportView.cs
@@ -5,12 +5,18 @@ public sealed class CanvasViewportView : Grid
 #if WINDOWS
     private Microsoft.UI.Xaml.FrameworkElement? _platformView;
     private Windows.Foundation.Point _lastPoint;
+    private Windows.Foundation.Point _marqueeStartLocal;
+    private Windows.Foundation.Point _marqueeStartWindow;
     private bool _isPanning;
+    private bool _isMarqueeSelecting;
+    private bool _marqueeAdditive;
 #endif
 
     public event EventHandler<CanvasPanEventArgs>? PanRequested;
 
     public event EventHandler<CanvasZoomEventArgs>? ZoomRequested;
+
+    public event EventHandler<CanvasMarqueeEventArgs>? MarqueeRequested;
 
     protected override void OnHandlerChanged()
     {
@@ -61,6 +67,22 @@ public sealed class CanvasViewportView : Grid
             (GetKeyState(0x20) & 0x8000) != 0;
         if (!point.Properties.IsMiddleButtonPressed && !spaceDrag)
         {
+            if (point.Properties.IsLeftButtonPressed &&
+                !IsDesignerChromeSource(e.OriginalSource))
+            {
+                _marqueeStartLocal = point.Position;
+                _marqueeStartWindow = e.GetCurrentPoint(null).Position;
+                _marqueeAdditive = (GetKeyState(0x11) & 0x8000) != 0;
+                _isMarqueeSelecting = _platformView.CapturePointer(e.Pointer);
+                if (_isMarqueeSelecting)
+                {
+                    MarqueeRequested?.Invoke(
+                        this,
+                        CreateMarqueeEventArgs(GestureStatus.Started, e));
+                    e.Handled = true;
+                }
+            }
+
             return;
         }
 
@@ -75,6 +97,14 @@ public sealed class CanvasViewportView : Grid
     {
         if (!_isPanning || _platformView is null)
         {
+            if (_isMarqueeSelecting && _platformView is not null)
+            {
+                MarqueeRequested?.Invoke(
+                    this,
+                    CreateMarqueeEventArgs(GestureStatus.Running, e));
+                e.Handled = true;
+            }
+
             return;
         }
 
@@ -90,20 +120,51 @@ public sealed class CanvasViewportView : Grid
         object sender,
         Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
     {
-        if (!_isPanning || _platformView is null)
+        if (_platformView is null)
         {
             return;
         }
 
-        _isPanning = false;
-        _platformView.ReleasePointerCapture(e.Pointer);
-        e.Handled = true;
+        if (_isPanning)
+        {
+            _isPanning = false;
+            _platformView.ReleasePointerCapture(e.Pointer);
+            e.Handled = true;
+        }
+        else if (_isMarqueeSelecting)
+        {
+            _isMarqueeSelecting = false;
+            MarqueeRequested?.Invoke(
+                this,
+                CreateMarqueeEventArgs(GestureStatus.Completed, e));
+            _platformView.ReleasePointerCapture(e.Pointer);
+            e.Handled = true;
+        }
     }
 
     private void OnPointerCaptureLost(
         object sender,
-        Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e) =>
+        Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
         _isPanning = false;
+        if (_isMarqueeSelecting)
+        {
+            _isMarqueeSelecting = false;
+            MarqueeRequested?.Invoke(
+                this,
+                new CanvasMarqueeEventArgs(
+                    GestureStatus.Canceled,
+                    _marqueeStartLocal.X,
+                    _marqueeStartLocal.Y,
+                    _marqueeStartLocal.X,
+                    _marqueeStartLocal.Y,
+                    _marqueeStartWindow.X,
+                    _marqueeStartWindow.Y,
+                    _marqueeStartWindow.X,
+                    _marqueeStartWindow.Y,
+                    _marqueeAdditive));
+        }
+    }
 
     private void OnPointerWheelChanged(
         object sender,
@@ -148,6 +209,45 @@ public sealed class CanvasViewportView : Grid
             new Microsoft.UI.Xaml.Input.PointerEventHandler(OnPointerWheelChanged));
         _platformView = null;
         _isPanning = false;
+        _isMarqueeSelecting = false;
+    }
+
+    private CanvasMarqueeEventArgs CreateMarqueeEventArgs(
+        GestureStatus status,
+        Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        Windows.Foundation.Point local = e.GetCurrentPoint(_platformView).Position;
+        Windows.Foundation.Point window = e.GetCurrentPoint(null).Position;
+        return new CanvasMarqueeEventArgs(
+            status,
+            _marqueeStartLocal.X,
+            _marqueeStartLocal.Y,
+            local.X,
+            local.Y,
+            _marqueeStartWindow.X,
+            _marqueeStartWindow.Y,
+            window.X,
+            window.Y,
+            _marqueeAdditive);
+    }
+
+    private bool IsDesignerChromeSource(object? source)
+    {
+        for (Microsoft.UI.Xaml.DependencyObject? current =
+                 source as Microsoft.UI.Xaml.DependencyObject;
+             current is not null && current != _platformView;
+             current = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current))
+        {
+            if (current is Microsoft.UI.Xaml.FrameworkElement element &&
+                Microsoft.UI.Xaml.Automation.AutomationProperties
+                    .GetAutomationId(element)
+                    .StartsWith("chrome-", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     [System.Runtime.InteropServices.DllImport("user32.dll")]
@@ -158,3 +258,15 @@ public sealed class CanvasViewportView : Grid
 public sealed record CanvasPanEventArgs(double DeltaX, double DeltaY);
 
 public sealed record CanvasZoomEventArgs(int WheelDelta, double X, double Y);
+
+public sealed record CanvasMarqueeEventArgs(
+    GestureStatus StatusType,
+    double StartX,
+    double StartY,
+    double CurrentX,
+    double CurrentY,
+    double WindowStartX,
+    double WindowStartY,
+    double WindowCurrentX,
+    double WindowCurrentY,
+    bool Additive);

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Hosting/IHostedDesignerBridge.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Hosting/IHostedDesignerBridge.cs
@@ -10,9 +10,13 @@ public interface IHostedDesignerBridge : IDisposable
 
     event EventHandler<string>? ErrorReported;
 
+    event EventHandler<string>? CommandRequested;
+
     void Start();
 
     void SendDocumentChanged(string xaml);
+
+    void SendTextInputFocusChanged(bool textInputFocused);
 
     void SendClosed(string requestId, string? xaml);
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Hosting/NamedPipeHostedDesignerBridge.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Hosting/NamedPipeHostedDesignerBridge.cs
@@ -38,6 +38,8 @@ public sealed class NamedPipeHostedDesignerBridge : IHostedDesignerBridge
 
     public event EventHandler<string>? ErrorReported;
 
+    public event EventHandler<string>? CommandRequested;
+
     public void Start()
     {
         if (!IsHosted || Interlocked.Exchange(ref _started, 1) != 0)
@@ -50,6 +52,11 @@ public sealed class NamedPipeHostedDesignerBridge : IHostedDesignerBridge
 
     public void SendDocumentChanged(string xaml) =>
         Enqueue(new BridgeMessage("document.changed", xaml));
+
+    public void SendTextInputFocusChanged(bool textInputFocused) =>
+        Enqueue(new BridgeMessage(
+            "designer.focusChanged",
+            TextInputFocused: textInputFocused));
 
     public void SendClosed(string requestId, string? xaml) =>
         Enqueue(new BridgeMessage("designer.closed", xaml, requestId));
@@ -108,6 +115,11 @@ public sealed class NamedPipeHostedDesignerBridge : IHostedDesignerBridge
             {
                 CloseRequested?.Invoke(this, message.RequestId);
             }
+            else if (message?.Type == "host.command" &&
+                     !string.IsNullOrWhiteSpace(message.Command))
+            {
+                CommandRequested?.Invoke(this, message.Command);
+            }
         }
     }
 
@@ -147,5 +159,9 @@ public sealed class NamedPipeHostedDesignerBridge : IHostedDesignerBridge
         [property: JsonPropertyName("xaml")]
         string? Xaml = null,
         [property: JsonPropertyName("requestId")]
-        string? RequestId = null);
+        string? RequestId = null,
+        [property: JsonPropertyName("command")]
+        string? Command = null,
+        [property: JsonPropertyName("textInputFocused")]
+        bool? TextInputFocused = null);
 }

--- a/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml
@@ -73,7 +73,7 @@
             BackgroundColor="{StaticResource SurfaceSubtle}"
             IsClippedToBounds="True">
             <Grid x:Name="ElementsSidebar" Grid.Column="0" Padding="16,15" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="11" BackgroundColor="{StaticResource Surface}">
-                <Grid ColumnDefinitions="*,Auto">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
                     <VerticalStackLayout Spacing="2">
                         <Label FontAttributes="Bold" FontSize="15" Text="Elements" TextColor="{StaticResource TextPrimary}" />
                         <Label FontSize="10" Text="Build and navigate your page" TextColor="{StaticResource TextMuted}" />
@@ -129,6 +129,7 @@
             </Grid>
 
             <controls:SidebarResizeHandle
+                x:Name="LeftSidebarResizeHandle"
                 Grid.Column="1"
                 AutomationId="left-sidebar-resizer"
                 BackgroundColor="{StaticResource SurfaceMuted}"
@@ -199,6 +200,7 @@
                     BackgroundColor="{StaticResource CanvasBackdrop}"
                     IsClippedToBounds="True"
                     PanRequested="OnCanvasPanRequested"
+                    MarqueeRequested="OnCanvasMarqueeRequested"
                     SizeChanged="OnCanvasViewportSizeChanged"
                     ZoomRequested="OnCanvasZoomRequested">
                     <Grid
@@ -223,6 +225,16 @@
                             </Grid>
                         </Border>
                     </Grid>
+                    <Border
+                        x:Name="MarqueeSelectionBorder"
+                        HorizontalOptions="Start"
+                        VerticalOptions="Start"
+                        IsVisible="False"
+                        InputTransparent="True"
+                        BackgroundColor="#1F7C5CFF"
+                        Stroke="#7C5CFF"
+                        StrokeDashArray="4,3"
+                        StrokeThickness="1.5" />
                     <GraphicsView x:Name="CanvasRulerOverlay" InputTransparent="True" />
                     <Border
                         Margin="14"
@@ -238,6 +250,7 @@
             </Grid>
 
             <controls:SidebarResizeHandle
+                x:Name="RightSidebarResizeHandle"
                 Grid.Column="3"
                 AutomationId="right-sidebar-resizer"
                 BackgroundColor="{StaticResource SurfaceMuted}"
@@ -246,10 +259,12 @@
                 ToggleRequested="OnRightSidebarToggleRequested" />
 
             <Grid x:Name="PropertiesSidebar" Grid.Column="4" Padding="16,15" RowDefinitions="Auto,Auto,Auto,*" RowSpacing="12" BackgroundColor="{StaticResource Surface}">
-                <VerticalStackLayout Spacing="2">
-                    <Label FontAttributes="Bold" FontSize="15" Text="Properties" TextColor="{StaticResource TextPrimary}" />
-                    <Label x:Name="SelectionLabel" AutomationId="selection-label" FontSize="10" TextColor="{StaticResource TextMuted}" />
-                </VerticalStackLayout>
+                <Grid>
+                    <VerticalStackLayout Spacing="2">
+                        <Label FontAttributes="Bold" FontSize="15" Text="Properties" TextColor="{StaticResource TextPrimary}" />
+                        <Label x:Name="SelectionLabel" AutomationId="selection-label" FontSize="10" TextColor="{StaticResource TextMuted}" />
+                    </VerticalStackLayout>
+                </Grid>
                 <Border
                     Grid.Row="1"
                     Padding="10,8"

--- a/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/MainPage.xaml.cs
@@ -50,6 +50,8 @@ public partial class MainPage : ContentPage
     private CancellationTokenSource? _xamlSyncCancellation;
 #if WINDOWS
     private Microsoft.UI.Xaml.FrameworkElement? _platformRoot;
+    private readonly List<Microsoft.UI.Xaml.Input.KeyboardAccelerator>
+        _keyboardAccelerators = [];
 #endif
 
     public MainPage(
@@ -87,6 +89,7 @@ public partial class MainPage : ContentPage
         _hostBridge.DocumentLoadRequested += OnHostedDocumentLoadRequested;
         _hostBridge.CloseRequested += OnHostedCloseRequested;
         _hostBridge.ErrorReported += OnHostedErrorReported;
+        _hostBridge.CommandRequested += OnHostedCommandRequested;
         _gridDrawable = new CanvasGridDrawable(viewport);
         _rulerDrawable = new CanvasRulerDrawable(viewport);
         CanvasGridOverlay.Drawable = _gridDrawable;
@@ -112,9 +115,12 @@ public partial class MainPage : ContentPage
 #if WINDOWS
         if (_platformRoot is not null)
         {
+            DetachKeyboardAccelerators();
             _platformRoot.RemoveHandler(
                 Microsoft.UI.Xaml.UIElement.KeyDownEvent,
                 new Microsoft.UI.Xaml.Input.KeyEventHandler(OnNativeKeyDown));
+            _platformRoot.GotFocus -= OnNativeFocusChanged;
+            _platformRoot.LostFocus -= OnNativeFocusChanged;
         }
 #endif
         base.OnHandlerChanged();
@@ -126,6 +132,9 @@ public partial class MainPage : ContentPage
                 Microsoft.UI.Xaml.UIElement.KeyDownEvent,
                 new Microsoft.UI.Xaml.Input.KeyEventHandler(OnNativeKeyDown),
                 true);
+            root.GotFocus += OnNativeFocusChanged;
+            root.LostFocus += OnNativeFocusChanged;
+            AttachKeyboardAccelerators(root);
         }
 #endif
     }
@@ -195,6 +204,45 @@ public partial class MainPage : ContentPage
         double factor = e.WheelDelta > 0 ? 1.1 : 0.9;
         _viewport.ZoomAt(_viewport.Zoom * factor, e.X, e.Y);
         UpdateViewportVisuals();
+    }
+
+    private void OnCanvasMarqueeRequested(object? sender, CanvasMarqueeEventArgs e)
+    {
+        double x = Math.Min(e.StartX, e.CurrentX);
+        double y = Math.Min(e.StartY, e.CurrentY);
+        double width = Math.Abs(e.CurrentX - e.StartX);
+        double height = Math.Abs(e.CurrentY - e.StartY);
+        MarqueeSelectionBorder.TranslationX = x;
+        MarqueeSelectionBorder.TranslationY = y;
+        MarqueeSelectionBorder.WidthRequest = Math.Max(1, width);
+        MarqueeSelectionBorder.HeightRequest = Math.Max(1, height);
+        MarqueeSelectionBorder.IsVisible =
+            e.StatusType is GestureStatus.Started or GestureStatus.Running;
+
+        if (e.StatusType != GestureStatus.Completed)
+        {
+            return;
+        }
+
+        if (width < MarqueeSelectionPolicy.MinimumDragDistance ||
+            height < MarqueeSelectionPolicy.MinimumDragDistance)
+        {
+            if (!e.Additive)
+            {
+                _workspace.Select(_workspace.Session.Current.Root.Id);
+            }
+
+            return;
+        }
+
+        var windowBounds = new MAUIDesigner.Fresh.Core.Geometry.RectD(
+            Math.Min(e.WindowStartX, e.WindowCurrentX),
+            Math.Min(e.WindowStartY, e.WindowCurrentY),
+            Math.Abs(e.WindowCurrentX - e.WindowStartX),
+            Math.Abs(e.WindowCurrentY - e.WindowStartY));
+        _workspace.SetSelection(
+            _materializer.FindElementsInside(windowBounds),
+            e.Additive);
     }
 
     private void OnCanvasViewportSizeChanged(object? sender, EventArgs e)
@@ -597,6 +645,55 @@ public partial class MainPage : ContentPage
             _hostBridge.SendClosed(requestId, xaml);
         });
 
+    private void OnHostedCommandRequested(object? sender, string command) =>
+        Dispatcher.Dispatch(() =>
+        {
+#if WINDOWS
+            if (IsTextInputFocused())
+            {
+                return;
+            }
+#endif
+            ExecuteDesignerCommand(command);
+        });
+
+    private void ExecuteDesignerCommand(string command)
+    {
+        switch (command)
+        {
+            case "selectAll":
+                _workspace.SelectAll();
+                break;
+            case "copy":
+                _workspace.CopySelection();
+                break;
+            case "cut":
+                _workspace.CutSelection();
+                break;
+            case "paste":
+                _ = _workspace.Paste();
+                break;
+            case "duplicate":
+                _ = _workspace.DuplicateSelection();
+                break;
+            case "undo":
+                _workspace.Session.Undo();
+                break;
+            case "redo":
+                _workspace.Session.Redo();
+                break;
+            case "moveUp":
+                _ = _workspace.MoveSelection(-1);
+                break;
+            case "moveDown":
+                _ = _workspace.MoveSelection(1);
+                break;
+            case "delete":
+                _workspace.DeleteSelection();
+                break;
+        }
+    }
+
     private void LoadHostedDocument(string xaml)
     {
         _hostDocumentLoaded = false;
@@ -650,7 +747,7 @@ public partial class MainPage : ContentPage
             ? descriptor?.DisplayName ?? node.ControlType.XamlName
             : node.ControlType.XamlName;
 
-        bool selected = node.Id == _workspace.SelectedId;
+        bool selected = _workspace.SelectedIds.Contains(node.Id);
         var row = new Border
         {
             AutomationId = $"hierarchy-{node.Id.Value}",
@@ -720,19 +817,28 @@ public partial class MainPage : ContentPage
             TextColor = Color.FromArgb("#64748B")
         });
         content.Add(labels, 1);
-        if (node.Id != _workspace.Session.Current.Root.Id)
+        content.Add(CreateHierarchyAction("\uE74D", "Delete", 2, () =>
         {
-            content.Add(CreateHierarchyAction("\uE74D", "Delete", 2, () =>
+            if (!_workspace.SelectedIds.Contains(node.Id))
             {
                 _workspace.Select(node.Id);
-                _workspace.DeleteSelection();
-            }, destructive: true, fontFamily: "Segoe Fluent Icons"));
-        }
+            }
+
+            _workspace.DeleteSelection();
+        }, destructive: true, fontFamily: "Segoe Fluent Icons"));
         row.Content = content;
         var select = new TapGestureRecognizer();
         select.Tapped += (_, _) =>
         {
-            _workspace.Select(node.Id);
+            if (IsControlModifierPressed())
+            {
+                _workspace.ToggleSelection(node.Id);
+            }
+            else
+            {
+                _workspace.Select(node.Id);
+            }
+
             FocusCanvasElement(node.Id);
         };
         row.GestureRecognizers.Add(select);
@@ -1032,41 +1138,60 @@ public partial class MainPage : ContentPage
             var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
             AddContextMenuItem(menu, "Cut", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _workspace.CutSelection();
             });
             AddContextMenuItem(menu, "Copy", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _workspace.CopySelection();
             });
             AddContextMenuItem(menu, "Paste", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _ = _workspace.Paste();
             });
             AddContextMenuItem(menu, "Duplicate", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _ = _workspace.DuplicateSelection();
             });
             AddContextMenuItem(menu, "Move up", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _ = _workspace.MoveSelection(-1);
             });
             AddContextMenuItem(menu, "Move down", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _ = _workspace.MoveSelection(1);
             });
             AddContextMenuItem(menu, "Delete", () =>
             {
-                _workspace.Select(elementId);
+                SelectForContextMenu(elementId);
                 _workspace.DeleteSelection();
             });
             native.ContextFlyout = menu;
         };
+#endif
+    }
+
+    private void SelectForContextMenu(ElementId elementId)
+    {
+        if (!_workspace.SelectedIds.Contains(elementId))
+        {
+            _workspace.Select(elementId);
+        }
+    }
+
+    private static bool IsControlModifierPressed()
+    {
+#if WINDOWS
+        return Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+#else
+        return false;
 #endif
     }
 
@@ -1100,6 +1225,18 @@ public partial class MainPage : ContentPage
     private void RebuildPropertyPanel()
     {
         PropertyPanel.Clear();
+        if (_workspace.SelectionCount > 1)
+        {
+            SelectionLabel.Text = $"{_workspace.SelectionCount} controls selected";
+            PropertyPanel.Add(new Label
+            {
+                Text = "Use the toolbar, keyboard shortcuts, or context menu to copy, duplicate, move, or delete the selection.",
+                FontSize = 11,
+                TextColor = Color.FromArgb("#64748B")
+            });
+            return;
+        }
+
         DesignerNode? selected = _workspace.Session.Current.Find(_workspace.SelectedId);
         if (selected is null || !_catalog.TryGet(selected.ControlType, out ControlDescriptor? descriptor) || descriptor is null)
         {
@@ -1371,6 +1508,14 @@ public partial class MainPage : ContentPage
     }
 
 #if WINDOWS
+    private void OnNativeFocusChanged(
+        object sender,
+        Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        _platformRoot?.DispatcherQueue.TryEnqueue(() =>
+            _hostBridge.SendTextInputFocusChanged(IsTextInputFocused()));
+    }
+
     private void OnNativeKeyDown(
         object sender,
         Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
@@ -1384,9 +1529,7 @@ public partial class MainPage : ContentPage
             return;
         }
 
-        bool control = Microsoft.UI.Input.InputKeyboardSource
-            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
-            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+        bool control = IsControlModifierPressed();
         bool alt = Microsoft.UI.Input.InputKeyboardSource
             .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Menu)
             .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
@@ -1428,6 +1571,84 @@ public partial class MainPage : ContentPage
             e.Handled = true;
         }
     }
+
+    private void AttachKeyboardAccelerators(
+        Microsoft.UI.Xaml.FrameworkElement root)
+    {
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.C,
+            () => _workspace.CopySelection());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.X,
+            () => _workspace.CutSelection());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.V,
+            () => _ = _workspace.Paste());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.D,
+            () => _ = _workspace.DuplicateSelection());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.A,
+            () => _workspace.SelectAll());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.Z,
+            () => _workspace.Session.Undo());
+        AddKeyboardAccelerator(
+            root,
+            Windows.System.VirtualKey.Y,
+            () => _workspace.Session.Redo());
+    }
+
+    private void AddKeyboardAccelerator(
+        Microsoft.UI.Xaml.FrameworkElement root,
+        Windows.System.VirtualKey key,
+        Action action)
+    {
+        var accelerator = new Microsoft.UI.Xaml.Input.KeyboardAccelerator
+        {
+            Key = key,
+            Modifiers = Windows.System.VirtualKeyModifiers.Control
+        };
+        accelerator.Invoked += (_, args) =>
+        {
+            if (IsTextInputFocused())
+            {
+                return;
+            }
+
+            action();
+            args.Handled = true;
+        };
+        root.KeyboardAccelerators.Add(accelerator);
+        _keyboardAccelerators.Add(accelerator);
+    }
+
+    private void DetachKeyboardAccelerators()
+    {
+        if (_platformRoot is not null)
+        {
+            foreach (Microsoft.UI.Xaml.Input.KeyboardAccelerator accelerator in
+                     _keyboardAccelerators)
+            {
+                _platformRoot.KeyboardAccelerators.Remove(accelerator);
+            }
+        }
+
+        _keyboardAccelerators.Clear();
+    }
+
+    private bool IsTextInputFocused() =>
+        _platformRoot?.XamlRoot is not null &&
+        Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(_platformRoot.XamlRoot) is
+            Microsoft.UI.Xaml.Controls.TextBox or
+            Microsoft.UI.Xaml.Controls.RichEditBox or
+            Microsoft.UI.Xaml.Controls.PasswordBox;
 #endif
 
     private static bool IsEditableProperty(PropertyDescriptor property)

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/ControlMaterializer.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/ControlMaterializer.cs
@@ -63,7 +63,7 @@ public sealed class ControlMaterializer
         RemoveActiveDropPreview();
         foreach ((ElementId id, Grid chrome) in _chromes)
         {
-            bool selected = id == _workspace.SelectedId;
+            bool selected = _workspace.SelectedIds.Contains(id);
             bool highlighted = selected || id == _workspace.DropTargetId;
             if (highlighted)
             {
@@ -75,7 +75,7 @@ public sealed class ControlMaterializer
                 chrome.Remove(outline);
             }
 
-            if (selected)
+            if (id == _workspace.SelectedId)
             {
                 EnsureSelectionHandles(chrome, id);
             }
@@ -123,6 +123,21 @@ public sealed class ControlMaterializer
         {
             return false;
         }
+    }
+
+    public IReadOnlyList<ElementId> FindElementsInside(RectD windowBounds)
+    {
+        if (windowBounds.Width <= 0 || windowBounds.Height <= 0)
+        {
+            return [];
+        }
+
+        return _chromes
+            .Where(pair =>
+                TryGetWindowBounds(pair.Value, out RectD bounds) &&
+                MarqueeSelectionPolicy.Contains(windowBounds, bounds))
+            .Select(pair => pair.Key)
+            .ToArray();
     }
 
     public void BeginManualDrag(View source, ElementId? movingId)
@@ -285,7 +300,17 @@ public sealed class ControlMaterializer
         }
 
         var tap = new TapGestureRecognizer();
-        tap.Tapped += (_, _) => _workspace.Select(node.Id);
+        tap.Tapped += (_, _) =>
+        {
+#if WINDOWS
+            if (IsControlPressed())
+            {
+                _workspace.ToggleSelection(node.Id);
+                return;
+            }
+#endif
+            _workspace.Select(node.Id);
+        };
         chrome.GestureRecognizers.Add(tap);
         AttachContextMenu(chrome, node.Id);
 
@@ -320,10 +345,13 @@ public sealed class ControlMaterializer
         };
         chrome.GestureRecognizers.Add(reparent);
 
-        if (node.Id == _workspace.SelectedId)
+        if (_workspace.SelectedIds.Contains(node.Id))
         {
             _ = EnsureOutline(chrome, node.Id);
-            EnsureSelectionHandles(chrome, node.Id);
+            if (node.Id == _workspace.SelectedId)
+            {
+                EnsureSelectionHandles(chrome, node.Id);
+            }
         }
 
         return chrome;
@@ -428,27 +456,27 @@ public sealed class ControlMaterializer
                 var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
                 AddContextMenuItem(menu, "Cut", () =>
                 {
-                    _workspace.Select(elementId);
+                    SelectForContextMenu(elementId);
                     _workspace.CutSelection();
                 });
                 AddContextMenuItem(menu, "Copy", () =>
                 {
-                    _workspace.Select(elementId);
+                    SelectForContextMenu(elementId);
                     _workspace.CopySelection();
                 });
                 AddContextMenuItem(menu, "Paste", () =>
                 {
-                    _workspace.Select(elementId);
+                    SelectForContextMenu(elementId);
                     _workspace.Paste();
                 });
                 AddContextMenuItem(menu, "Duplicate", () =>
                 {
-                    _workspace.Select(elementId);
+                    SelectForContextMenu(elementId);
                     _workspace.DuplicateSelection();
                 });
                 AddContextMenuItem(menu, "Delete", () =>
                 {
-                    _workspace.Select(elementId);
+                    SelectForContextMenu(elementId);
                     _workspace.DeleteSelection();
                 });
                 menu.ShowAt(native);
@@ -620,7 +648,7 @@ public sealed class ControlMaterializer
 
     private void UpdateOutline(Border outline, ElementId id)
     {
-        bool selected = id == _workspace.SelectedId;
+        bool selected = _workspace.SelectedIds.Contains(id);
         bool dropTarget = id == _workspace.DropTargetId;
         outline.Stroke = dropTarget
             ? Color.FromArgb("#38BDF8")
@@ -629,6 +657,21 @@ public sealed class ControlMaterializer
                 : Colors.Transparent;
         outline.StrokeThickness = dropTarget ? 3 : selected ? 2 : 0;
     }
+
+    private void SelectForContextMenu(ElementId elementId)
+    {
+        if (!_workspace.SelectedIds.Contains(elementId))
+        {
+            _workspace.Select(elementId);
+        }
+    }
+
+#if WINDOWS
+    private static bool IsControlPressed() =>
+        Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+#endif
 
     private void RemoveActiveDropPreview()
     {

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/MarqueeSelectionPolicy.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Rendering/MarqueeSelectionPolicy.cs
@@ -1,0 +1,16 @@
+using MAUIDesigner.Fresh.Core.Geometry;
+
+namespace MAUIDesigner.Fresh.App.Rendering;
+
+public static class MarqueeSelectionPolicy
+{
+    public const double MinimumDragDistance = 4;
+
+    public static bool Contains(RectD marquee, RectD element) =>
+        marquee.Width >= MinimumDragDistance &&
+        marquee.Height >= MinimumDragDistance &&
+        element.X >= marquee.X &&
+        element.Y >= marquee.Y &&
+        element.Right <= marquee.Right &&
+        element.Bottom <= marquee.Bottom;
+}

--- a/maui-designer-native/MAUIDesigner.Fresh.App/Workspace/DesignerWorkspace.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.App/Workspace/DesignerWorkspace.cs
@@ -9,16 +9,20 @@ public sealed class DesignerWorkspace
 {
     private const double PasteOffset = 16;
     private readonly IControlCatalog _catalog;
+    private readonly ControlTypeId _defaultRootType;
     private long _nextId;
-    private DesignerNode? _clipboard;
+    private ImmutableArray<DesignerNode> _clipboard = [];
+    private ImmutableHashSet<ElementId> _selectedIds = [];
     private int _pasteCount;
 
     public DesignerWorkspace(IControlCatalog catalog)
     {
         _catalog = catalog;
         ControlDescriptor root = catalog.Controls.First(descriptor => descriptor.RuntimeType == typeof(AbsoluteLayout));
+        _defaultRootType = root.Id;
         Session = new DocumentSession(DesignerDocument.Create(root.Id));
         SelectedId = Session.Current.Root.Id;
+        _selectedIds = ImmutableHashSet.Create(SelectedId);
     }
 
     public event EventHandler? SelectionChanged;
@@ -29,25 +33,33 @@ public sealed class DesignerWorkspace
 
     public ElementId SelectedId { get; private set; }
 
+    public IReadOnlySet<ElementId> SelectedIds => _selectedIds;
+
+    public int SelectionCount => _selectedIds.Count;
+
     public ElementId? DropTargetId { get; private set; }
 
     public LayoutPlacement? DropPlacement { get; private set; }
 
-    public bool CanCopy => SelectedId != Session.Current.Root.Id &&
-        Session.Current.Find(SelectedId) is not null;
+    public bool CanCopy => GetSelectionRoots().Count > 0;
 
-    public bool CanCut => SelectedId != Session.Current.Root.Id &&
-        Session.Current.Find(SelectedId) is not null;
+    public bool CanCut => CanCopy;
 
-    public bool CanPaste => _clipboard is not null && TryResolveInsertionParent(out _);
+    public bool CanPaste => !_clipboard.IsDefaultOrEmpty &&
+        TryResolveInsertionParent(_clipboard.Length, out _);
 
-    public bool CanDuplicate => TryGetSelectedSiblingPosition(out DesignerNode? parent, out _) &&
-        CanAcceptChild(parent!.Id);
+    public bool CanDuplicate => GetSelectionRoots().Count > 0 &&
+        GetSelectionRoots().All(node =>
+            node.Id != Session.Current.Root.Id &&
+            TryGetSiblingPosition(node.Id, out DesignerNode? parent, out _) &&
+            CanAcceptChild(parent!.Id));
 
     public bool CanMoveSelectionUp =>
+        _selectedIds.Count == 1 &&
         TryGetSelectedSiblingPosition(out _, out int index) && index > 0;
 
     public bool CanMoveSelectionDown =>
+        _selectedIds.Count == 1 &&
         TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index) &&
         index < parent!.Children.Length - 1;
 
@@ -58,12 +70,92 @@ public sealed class DesignerWorkspace
             throw new KeyNotFoundException($"Element '{id}' was not found.");
         }
 
-        if (SelectedId == id)
+        SetSelection([id], additive: false);
+    }
+
+    public void ToggleSelection(ElementId id)
+    {
+        if (Session.Current.Find(id) is null)
+        {
+            throw new KeyNotFoundException($"Element '{id}' was not found.");
+        }
+
+        if (id == Session.Current.Root.Id)
+        {
+            Select(id);
+            return;
+        }
+
+        if (_selectedIds.Contains(id))
+        {
+            if (_selectedIds.Count == 1)
+            {
+                Select(Session.Current.Root.Id);
+                return;
+            }
+
+            ImmutableHashSet<ElementId> remaining = _selectedIds.Remove(id);
+            ElementId primary = SelectedId == id
+                ? GetNodesInDocumentOrder().Last(node => remaining.Contains(node.Id)).Id
+                : SelectedId;
+            ApplySelection(remaining, primary);
+            return;
+        }
+
+        ApplySelection(_selectedIds.Remove(Session.Current.Root.Id).Add(id), id);
+    }
+
+    public void SelectAll()
+    {
+        ElementId[] descendants = GetNodesInDocumentOrder()
+            .Skip(1)
+            .Select(node => node.Id)
+            .ToArray();
+        SetSelection(
+            descendants.Length == 0 ? [Session.Current.Root.Id] : descendants,
+            additive: false);
+    }
+
+    public void SetSelection(IEnumerable<ElementId> ids, bool additive)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        ElementId[] requested = ids
+            .Where(id => Session.Current.Find(id) is not null)
+            .Distinct()
+            .ToArray();
+        ImmutableHashSet<ElementId> selection = additive
+            ? _selectedIds.Union(requested)
+            : requested.ToImmutableHashSet();
+        if (selection.Count > 1)
+        {
+            selection = selection.Remove(Session.Current.Root.Id);
+        }
+
+        if (selection.Count == 0)
+        {
+            selection = ImmutableHashSet.Create(Session.Current.Root.Id);
+        }
+
+        ElementId primary = requested.LastOrDefault(id => selection.Contains(id));
+        if (primary == default || !selection.Contains(primary))
+        {
+            primary = GetNodesInDocumentOrder().Last(node => selection.Contains(node.Id)).Id;
+        }
+
+        ApplySelection(selection, primary);
+    }
+
+    private void ApplySelection(
+        ImmutableHashSet<ElementId> selection,
+        ElementId primary)
+    {
+        if (_selectedIds.SetEquals(selection) && SelectedId == primary)
         {
             return;
         }
 
-        SelectedId = id;
+        _selectedIds = selection;
+        SelectedId = primary;
         SelectionChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -141,16 +233,27 @@ public sealed class DesignerWorkspace
 
     public void DeleteSelection()
     {
-        if (SelectedId == Session.Current.Root.Id)
+        IReadOnlyList<DesignerNode> selected = GetSelectionRoots();
+        if (selected.Count == 0)
         {
             return;
         }
 
-        ElementId removedId = SelectedId;
-        DesignerNode parent = FindParent(Session.Current.Root, removedId)
-            ?? throw new InvalidOperationException($"Element '{removedId}' has no parent.");
-        Session.Execute(new RemoveElementCommand(removedId));
-        Select(parent.Id);
+        if (selected.Any(node => node.Id == Session.Current.Root.Id))
+        {
+            Session.Execute(new ReplaceDocumentCommand(
+                DesignerDocument.Create(_defaultRootType),
+                "Clear document"));
+            Select(Session.Current.Root.Id);
+            return;
+        }
+
+        Session.Execute(new CompositeDocumentCommand(
+            selected
+                .Select(node => (IDocumentCommand)new RemoveElementCommand(node.Id))
+                .ToArray(),
+            selected.Count == 1 ? "Delete element" : $"Delete {selected.Count} elements"));
+        Select(Session.Current.Root.Id);
     }
 
     public void CopySelection()
@@ -160,8 +263,7 @@ public sealed class DesignerWorkspace
             return;
         }
 
-        _clipboard = Session.Current.Find(SelectedId)
-            ?? throw new KeyNotFoundException($"Element '{SelectedId}' was not found.");
+        _clipboard = GetSelectionRoots().ToImmutableArray();
         _pasteCount = 0;
         InteractionChanged?.Invoke(this, EventArgs.Empty);
     }
@@ -179,31 +281,61 @@ public sealed class DesignerWorkspace
 
     public ElementId? Paste()
     {
-        if (_clipboard is null || !TryResolveInsertionParent(out ElementId parentId))
+        if (_clipboard.IsDefaultOrEmpty ||
+            !TryResolveInsertionParent(_clipboard.Length, out ElementId parentId))
         {
             return null;
         }
 
         _pasteCount++;
-        DesignerNode clone = PrepareCloneForParent(_clipboard, parentId, _pasteCount);
-        Session.Execute(new AddElementCommand(parentId, clone));
-        Select(clone.Id);
-        return clone.Id;
+        DesignerNode[] clones = _clipboard
+            .Select(source =>
+                PrepareCloneForParent(source, parentId, _pasteCount))
+            .ToArray();
+        Session.Execute(new CompositeDocumentCommand(
+            clones
+                .Select(clone => (IDocumentCommand)new AddElementCommand(parentId, clone))
+                .ToArray(),
+            clones.Length == 1 ? "Paste element" : $"Paste {clones.Length} elements"));
+        SetSelection(clones.Select(clone => clone.Id), additive: false);
+        return clones[^1].Id;
     }
 
     public ElementId? DuplicateSelection()
     {
-        if (!TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index) ||
-            !CanAcceptChild(parent!.Id))
+        IReadOnlyList<DesignerNode> selected = GetSelectionRoots()
+            .Where(node => node.Id != Session.Current.Root.Id)
+            .ToArray();
+        if (selected.Count == 0 || !CanDuplicate)
         {
             return null;
         }
 
-        DesignerNode source = Session.Current.Find(SelectedId)!;
-        DesignerNode clone = PrepareCloneForParent(source, parent.Id, 1);
-        Session.Execute(new AddElementCommand(parent.Id, clone, index + 1));
-        Select(clone.Id);
-        return clone.Id;
+        var commands = new List<IDocumentCommand>();
+        var clones = new List<DesignerNode>();
+        foreach (IGrouping<ElementId, DesignerNode> group in selected.GroupBy(node =>
+                 FindParent(Session.Current.Root, node.Id)!.Id))
+        {
+            DesignerNode parent = Session.Current.Find(group.Key)!;
+            int inserted = 0;
+            foreach (DesignerNode source in group.OrderBy(node =>
+                         IndexOf(parent.Children, node.Id)))
+            {
+                DesignerNode clone = PrepareCloneForParent(source, parent.Id, 1);
+                commands.Add(new AddElementCommand(
+                    parent.Id,
+                    clone,
+                    IndexOf(parent.Children, source.Id) + 1 + inserted));
+                clones.Add(clone);
+                inserted++;
+            }
+        }
+
+        Session.Execute(new CompositeDocumentCommand(
+            commands,
+            clones.Count == 1 ? "Duplicate element" : $"Duplicate {clones.Count} elements"));
+        SetSelection(clones.Select(clone => clone.Id), additive: false);
+        return clones[^1].Id;
     }
 
     public bool MoveSelectionUp() => MoveSelection(-1);
@@ -242,7 +374,7 @@ public sealed class DesignerWorkspace
 
     private ElementId ResolveInsertionParent()
     {
-        if (TryResolveInsertionParent(out ElementId parentId))
+        if (TryResolveInsertionParent(1, out ElementId parentId))
         {
             return parentId;
         }
@@ -250,12 +382,12 @@ public sealed class DesignerWorkspace
         throw new InvalidOperationException("The document has no container that can accept another child control.");
     }
 
-    private bool TryResolveInsertionParent(out ElementId parentId)
+    private bool TryResolveInsertionParent(int childCount, out ElementId parentId)
     {
         DesignerNode? candidate = Session.Current.Find(SelectedId) ?? Session.Current.Root;
         while (candidate is not null)
         {
-            if (CanAcceptChild(candidate.Id))
+            if (CanAcceptChildren(candidate.Id, childCount))
             {
                 parentId = candidate.Id;
                 return true;
@@ -292,6 +424,20 @@ public sealed class DesignerWorkspace
         return parent.Children.Length == 0 ||
             movingId is not null &&
             parent.Children.Any(child => child.Id == movingId.Value);
+    }
+
+    private bool CanAcceptChildren(ElementId parentId, int childCount)
+    {
+        if (!CanAcceptChild(parentId))
+        {
+            return false;
+        }
+
+        DesignerNode parent = Session.Current.Find(parentId)!;
+        ControlDescriptor descriptor = _catalog.Controls.First(control =>
+            control.Id == parent.ControlType);
+        return typeof(Layout).IsAssignableFrom(descriptor.RuntimeType) ||
+            parent.Children.Length + childCount <= 1;
     }
 
     private void EnsureValidParent(ElementId parentId, ElementId? movingId = null)
@@ -364,14 +510,20 @@ public sealed class DesignerWorkspace
     }
 
     private bool TryGetSelectedSiblingPosition(out DesignerNode? parent, out int index)
+        => TryGetSiblingPosition(SelectedId, out parent, out index);
+
+    private bool TryGetSiblingPosition(
+        ElementId id,
+        out DesignerNode? parent,
+        out int index)
     {
-        parent = FindParent(Session.Current.Root, SelectedId);
+        parent = FindParent(Session.Current.Root, id);
         index = -1;
         if (parent is not null)
         {
             for (int childIndex = 0; childIndex < parent.Children.Length; childIndex++)
             {
-                if (parent.Children[childIndex].Id == SelectedId)
+                if (parent.Children[childIndex].Id == id)
                 {
                     index = childIndex;
                     break;
@@ -380,6 +532,47 @@ public sealed class DesignerWorkspace
         }
 
         return parent is not null && index >= 0;
+    }
+
+    private IReadOnlyList<DesignerNode> GetSelectionRoots()
+    {
+        DesignerNode[] selected = GetNodesInDocumentOrder()
+            .Where(node => _selectedIds.Contains(node.Id))
+            .ToArray();
+        return selected
+            .Where(node => !selected.Any(candidate =>
+                candidate.Id != node.Id && candidate.Find(node.Id) is not null))
+            .ToArray();
+    }
+
+    private IEnumerable<DesignerNode> GetNodesInDocumentOrder() =>
+        Enumerate(Session.Current.Root);
+
+    private static IEnumerable<DesignerNode> Enumerate(DesignerNode node)
+    {
+        yield return node;
+        foreach (DesignerNode child in node.Children)
+        {
+            foreach (DesignerNode descendant in Enumerate(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static int IndexOf(
+        ImmutableArray<DesignerNode> children,
+        ElementId id)
+    {
+        for (int index = 0; index < children.Length; index++)
+        {
+            if (children[index].Id == id)
+            {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     private static DesignerNode? FindParent(DesignerNode parent, ElementId childId)

--- a/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentCommands.cs
+++ b/maui-designer-native/MAUIDesigner.Fresh.Core/Documents/DocumentCommands.cs
@@ -10,6 +10,23 @@ public interface IDocumentCommand
     DesignerDocument Apply(DesignerDocument document);
 }
 
+public sealed record CompositeDocumentCommand(
+    IReadOnlyList<IDocumentCommand> Commands,
+    string Description) : IDocumentCommand
+{
+    public DesignerDocument Apply(DesignerDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(Commands);
+        DesignerDocument result = document;
+        foreach (IDocumentCommand command in Commands)
+        {
+            result = command.Apply(result);
+        }
+
+        return result;
+    }
+}
+
 public sealed record ReplaceDocumentCommand(
     DesignerDocument Replacement,
     string Description = "Apply XAML") : IDocumentCommand


### PR DESCRIPTION
## Summary
- harden Visual Studio ↔ native designer synchronization with ordered writes, revision acknowledgments, retry/reconnect, and stale-edit rejection
- add Grid row/column/span editing and richer XAML round-trip preservation
- automate main-branch VSIX versioning, real Visual Studio install checks, and Marketplace publication
- add the Marketplace publish manifest and maintained overview

## Validation
- 92 native tests pass
- 62 extension tests pass
- native Release build passes with warnings as errors
- VSIX packages successfully with Visual Studio MSBuild
- live Visual Studio validation covers both sync directions, rapid edits, conflict handling, invalid-XAML recovery, and Grid placement
- GitHub workflow passes actionlint

## Deployment gate
Marketplace publishing runs only for a direct push to `main`, after both Visual Studio install-check jobs succeed. The repository must have a `VS_PUBLISHER_ACCESS_TOKEN` Actions secret with Marketplace **Acquire + Manage** permission before the first merged run.